### PR TITLE
Added distutils/setuptools script.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,18 @@
+nntools
+=======
+
+nntools is a lightweight library to build and train neural networks in Theano.
+
+nntools is a work in progress, input is welcome.
+
+Design goals:
+
+* Simplicity: it should be easy to use and extend the library. Whenever a feature is added, the effect on both of these should be considered. Every added abstraction should be carefully scrutinized, to determine whether the added complexity is justified.
+
+* Small interfaces: as few classes and methods as possible. Try to rely on Theano's functionality and data types where possible, and follow Theano's conventions. Don't wrap things in classes if it is not strictly necessary. This should make it easier to both use the library and extend it (less cognitive overhead).
+
+* Don't get in the way: unused features should be invisible, the user should not have to take into account a feature that they do not use. It should be possible to use each component of the library in isolation from the others.
+
+* Transparency: don't try to hide Theano behind abstractions. Functions and methods should return Theano expressions and standard Python / numpy data types where possible.
+
+* Focus: follow the Unix philosophy of "do one thing and do it well", with a strong focus on feed-forward neural networks.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[aliases]
+dev = develop easy_install nntools[testing]
+docs = develop easy_install nntools[docs]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+import os
+from setuptools import find_packages
+from setuptools import setup
+
+version = '0.1dev'
+
+here = os.path.abspath(os.path.dirname(__file__))
+try:
+    README = open(os.path.join(here, 'README.rst')).read()
+    CHANGES = ''
+    #CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
+except IOError:
+    README = CHANGES = ''
+
+install_requires = [
+    'numpy',
+    'Theano',
+    ]
+
+tests_require = [
+    ]
+
+docs_require = [
+    'Sphinx',
+    ]
+
+setup(
+    name="nntools",
+    version=version,
+    description="neural network tools for Theano",
+    long_description="\n\n".join([README, CHANGES]),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        ],
+    keywords="",
+    author="Sander Dieleman",
+    author_email="sanderdieleman@gmail.com",
+    url="https://github.com/benanne/nntools",
+    license="MIT",
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=install_requires,
+    extras_require={
+        'testing': tests_require,
+        'docs': docs_require,
+        },
+    )


### PR DESCRIPTION
First humble pull request to address #22.

PyPI likes the Readme to be in ReST format.  And Github is okay with it, too.

Regarding dependency versions: Once our requirements have stabilized (and we know which versions exactly we want to support), we can add a requirements.txt file for pip that pins versions.  Pinning versions is not normally done inside of setup.py.
