### PR TITLE
Use coverage to print out report at end of test runs.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,6 @@ docs = develop easy_install lasagne[docs]
 [pytest]
 addopts =
     -v --doctest-modules
+    --cov=lasagne --cov-report=term-missing
     lasagne/
 python_files = test*py

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ install_requires = [
 tests_require = [
     'mock',
     'pytest',
+    'pytest-cov',
     ]
 
 docs_require = [


### PR DESCRIPTION
Following out discussion in #67, here's an integration of Python's coverage with our test runner.  Prints out coverage report at the end of every test run.
