### PR TITLE
Weighted elementwise sum layer

### DIFF
--- a/nntools/layers/base.py
+++ b/nntools/layers/base.py
@@ -854,7 +854,7 @@ class ConcatLayer(MultipleInputsLayer):
 concat = ConcatLayer # shortcut
 
 
-class EltSumLayer(MultipleInputsLayer):
+class ElemwiseSumLayer(MultipleInputsLayer):
     """
     This layer performs an elementwise sum of its input layers.
     It requires all input layers to have the same output shape.
@@ -876,9 +876,9 @@ class EltSumLayer(MultipleInputsLayer):
             - coeffs: list or scalar
                 A same-sized list of coefficients, or a single coefficient that
                 is to be applied to all instances. By default, these will not
-                be included in the learnable parameters of this layers.
+                be included in the learnable parameters of this layer.
         """
-        super(EltSumLayer, self).__init__(input_layers)
+        super(ElemwiseSumLayer, self).__init__(input_layers)
         if isinstance(coeffs, list):
             if len(coeffs) != len(input_layers):
                 raise ValueError("Mismatch: got %d coeffs for %d input_layers" %

--- a/nntools/tests/test_layers.py
+++ b/nntools/tests/test_layers.py
@@ -306,11 +306,11 @@ class TestConcatLayer:
         assert (result_eval == desired_result).all()
 
 
-class TestEltSumLayer:
+class TestElemwiseSumLayer:
     @pytest.fixture
     def layer(self):
-        from nntools.layers.base import EltSumLayer
-        return EltSumLayer([Mock(), Mock()], coeffs=[2, -1])
+        from nntools.layers.base import ElemwiseSumLayer
+        return ElemwiseSumLayer([Mock(), Mock()], coeffs=[2, -1])
 
     def test_get_output_for(self, layer):
         a = numpy.array([[0, 1], [2, 3]])


### PR DESCRIPTION
This PR adds a layer that computes a weighted sum of its input layers. This can often serve as an alternative to concatenating layers.
The PR is on top of #61 -- if you merge that first, everything is fine, otherwise I can modify this PR to remove the first commit.
