### PR TITLE
Use Thenao version from Git; required for GpuCorrMM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ virtualenv:
 before_install:
   - sudo apt-get install -qq python-numpy python-scipy libatlas3gf-base libatlas-dev liblapack-dev gfortran
 install:
+  - pip install -r requirements.txt
   - python setup.py dev
 script: travis_wait py.test --runslow
 cache: apt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e git+https://github.com/Theano/Theano.git@647921d7d26f4a848f023d5c7ef6329f4dfb5563#egg=Theano


### PR DESCRIPTION
For #44: Add a requirements.txt that has Theano git version.

Uses Theano's current HEAD as the revision.

Travis tests fail because deeplearning.net is down.  (I wonder if we should host that mnist.pkl.gz ourselves...)
