### PR TITLE
Allow handing an existing input variable to InputLayer

### DIFF
--- a/nntools/layers/base.py
+++ b/nntools/layers/base.py
@@ -352,13 +352,19 @@ class MultipleInputsLayer(Layer):
 
 
 class InputLayer(Layer):
-    def __init__(self, shape):
+    def __init__(self, shape, input_var=None):
         self.shape = shape
         ndim = len(shape)
-
-        # create the right TensorType for the given number of dimensions
-        input_var_type = T.TensorType(theano.config.floatX, [False] * ndim)
-        self.input_var = input_var_type("input")
+        if input_var is None:
+            # create the right TensorType for the given number of dimensions
+            input_var_type = T.TensorType(theano.config.floatX, [False] * ndim)
+            input_var = input_var_type("input")
+        else:
+            # ensure the given variable has the correct dimensionality
+            if input_var.ndim != ndim:
+                raise ValueError("shape has %d dimensions, "
+                    "but variable has %d" % (ndim, input_var.ndim))
+        self.input_var = input_var
 
     def get_output_shape(self):
         return self.shape


### PR DESCRIPTION
This PR extends `InputLayer` with an optional second constructor argument that gives a Theano expression to use as the input. Useful if you already know the variables to use when constructing a network.
