### PR TITLE
turn get_output() into a global function

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -131,7 +131,8 @@ def create_iter_functions(dataset, output_layer,
                                    deterministic=True)
 
     pred = T.argmax(
-        output_layer.get_output(X_batch, deterministic=True), axis=1)
+        lasagne.layers.get_output(output_layer, X_batch, deterministic=True),
+        axis=1)
     accuracy = T.mean(T.eq(pred, y_batch), dtype=theano.config.floatX)
 
     all_params = lasagne.layers.get_all_params(output_layer)

--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -93,40 +93,14 @@ class Layer(object):
 
     def get_output(self, input=None, **kwargs):
         """
-        Computes the output of the network at this layer. Optionally, you can
-        define an input to propagate through the network instead of using the
-        input variables associated with the network's input layers.
-
-        :parameters:
-            - input : None, Theano expression, numpy array, or dict
-                If None, uses the inputs of the :class:`InputLayer` instances.
-                If a Theano expression, this will replace the inputs of all
-                :class:`InputLayer` instances (useful if your network has a
-                single input layer).
-                If a numpy array, this will be wrapped as a Theano constant
-                and used just like a Theano expression.
-                If a dictionary, any :class:`Layer` instance (including the
-                input layers) can be mapped to a Theano expression or numpy
-                array to use instead of its regular output.
-
-        :returns:
-            - output : Theano expression
-                the output of this layer given the input to the network
-
-        :note:
-            When implementing a new :class:`Layer` class, you will usually
-            keep this unchanged and just override `get_output_for()`.
+        Deprecated. Use `lasagne.layers.get_output(layer, input, **kwargs)`.
         """
-        if isinstance(input, dict) and (self in input):
-            # this layer is mapped to an expression or numpy array
-            return utils.as_theano_expression(input[self])
-        elif self.input_layer is None:
-            raise RuntimeError("get_output() called on a free-floating layer; "
-                               "there isn't anything to get its input from. "
-                               "Did you mean get_output_for()?")
-        else:  # in all other cases, just pass the input on to the next layer.
-            layer_input = self.input_layer.get_output(input, **kwargs)
-            return self.get_output_for(layer_input, **kwargs)
+        import warnings
+        warnings.warn("layer.get_output(...) is deprecated and will be "
+                      "removed for the first release of Lasagne. Please use "
+                      "lasagne.layers.get_output(layer, ...) instead.")
+        from .helper import get_output
+        return get_output(self, input, **kwargs)
 
     def get_output_shape_for(self, input_shape):
         """
@@ -271,20 +245,6 @@ class MultipleInputsLayer(Layer):
 
     def get_output_shape(self):
         return self.get_output_shape_for(self.input_shapes)
-
-    def get_output(self, input=None, **kwargs):
-        if isinstance(input, dict) and (self in input):
-            # this layer is mapped to an expression or numpy array
-            return utils.as_theano_expression(input[self])
-        elif any(input_layer is None for input_layer in self.input_layers):
-            raise RuntimeError("get_output() called on a free-floating layer; "
-                               "there isn't anything to get its inputs from. "
-                               "Did you mean get_output_for()?")
-        # In all other cases, just pass the network input on to the next layers
-        else:
-            layer_inputs = [input_layer.get_output(input, **kwargs) for
-                            input_layer in self.input_layers]
-            return self.get_output_for(layer_inputs, **kwargs)
 
     def get_output_shape_for(self, input_shapes):
         """

--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -36,10 +36,13 @@ class Layer(object):
             self.input_shape = incoming
             self.input_layer = None
         else:
-            from .helper import get_output_shape
-            self.input_shape = get_output_shape(incoming)
+            self.input_shape = incoming.output_shape
             self.input_layer = incoming
         self.name = name
+
+    @property
+    def output_shape(self):
+        return self.get_output_shape_for(self.input_shape)
 
     def get_params(self):
         """
@@ -78,14 +81,13 @@ class Layer(object):
 
     def get_output_shape(self):
         """
-        Deprecated. Use `lasagne.layers.get_output_shape(layer)`.
+        Deprecated. Use `layer.output_shape`.
         """
         import warnings
         warnings.warn("layer.get_output_shape() is deprecated and will be "
                       "removed for the first release of Lasagne. Please use "
-                      "lasagne.layers.get_output_shape(layer) instead.")
-        from .helper import get_output_shape
-        return get_output_shape(self)
+                      "layer.output_shape instead.")
+        return self.output_shape
 
     def get_output(self, input=None, **kwargs):
         """
@@ -231,14 +233,17 @@ class MultipleInputsLayer(Layer):
             - name : a string or None
                 an optional name to attach to this layer
         """
-        from .helper import get_output_shape
         self.input_shapes = [incoming if isinstance(incoming, tuple)
-                             else get_output_shape(incoming)
+                             else incoming.output_shape
                              for incoming in incomings]
         self.input_layers = [None if isinstance(incoming, tuple)
                              else incoming
                              for incoming in incomings]
         self.name = name
+
+    @Layer.output_shape.getter
+    def output_shape(self):
+        return self.get_output_shape_for(self.input_shapes)
 
     def get_output_shape_for(self, input_shapes):
         """

--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -36,7 +36,8 @@ class Layer(object):
             self.input_shape = incoming
             self.input_layer = None
         else:
-            self.input_shape = incoming.get_output_shape()
+            from .helper import get_output_shape
+            self.input_shape = get_output_shape(incoming)
             self.input_layer = incoming
         self.name = name
 
@@ -77,19 +78,14 @@ class Layer(object):
 
     def get_output_shape(self):
         """
-        Computes the output shape of the network at this layer.
-
-        :returns:
-            - output shape: tuple
-                a tuple that represents the output shape of this layer. The
-                tuple has as many elements as there are output dimensions, and
-                the elements of the tuple are either integers or `None`.
-
-        :note:
-            When implementing a new :class:`Layer` class, you will usually
-            keep this unchanged and just override `get_output_shape_for()`.
+        Deprecated. Use `lasagne.layers.get_output_shape(layer)`.
         """
-        return self.get_output_shape_for(self.input_shape)
+        import warnings
+        warnings.warn("layer.get_output_shape() is deprecated and will be "
+                      "removed for the first release of Lasagne. Please use "
+                      "lasagne.layers.get_output_shape(layer) instead.")
+        from .helper import get_output_shape
+        return get_output_shape(self)
 
     def get_output(self, input=None, **kwargs):
         """
@@ -235,16 +231,14 @@ class MultipleInputsLayer(Layer):
             - name : a string or None
                 an optional name to attach to this layer
         """
+        from .helper import get_output_shape
         self.input_shapes = [incoming if isinstance(incoming, tuple)
-                             else incoming.get_output_shape()
+                             else get_output_shape(incoming)
                              for incoming in incomings]
         self.input_layers = [None if isinstance(incoming, tuple)
                              else incoming
                              for incoming in incomings]
         self.name = name
-
-    def get_output_shape(self):
-        return self.get_output_shape_for(self.input_shapes)
 
     def get_output_shape_for(self, input_shapes):
         """

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -202,8 +202,7 @@ class Conv1DLayer(Layer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape_for(self.input_shape)
-            self.b = self.create_param(b, (num_filters, output_shape[2]),
+            self.b = self.create_param(b, (num_filters, self.output_shape[2]),
                                        name="b")
         else:
             self.b = self.create_param(b, (num_filters,), name="b")
@@ -382,9 +381,8 @@ class Conv2DLayer(Layer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape_for(self.input_shape)
-            self.b = self.create_param(b, (num_filters, output_shape[2],
-                                           output_shape[3]), name="b")
+            self.b = self.create_param(b, (num_filters, self.output_shape[2],
+                                           self.output_shape[3]), name="b")
         else:
             self.b = self.create_param(b, (num_filters,), name="b")
 

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -202,7 +202,7 @@ class Conv1DLayer(Layer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape()
+            output_shape = self.get_output_shape_for(self.input_shape)
             self.b = self.create_param(b, (num_filters, output_shape[2]),
                                        name="b")
         else:
@@ -382,7 +382,7 @@ class Conv2DLayer(Layer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape()
+            output_shape = self.get_output_shape_for(self.input_shape)
             self.b = self.create_param(b, (num_filters, output_shape[2],
                                            output_shape[3]), name="b")
         else:

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -170,9 +170,8 @@ class Conv2DMMLayer(MMLayer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape_for(self.input_shape)
-            self.b = self.create_param(b, (num_filters, output_shape[2],
-                                           output_shape[3]), name="b")
+            self.b = self.create_param(b, (num_filters, self.output_shape[2],
+                                           self.output_shape[3]), name="b")
         else:
             self.b = self.create_param(b, (num_filters,), name="b")
 

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -170,7 +170,7 @@ class Conv2DMMLayer(MMLayer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape()
+            output_shape = self.get_output_shape_for(self.input_shape)
             self.b = self.create_param(b, (num_filters, output_shape[2],
                                            output_shape[3]), name="b")
         else:

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -107,13 +107,14 @@ class Conv2DCCLayer(CCLayer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape_for(self.input_shape)
             if self.dimshuffle:
-                self.b = self.create_param(b, (num_filters, output_shape[2],
-                                               output_shape[3]))
+                self.b = self.create_param(b, (num_filters,
+                                               self.output_shape[2],
+                                               self.output_shape[3]))
             else:
-                self.b = self.create_param(b, (num_filters, output_shape[1],
-                                               output_shape[2]))
+                self.b = self.create_param(b, (num_filters,
+                                               self.output_shape[1],
+                                               self.output_shape[2]))
         else:
             self.b = self.create_param(b, (num_filters,))
 
@@ -345,8 +346,8 @@ class NINLayer_c01b(Layer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape_for(self.input_shape)
-            self.b = self.create_param(b, (num_units,) + output_shape[1:-1])
+            self.b = self.create_param(b, (num_units,) +
+                                       self.output_shape[1:-1])
         else:
             self.b = self.create_param(b, (num_units,))
 

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -107,7 +107,7 @@ class Conv2DCCLayer(CCLayer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape()
+            output_shape = self.get_output_shape_for(self.input_shape)
             if self.dimshuffle:
                 self.b = self.create_param(b, (num_filters, output_shape[2],
                                                output_shape[3]))
@@ -345,7 +345,7 @@ class NINLayer_c01b(Layer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape()
+            output_shape = self.get_output_shape_for(self.input_shape)
             self.b = self.create_param(b, (num_units,) + output_shape[1:-1])
         else:
             self.b = self.create_param(b, (num_units,))

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -175,9 +175,8 @@ class NINLayer(Layer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape_for(self.input_shape)
-            self.b = self.create_param(b, (num_units,) + output_shape[2:],
-                                       name="b")
+            self.b = self.create_param(b, (num_units,) +
+                                       self.output_shape[2:], name="b")
         else:
             self.b = self.create_param(b, (num_units,), name="b")
 

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -175,7 +175,7 @@ class NINLayer(Layer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape()
+            output_shape = self.get_output_shape_for(self.input_shape)
             self.b = self.create_param(b, (num_units,) + output_shape[2:],
                                        name="b")
         else:

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -248,7 +248,7 @@ class Conv2DDNNLayer(DNNLayer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape()
+            output_shape = self.get_output_shape_for(self.input_shape)
             self.b = self.create_param(b, (num_filters, output_shape[2],
                                            output_shape[3]), name="b")
         else:

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -248,9 +248,8 @@ class Conv2DDNNLayer(DNNLayer):
         if b is None:
             self.b = None
         elif self.untie_biases:
-            output_shape = self.get_output_shape_for(self.input_shape)
-            self.b = self.create_param(b, (num_filters, output_shape[2],
-                                           output_shape[3]), name="b")
+            self.b = self.create_param(b, (num_filters, self.output_shape[2],
+                                           self.output_shape[3]), name="b")
         else:
             self.b = self.create_param(b, (num_filters,), name="b")
 

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -285,7 +285,7 @@ def get_output_shape(layer_or_layers, input_shapes=None):
                 raise ValueError("get_output() was called without giving an "
                                  "input shape for the free-floating layer %r. "
                                  "Please call it with a dictionary mapping "
-                                 "this layer to an input expression."
+                                 "this layer to an input shape."
                                  % layer)
             all_shapes[layer] = layer.get_output_shape_for(input_shapes)
     # return the output shape(s) of the requested layer(s) only

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -180,12 +180,13 @@ def get_output(layer_or_layers, inputs=None, **kwargs):
     from .input import InputLayer
     from .base import MultipleInputsLayer
     # obtain topological ordering of all layers the output layer(s) depend on
-    treat_as_input = inputs.keys() if isinstance(inputs, dict) else None
+    treat_as_input = inputs.keys() if isinstance(inputs, dict) else []
     all_layers = get_all_layers(layer_or_layers, treat_as_input)
     # initialize layer-to-expression mapping from all input layers
     all_outputs = dict((layer, layer.input_var)
                        for layer in all_layers
-                       if isinstance(layer, InputLayer))
+                       if isinstance(layer, InputLayer) and
+                       layer not in treat_as_input)
     # update layer-to-expression mapping from given input(s), if any
     if isinstance(inputs, dict):
         all_outputs.update((layer, utils.as_theano_expression(expr))

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -187,11 +187,19 @@ def get_output(layer_or_layers, inputs=None, **kwargs):
     # update layer-to-expression mapping by propagating the inputs
     for layer in all_layers:
         if layer not in all_outputs:
-            if isinstance(layer, MultipleInputsLayer):
-                layer_inputs = [all_outputs[input_layer]
-                                for input_layer in layer.input_layers]
-            else:
-                layer_inputs = all_outputs[layer.input_layer]
+            try:
+                if isinstance(layer, MultipleInputsLayer):
+                    layer_inputs = [all_outputs[input_layer]
+                                    for input_layer in layer.input_layers]
+                else:
+                    layer_inputs = all_outputs[layer.input_layer]
+            except KeyError:
+                # one of the input_layer attributes must have been `None`
+                raise ValueError("get_output() was called without giving an "
+                                 "input expression for the free-floating "
+                                 "layer %r. Please call it with a dictionary "
+                                 "mapping this layer to an input expression."
+                                 % layer)
             all_outputs[layer] = layer.get_output_for(layer_inputs, **kwargs)
     # return the output(s) of the requested layer(s) only
     try:

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -240,18 +240,10 @@ def get_output_shape(layer_or_layers):
     from .input import InputLayer
     from .base import MultipleInputsLayer
 
-    def default_shape(layer):
-        if isinstance(layer, InputLayer):
-            return layer.shape
-        elif isinstance(layer, MultipleInputsLayer):
-            return layer.get_output_shape_for(layer.input_shapes)
-        else:
-            return layer.get_output_shape_for(layer.input_shape)
-
     try:
-        return [default_shape(layer) for layer in layer_or_layers]
+        return [layer.output_shape for layer in layer_or_layers]
     except TypeError:
-        return default_shape(layer_or_layers)
+        return layer_or_layers.output_shape
 
 
 def get_all_params(layer):

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -9,6 +9,7 @@ __all__ = [
     "get_all_layers",
     "get_all_layers_old",
     "get_output",
+    "get_output_shape",
     "get_all_params",
     "get_all_bias_params",
     "get_all_non_bias_params",
@@ -221,6 +222,36 @@ def get_output(layer_or_layers, inputs=None, **kwargs):
         return [all_outputs[layer] for layer in layer_or_layers]
     except TypeError:
         return all_outputs[layer_or_layers]
+
+
+def get_output_shape(layer_or_layers):
+    """
+    Computes the output shape of the network at one or more given layers.
+
+    :parameters:
+        - layer_or_layers : Layer or list
+            the :class:`Layer` instance for which to compute the output
+            shapes, or a list of :class:`Layer` instances.
+
+    :returns:
+        - output : tuple or list
+            the output shape of the given layer(s) for the given network input
+    """
+    from .input import InputLayer
+    from .base import MultipleInputsLayer
+
+    def default_shape(layer):
+        if isinstance(layer, InputLayer):
+            return layer.shape
+        elif isinstance(layer, MultipleInputsLayer):
+            return layer.get_output_shape_for(layer.input_shapes)
+        else:
+            return layer.get_output_shape_for(layer.input_shape)
+
+    try:
+        return [default_shape(layer) for layer in layer_or_layers]
+    except TypeError:
+        return default_shape(layer_or_layers)
 
 
 def get_all_params(layer):

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -236,7 +236,7 @@ def get_output_shape(layer_or_layers, input_shapes=None):
         - input_shapes : None, tuple, or dict
             If None, uses the input shapes associated with the
             :class:`InputLayer` instances.
-            If a tuple, this defines the input shape for a single 
+            If a tuple, this defines the input shape for a single
             :class:`InputLayer` instance. Will throw a ValueError if there
             are multiple :class:`InputLayer` instances.
             If a dictionary, any :class:`Layer` instance (including the

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -247,6 +247,13 @@ def get_output_shape(layer_or_layers, input_shapes=None):
         - output : tuple or list
             the output shape of the given layer(s) for the given network input
     """
+    # shortcut: return precomputed shapes if we do not need to propagate any
+    if input_shapes is None or input_shapes == {}:
+        try:
+            return [layer.output_shape for layer in layer_or_layers]
+        except TypeError:
+            return layer_or_layers.output_shape
+
     from .input import InputLayer
     from .base import MultipleInputsLayer
     # obtain topological ordering of all layers the output layer(s) depend on

--- a/lasagne/layers/input.py
+++ b/lasagne/layers/input.py
@@ -52,3 +52,7 @@ class InputLayer(Layer):
                                  "%d" % (ndim, input_var.ndim))
         self.input_var = input_var
         self.name = name
+
+    @Layer.output_shape.getter
+    def output_shape(self):
+        return self.shape

--- a/lasagne/layers/input.py
+++ b/lasagne/layers/input.py
@@ -52,6 +52,3 @@ class InputLayer(Layer):
                                  "%d" % (ndim, input_var.ndim))
         self.input_var = input_var
         self.name = name
-
-    def get_output_shape(self):
-        return self.shape

--- a/lasagne/layers/input.py
+++ b/lasagne/layers/input.py
@@ -55,10 +55,3 @@ class InputLayer(Layer):
 
     def get_output_shape(self):
         return self.shape
-
-    def get_output(self, input=None, **kwargs):
-        if isinstance(input, dict):
-            input = input.get(self, None)
-        if input is None:
-            input = self.input_var
-        return utils.as_theano_expression(input)

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -57,17 +57,18 @@ class ReshapeLayer(Layer):
     Usage
     ----------
     >>> from lasagne.layers import InputLayer, ReshapeLayer
+    >>> from lasagne.layers import get_output_shape
     >>> l_in = InputLayer((32, 100, 20))
     >>> l1 = ReshapeLayer(l_in, ((32, 50, 40)))
-    >>> l1.get_output_shape()
+    >>> get_output_shape(l1)
     (32, 50, 40)
     >>> l_in = InputLayer((None, 100, 20))
     >>> l2 = ReshapeLayer(l_in, ([0], 50, 40))
-    >>> l2.get_output_shape()
+    >>> get_output_shape(l2)
     (None, 50, 40)
     >>> l_in = InputLayer((None, 100, 20))
     >>> l3 = ReshapeLayer(l_in, (-1, [1], [0], 1))
-    >>> l3.get_output_shape()
+    >>> get_output_shape(l3)
     (20, 100, None, 1)
 
     Note
@@ -183,12 +184,13 @@ class DimshuffleLayer(Layer):
     Usage
     -----------
     >>> from lasagne.layers import InputLayer, DimshuffleLayer
+    >>> from lasagne.layers import get_output_shape
     >>> l_in = InputLayer((2, 3, 5, 7))
     >>> l1 = DimshuffleLayer(l_in, (3, 2, 1, 'x', 0))
-    >>> l1.get_output_shape()
+    >>> get_output_shape(l1)
     (7, 5, 3, 1, 2)
     >>> l2 = DimshuffleLayer(l1, (4, 2, 1, 0))
-    >>> l2.get_output_shape()
+    >>> get_output_shape(l2)
     (2, 3, 5, 7)
 
     See Also

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -57,18 +57,17 @@ class ReshapeLayer(Layer):
     Usage
     ----------
     >>> from lasagne.layers import InputLayer, ReshapeLayer
-    >>> from lasagne.layers import get_output_shape
     >>> l_in = InputLayer((32, 100, 20))
     >>> l1 = ReshapeLayer(l_in, ((32, 50, 40)))
-    >>> get_output_shape(l1)
+    >>> l1.output_shape
     (32, 50, 40)
     >>> l_in = InputLayer((None, 100, 20))
     >>> l2 = ReshapeLayer(l_in, ([0], 50, 40))
-    >>> get_output_shape(l2)
+    >>> l2.output_shape
     (None, 50, 40)
     >>> l_in = InputLayer((None, 100, 20))
     >>> l3 = ReshapeLayer(l_in, (-1, [1], [0], 1))
-    >>> get_output_shape(l3)
+    >>> l3.output_shape
     (20, 100, None, 1)
 
     Note
@@ -96,6 +95,8 @@ class ReshapeLayer(Layer):
         if sum(s == -1 for s in shape) > 1:
             raise ValueError("`shape` cannot contain multiple -1")
         self.shape = shape
+        # try computing the output shape once as a sanity check
+        self.get_output_shape_for(self.input_shape)
 
     def get_output_shape_for(self, input_shape, **kwargs):
         # Initialize output shape from shape specification
@@ -184,13 +185,12 @@ class DimshuffleLayer(Layer):
     Usage
     -----------
     >>> from lasagne.layers import InputLayer, DimshuffleLayer
-    >>> from lasagne.layers import get_output_shape
     >>> l_in = InputLayer((2, 3, 5, 7))
     >>> l1 = DimshuffleLayer(l_in, (3, 2, 1, 'x', 0))
-    >>> get_output_shape(l1)
+    >>> l1.output_shape
     (7, 5, 3, 1, 2)
     >>> l2 = DimshuffleLayer(l1, (4, 2, 1, 0))
-    >>> get_output_shape(l2)
+    >>> l2.output_shape
     (2, 3, 5, 7)
 
     See Also
@@ -217,6 +217,9 @@ class DimshuffleLayer(Layer):
                                  "indices or 'x', not {0}".format(p))
 
         self.pattern = pattern
+
+        # try computing the output shape once as a sanity check
+        self.get_output_shape_for(self.input_shape)
 
     def get_output_shape_for(self, input_shape):
         # Build output shape while keeping track of the dimensions that we are

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -1,6 +1,7 @@
 import theano
 import theano.tensor as T
 from theano.tensor.nnet import binary_crossentropy, categorical_crossentropy
+from lasagne.layers import get_output
 
 
 def mse(x, t):
@@ -68,7 +69,7 @@ class Objective(object):
         :returns:
             - output : loss expressions
         """
-        network_output = self.input_layer.get_output(input, **kwargs)
+        network_output = get_output(self.input_layer, input, **kwargs)
         if target is None:
             target = self.target_var
         if aggregation not in self._valid_aggregation:
@@ -149,7 +150,7 @@ class MaskedObjective(object):
         :returns:
             - output : loss expressions
         """
-        network_output = self.input_layer.get_output(input, **kwargs)
+        network_output = get_output(self.input_layer, input, **kwargs)
         if target is None:
             target = self.target_var
         if mask is None:

--- a/lasagne/tests/layers/conftest.py
+++ b/lasagne/tests/layers/conftest.py
@@ -4,6 +4,9 @@ import pytest
 
 @pytest.fixture
 def dummy_input_layer():
-    input_layer = Mock()
-    input_layer.get_output_shape.return_value = (2, 3, 4)
-    return input_layer
+    from lasagne.layers.input import InputLayer
+    input_layer = InputLayer((2, 3, 4))
+    mock = Mock(input_layer)
+    mock.shape = input_layer.shape
+    mock.input_var = input_layer.input_var
+    return mock

--- a/lasagne/tests/layers/conftest.py
+++ b/lasagne/tests/layers/conftest.py
@@ -9,4 +9,5 @@ def dummy_input_layer():
     mock = Mock(input_layer)
     mock.shape = input_layer.shape
     mock.input_var = input_layer.input_var
+    mock.output_shape = input_layer.output_shape
     return mock

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -10,16 +10,8 @@ class TestLayer:
         from lasagne.layers.base import Layer
         return Layer(Mock())
 
-    def test_input_shape(self):
-        from lasagne.layers.base import Layer
-        from lasagne.layers.input import InputLayer
-        from lasagne.layers.helper import get_output_shape
-
-        shp = (1, 2, 3, 4)
-        l_in = InputLayer(shp)
-        layer = Layer(l_in)
-
-        assert layer.input_shape == get_output_shape(layer.input_layer)
+    def test_input_shape(self, layer):
+        assert layer.input_shape == layer.input_layer.output_shape
 
     def test_get_output_shape_for(self, layer):
         shape = Mock()
@@ -77,16 +69,9 @@ class TestMultipleInputsLayer:
         from lasagne.layers.base import MultipleInputsLayer
         return MultipleInputsLayer([Mock(), Mock()])
 
-    def test_input_shapes(self):
-        from lasagne.layers.base import MultipleInputsLayer
-        from lasagne.layers.input import InputLayer
-        from lasagne.layers.helper import get_output_shape
-
-        l_in1 = InputLayer((1, 2, 3, 4))
-        l_in2 = InputLayer((4, 5, 6))
-        layer = MultipleInputsLayer([l_in1, l_in2])
-
-        assert layer.input_shapes == get_output_shape(layer.input_layers)
+    def test_input_shapes(self, layer):
+        assert layer.input_shapes == [l.output_shape
+                                      for l in layer.input_layers]
 
     @pytest.fixture
     def layer_from_shape(self):

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -10,8 +10,15 @@ class TestLayer:
         from lasagne.layers.base import Layer
         return Layer(Mock())
 
-    def test_input_shape(self, layer):
+    def test_input_shape(self):
+        from lasagne.layers.base import Layer
+        from lasagne.layers.input import InputLayer
         from lasagne.layers.helper import get_output_shape
+
+        shp = (1, 2, 3, 4)
+        l_in = InputLayer(shp)
+        layer = Layer(l_in)
+
         assert layer.input_shape == get_output_shape(layer.input_layer)
 
     def test_get_output_shape_for(self, layer):
@@ -70,8 +77,15 @@ class TestMultipleInputsLayer:
         from lasagne.layers.base import MultipleInputsLayer
         return MultipleInputsLayer([Mock(), Mock()])
 
-    def test_input_shapes(self, layer):
+    def test_input_shapes(self):
+        from lasagne.layers.base import MultipleInputsLayer
+        from lasagne.layers.input import InputLayer
         from lasagne.layers.helper import get_output_shape
+
+        l_in1 = InputLayer((1, 2, 3, 4))
+        l_in2 = InputLayer((4, 5, 6))
+        layer = MultipleInputsLayer([l_in1, l_in2])
+
         assert layer.input_shapes == get_output_shape(layer.input_layers)
 
     @pytest.fixture

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -85,4 +85,4 @@ class TestMultipleInputsLayer:
         assert layer.input_layers[0] is None
         assert layer.input_shapes[0] == (None, 20)
         assert layer.input_layers[1] is not None
-        assert (layer.input_shapes[1] == layer.input_layers[1].shape)
+        assert (layer.input_shapes[1] == layer.input_layers[1].output_shape)

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -16,41 +16,6 @@ class TestLayer:
     def test_get_output_shape(self, layer):
         assert layer.get_output_shape() == layer.input_layer.get_output_shape()
 
-    def test_get_output_without_arguments(self, layer):
-        layer.get_output_for = Mock()
-
-        output = layer.get_output()
-        assert output is layer.get_output_for.return_value
-        layer.get_output_for.assert_called_with(
-            layer.input_layer.get_output.return_value)
-        layer.input_layer.get_output.assert_called_with(None)
-
-    def test_get_output_passes_on_arguments_to_input_layer(self, layer):
-        input, kwarg = object(), object()
-        layer.get_output_for = Mock()
-
-        output = layer.get_output(input, kwarg=kwarg)
-        assert output is layer.get_output_for.return_value
-        layer.get_output_for.assert_called_with(
-            layer.input_layer.get_output.return_value, kwarg=kwarg)
-        layer.input_layer.get_output.assert_called_with(
-            input, kwarg=kwarg)
-
-    def test_get_output_input_is_a_mapping(self, layer):
-        input = {layer: theano.tensor.matrix()}
-        assert layer.get_output(input) is input[layer]
-
-    def test_get_output_input_is_a_mapping_no_key(self, layer):
-        layer.get_output_for = Mock()
-
-        output = layer.get_output({})
-        assert output is layer.get_output_for.return_value
-
-    def test_get_output_input_is_a_mapping_to_array(self, layer):
-        input = {layer: [[1, 2, 3]]}
-        output = layer.get_output(input)
-        assert numpy.all(output.eval() == input[layer])
-
     @pytest.fixture
     def layer_from_shape(self):
         from lasagne.layers.base import Layer
@@ -61,20 +26,6 @@ class TestLayer:
         assert layer.input_layer is None
         assert layer.input_shape == (None, 20)
         assert layer.get_output_shape() == (None, 20)
-
-    def test_layer_from_shape_invalid_get_output(self, layer_from_shape):
-        layer = layer_from_shape
-        with pytest.raises(RuntimeError):
-            layer.get_output()
-        with pytest.raises(RuntimeError):
-            layer.get_output(Mock())
-        with pytest.raises(RuntimeError):
-            layer.get_output({Mock(): Mock()})
-
-    def test_layer_from_shape_valid_get_output(self, layer_from_shape):
-        layer = layer_from_shape
-        input = {layer: theano.tensor.matrix()}
-        assert layer.get_output(input) is input[layer]
 
     def test_create_param_numpy_bad_shape_raises_error(self, layer):
         param = numpy.array([[1, 2, 3], [4, 5, 6]])
@@ -127,52 +78,11 @@ class TestMultipleInputsLayer:
             layer.input_layers[1].get_output_shape.return_value,
             ])
 
-    def test_get_output_without_arguments(self, layer):
-        layer.get_output_for = Mock()
-
-        output = layer.get_output()
-        assert output is layer.get_output_for.return_value
-        layer.get_output_for.assert_called_with([
-            layer.input_layers[0].get_output.return_value,
-            layer.input_layers[1].get_output.return_value,
-            ])
-        layer.input_layers[0].get_output.assert_called_with(None)
-        layer.input_layers[1].get_output.assert_called_with(None)
-
-    def test_get_output_passes_on_arguments_to_input_layer(self, layer):
-        input, kwarg = object(), object()
-        layer.get_output_for = Mock()
-
-        output = layer.get_output(input, kwarg=kwarg)
-        assert output is layer.get_output_for.return_value
-        layer.get_output_for.assert_called_with([
-            layer.input_layers[0].get_output.return_value,
-            layer.input_layers[1].get_output.return_value,
-            ], kwarg=kwarg)
-        layer.input_layers[0].get_output.assert_called_with(
-            input, kwarg=kwarg)
-        layer.input_layers[1].get_output.assert_called_with(
-            input, kwarg=kwarg)
-
-    def test_get_output_input_is_a_mapping(self, layer):
-        input = {layer: theano.tensor.matrix()}
-        assert layer.get_output(input) is input[layer]
-
-    def test_get_output_input_is_a_mapping_no_key(self, layer):
-        layer.get_output_for = Mock()
-
-        output = layer.get_output({})
-        assert output is layer.get_output_for.return_value
-
-    def test_get_output_input_is_a_mapping_to_array(self, layer):
-        input = {layer: [[1, 2, 3]]}
-        output = layer.get_output(input)
-        assert numpy.all(output.eval() == input[layer])
-
     @pytest.fixture
     def layer_from_shape(self):
+        from lasagne.layers.input import InputLayer
         from lasagne.layers.base import MultipleInputsLayer
-        return MultipleInputsLayer([(None, 20), Mock()])
+        return MultipleInputsLayer([(None, 20), Mock(InputLayer((None,)))])
 
     def test_layer_from_shape(self, layer_from_shape):
         layer = layer_from_shape
@@ -188,17 +98,3 @@ class TestMultipleInputsLayer:
             layer.input_shapes[0],
             layer.input_layers[1].get_output_shape.return_value,
             ])
-
-    def test_layer_from_shape_invalid_get_output(self, layer_from_shape):
-        layer = layer_from_shape
-        with pytest.raises(RuntimeError):
-            layer.get_output()
-        with pytest.raises(RuntimeError):
-            layer.get_output(Mock())
-        with pytest.raises(RuntimeError):
-            layer.get_output({layer.input_layers[1]: Mock()})
-
-    def test_layer_from_shape_valid_get_output(self, layer_from_shape):
-        layer = layer_from_shape
-        input = {layer: theano.tensor.matrix()}
-        assert layer.get_output(input) is input[layer]

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -92,6 +92,7 @@ class TestConv1DLayer:
         input_layer = DummyInputLayer((b, c, w))
         try:
             from lasagne.layers.conv import Conv1DLayer
+            from lasagne.layers.helper import get_output
             layer = Conv1DLayer(
                 input_layer,
                 num_filters=kernel.shape[0],
@@ -99,9 +100,9 @@ class TestConv1DLayer:
                 W=kernel,
                 **kwargs
             )
-            actual = layer.get_output(input).eval()
+            actual = get_output(layer, input).eval()
             assert actual.shape == output.shape
-            assert actual.shape == layer.get_output_shape()
+            assert actual.shape == layer.output_shape
             assert np.allclose(actual, output)
 
         except NotImplementedError:

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -6,6 +6,7 @@ import theano
 from theano.tensor.nnet import conv2d
 
 from lasagne.utils import floatX
+from lasagne.layers.helper import get_output_shape
 
 
 def conv2d_test_sets():
@@ -158,7 +159,7 @@ class TestConv2DLayerImplementations:
             )
             actual = layer.get_output_for(input).eval()
             assert actual.shape == output.shape
-            assert actual.shape == layer.get_output_shape()
+            assert actual.shape == get_output_shape(layer)
             assert np.allclose(actual, output)
 
         except NotImplementedError:
@@ -180,10 +181,10 @@ class TestConv2DLayerImplementations:
             )
             actual = layer.get_output_for(input).eval()
 
-            assert layer.get_output_shape() == (None,
-                                                kernel.shape[0],
-                                                None,
-                                                None)
+            assert get_output_shape(layer) == (None,
+                                               kernel.shape[0],
+                                               None,
+                                               None)
             assert actual.shape == output.shape
             assert np.allclose(actual, output)
 

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -6,7 +6,6 @@ import theano
 from theano.tensor.nnet import conv2d
 
 from lasagne.utils import floatX
-from lasagne.layers.helper import get_output_shape
 
 
 def conv2d_test_sets():
@@ -159,7 +158,7 @@ class TestConv2DLayerImplementations:
             )
             actual = layer.get_output_for(input).eval()
             assert actual.shape == output.shape
-            assert actual.shape == get_output_shape(layer)
+            assert actual.shape == layer.output_shape
             assert np.allclose(actual, output)
 
         except NotImplementedError:
@@ -181,10 +180,10 @@ class TestConv2DLayerImplementations:
             )
             actual = layer.get_output_for(input).eval()
 
-            assert get_output_shape(layer) == (None,
-                                               kernel.shape[0],
-                                               None,
-                                               None)
+            assert layer.output_shape == (None,
+                                          kernel.shape[0],
+                                          None,
+                                          None)
             assert actual.shape == output.shape
             assert np.allclose(actual, output)
 

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -71,11 +71,9 @@ def conv1d_test_sets():
 
 @pytest.fixture
 def DummyInputLayer():
-    def factory(get_output_shape):
-        return Mock(
-            get_output_shape=lambda: get_output_shape,
-            get_output=lambda input: input,
-        )
+    def factory(shape):
+        from lasagne.layers.input import InputLayer
+        return InputLayer(shape)
     return factory
 
 
@@ -158,7 +156,7 @@ class TestConv2DLayerImplementations:
                 W=kernel,
                 **kwargs
             )
-            actual = layer.get_output(input).eval()
+            actual = layer.get_output_for(input).eval()
             assert actual.shape == output.shape
             assert actual.shape == layer.get_output_shape()
             assert np.allclose(actual, output)
@@ -180,7 +178,7 @@ class TestConv2DLayerImplementations:
                 W=kernel,
                 **kwargs
             )
-            actual = layer.get_output(input).eval()
+            actual = layer.get_output_for(input).eval()
 
             assert layer.get_output_shape() == (None,
                                                 kernel.shape[0],

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -1,8 +1,7 @@
+from mock import Mock, PropertyMock
 import pytest
+import numpy
 import theano
-
-
-import lasagne
 
 
 class TestGetAllLayers:
@@ -74,3 +73,267 @@ class TestGetAllLayers:
         assert get_all_layers(l5) == [l1, l2, l3, l4, l5]
         assert get_all_layers(l5, treat_as_input=[l4]) == [l4, l5]
         assert get_all_layers(l5, treat_as_input=[l3]) == [l1, l2, l3, l4, l5]
+
+
+class TestGetOutput_InputLayer:
+    @pytest.fixture
+    def get_output(self):
+        from lasagne.layers.helper import get_output
+        return get_output
+
+    @pytest.fixture
+    def layer(self):
+        from lasagne.layers.input import InputLayer
+        return InputLayer((3, 2))
+
+    def test_get_output_without_arguments(self, layer, get_output):
+        assert get_output(layer) is layer.input_var
+
+    def test_get_output_input_is_variable(self, layer, get_output):
+        variable = theano.Variable("myvariable")
+        assert get_output(layer, variable) is variable
+
+    def test_get_output_input_is_array(self, layer, get_output):
+        inputs = [[1, 2, 3]]
+        output = get_output(layer, inputs)
+        assert numpy.all(output.eval() == inputs)
+
+    def test_get_output_input_is_a_mapping(self, layer, get_output):
+        inputs = {layer: theano.tensor.matrix()}
+        assert get_output(layer, inputs) is inputs[layer]
+
+
+class TestGetOutput_Layer:
+    @pytest.fixture
+    def get_output(self):
+        from lasagne.layers.helper import get_output
+        return get_output
+
+    @pytest.fixture
+    def layer(self):
+        from lasagne.layers.base import Layer
+        from lasagne.layers.input import InputLayer
+        # create a mock that has the same attributes as an InputLayer instance
+        input_layer = Mock(InputLayer((None,)))
+        # create a mock that has the same attributes as a Layer instance
+        layer1 = Mock(Layer(input_layer))
+        # link it to the InputLayer mock
+        layer1.input_layer = input_layer
+        # create another mock that has the same attributes as a Layer instance
+        layer2 = Mock(Layer(layer1))
+        # link it to the first mock, to get an "input -> layer -> layer" chain
+        layer2.input_layer = layer1
+        return layer2
+
+    def test_get_output_without_arguments(self, layer, get_output):
+        output = get_output(layer)
+        assert output is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with(
+            layer.input_layer.get_output_for.return_value)
+        layer.input_layer.get_output_for.assert_called_with(
+            layer.input_layer.input_layer.input_var)
+
+    def test_get_output_with_single_argument(self, layer, get_output):
+        inputs, kwarg = theano.tensor.matrix(), object()
+        output = get_output(layer, inputs, kwarg=kwarg)
+        assert output is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with(
+            layer.input_layer.get_output_for.return_value, kwarg=kwarg)
+        layer.input_layer.get_output_for.assert_called_with(
+            inputs, kwarg=kwarg)
+
+    def test_get_output_input_is_a_mapping(self, layer, get_output):
+        p = PropertyMock()
+        type(layer.input_layer.input_layer).input_var = p
+        inputs = {layer: theano.tensor.matrix()}
+        assert get_output(layer, inputs) is inputs[layer]
+        assert layer.get_output_for.call_count == 0
+        assert layer.input_layer.get_output_for.call_count == 0
+        assert p.call_count == 0
+
+    def test_get_output_input_is_a_mapping_no_key(self, layer, get_output):
+        output = get_output(layer, {})
+        assert output is layer.get_output_for.return_value
+
+    def test_get_output_input_is_a_mapping_to_array(self, layer, get_output):
+        p = PropertyMock()
+        type(layer.input_layer.input_layer).input_var = p
+        inputs = {layer: [[1, 2, 3]]}
+        output = get_output(layer, inputs)
+        assert numpy.all(output.eval() == inputs[layer])
+        assert layer.get_output_for.call_count == 0
+        assert layer.input_layer.get_output_for.call_count == 0
+        assert p.call_count == 0
+
+    def test_get_output_input_is_a_mapping_for_layer(self, layer, get_output):
+        p = PropertyMock()
+        type(layer.input_layer.input_layer).input_var = p
+        input_expr, kwarg = theano.tensor.matrix(), object()
+        inputs = {layer.input_layer: input_expr}
+        output = get_output(layer, inputs, kwarg=kwarg)
+        assert output is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with(input_expr, kwarg=kwarg)
+        assert layer.input_layer.get_output_for.call_count == 0
+        assert p.call_count == 0
+
+    def test_get_output_input_is_a_mapping_for_input_layer(self, layer,
+                                                           get_output):
+        input_expr, kwarg = theano.tensor.matrix(), object()
+        inputs = {layer.input_layer.input_layer: input_expr}
+        output = get_output(layer, inputs, kwarg=kwarg)
+        assert output is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with(
+            layer.input_layer.get_output_for.return_value, kwarg=kwarg)
+        layer.input_layer.get_output_for.assert_called_with(
+            input_expr, kwarg=kwarg)
+
+    @pytest.fixture
+    def layer_from_shape(self):
+        from lasagne.layers.base import Layer
+        return Layer((None, 20))
+
+    def test_layer_from_shape_invalid_get_output(self, layer_from_shape,
+                                                 get_output):
+        layer = layer_from_shape
+        with pytest.raises(ValueError):
+            get_output(layer)
+        with pytest.raises(ValueError):
+            get_output(layer, [1, 2])
+        with pytest.raises(ValueError):
+            get_output(layer, {Mock(): [1, 2]})
+
+    def test_layer_from_shape_valid_get_output(self, layer_from_shape,
+                                               get_output):
+        layer = layer_from_shape
+        inputs = {layer: theano.tensor.matrix()}
+        assert get_output(layer, inputs) is inputs[layer]
+        inputs = {None: theano.tensor.matrix()}
+        layer.get_output_for = Mock()
+        assert get_output(layer, inputs) is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with(inputs[None])
+
+
+class TestGetOutput_MultipleInputsLayer:
+    @pytest.fixture
+    def get_output(self):
+        from lasagne.layers.helper import get_output
+        return get_output
+
+    @pytest.fixture
+    def layer(self):
+        from lasagne.layers.base import Layer, MultipleInputsLayer
+        from lasagne.layers.input import InputLayer
+        # create two mocks of the same attributes as an InputLayer instance
+        input_layers = [Mock(InputLayer((None,))), Mock(InputLayer((None,)))]
+        # create two mocks of the same attributes as a Layer instance
+        layers = [Mock(Layer(input_layers[0])), Mock(Layer(input_layers[1]))]
+        # link them to the InputLayer mocks
+        layers[0].input_layer = input_layers[0]
+        layers[1].input_layer = input_layers[1]
+        # create a mock that has the same attributes as a MultipleInputsLayer
+        layer = Mock(MultipleInputsLayer(input_layers))
+        # link it to the two "input -> layer" mocks
+        layer.input_layers = layers
+        return layer
+
+    def test_get_output_without_arguments(self, layer, get_output):
+        output = get_output(layer)
+        assert output is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with([
+            layer.input_layers[0].get_output_for.return_value,
+            layer.input_layers[1].get_output_for.return_value,
+            ])
+        layer.input_layers[0].get_output_for.assert_called_with(
+            layer.input_layers[0].input_layer.input_var)
+        layer.input_layers[1].get_output_for.assert_called_with(
+            layer.input_layers[1].input_layer.input_var)
+
+    def test_get_output_with_single_argument_fails(self, layer, get_output):
+        inputs, kwarg = theano.tensor.matrix(), object()
+        with pytest.raises(ValueError):
+            output = get_output(layer, inputs, kwarg=kwarg)
+
+    def test_get_output_input_is_a_mapping(self, layer, get_output):
+        p = PropertyMock()
+        type(layer.input_layers[0].input_layer).input_var = p
+        type(layer.input_layers[1].input_layer).input_var = p
+        inputs = {layer: theano.tensor.matrix()}
+        assert get_output(layer, inputs) is inputs[layer]
+        assert layer.get_output_for.call_count == 0
+        assert layer.input_layers[0].get_output_for.call_count == 0
+        assert layer.input_layers[1].get_output_for.call_count == 0
+        assert p.call_count == 0
+
+    def test_get_output_input_is_a_mapping_no_key(self, layer, get_output):
+        output = get_output(layer, {})
+        assert output is layer.get_output_for.return_value
+
+    def test_get_output_input_is_a_mapping_to_array(self, layer, get_output):
+        p = PropertyMock()
+        type(layer.input_layers[0].input_layer).input_var = p
+        type(layer.input_layers[1].input_layer).input_var = p
+        inputs = {layer: [[1, 2, 3]]}
+        output = get_output(layer, inputs)
+        assert numpy.all(output.eval() == inputs[layer])
+        assert layer.get_output_for.call_count == 0
+        assert layer.input_layers[0].get_output_for.call_count == 0
+        assert layer.input_layers[1].get_output_for.call_count == 0
+        assert p.call_count == 0
+
+    def test_get_output_input_is_a_mapping_for_layer(self, layer, get_output):
+        p = PropertyMock()
+        type(layer.input_layers[0].input_layer).input_var = p
+        input_expr, kwarg = theano.tensor.matrix(), object()
+        inputs = {layer.input_layers[0]: input_expr}
+        output = get_output(layer, inputs, kwarg=kwarg)
+        assert output is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with([
+            input_expr,
+            layer.input_layers[1].get_output_for.return_value,
+            ], kwarg=kwarg)
+        assert layer.input_layers[0].get_output_for.call_count == 0
+        layer.input_layers[1].get_output_for.assert_called_with(
+            layer.input_layers[1].input_layer.input_var, kwarg=kwarg)
+        assert p.call_count == 0
+
+    def test_get_output_input_is_a_mapping_for_input_layer(self, layer,
+                                                           get_output):
+        input_expr, kwarg = theano.tensor.matrix(), object()
+        inputs = {layer.input_layers[0].input_layer: input_expr}
+        output = get_output(layer, inputs, kwarg=kwarg)
+        assert output is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with([
+            layer.input_layers[0].get_output_for.return_value,
+            layer.input_layers[1].get_output_for.return_value,
+            ], kwarg=kwarg)
+        layer.input_layers[0].get_output_for.assert_called_with(
+            input_expr, kwarg=kwarg)
+        layer.input_layers[1].get_output_for.assert_called_with(
+            layer.input_layers[1].input_layer.input_var, kwarg=kwarg)
+
+    @pytest.fixture
+    def layer_from_shape(self):
+        from lasagne.layers.input import InputLayer
+        from lasagne.layers.base import MultipleInputsLayer
+        return MultipleInputsLayer([(None, 20), Mock(InputLayer((None,)))])
+
+    def test_layer_from_shape_invalid_get_output(self, layer_from_shape,
+                                                 get_output):
+        layer = layer_from_shape
+        with pytest.raises(ValueError):
+            get_output(layer)
+        with pytest.raises(ValueError):
+            get_output(layer, [1, 2])
+        with pytest.raises(ValueError):
+            get_output(layer, {layer.input_layers[1]: [1, 2]})
+
+    def test_layer_from_shape_valid_get_output(self, layer_from_shape,
+                                               get_output):
+        layer = layer_from_shape
+        inputs = {layer: theano.tensor.matrix()}
+        assert get_output(layer, inputs) is inputs[layer]
+        inputs = {None: theano.tensor.matrix()}
+        layer.get_output_for = Mock()
+        assert get_output(layer, inputs) is layer.get_output_for.return_value
+        layer.get_output_for.assert_called_with(
+            [inputs[None], layer.input_layers[1].input_var])

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -471,12 +471,12 @@ class TestGetOutputShape_Layer:
                                                 get_output_shape):
         l1, l2, l3 = layers
         output_shape = get_output_shape(l3)
-        # expected: l3.get_output_shape_for(l2.get_output_shape_for(l1.shape))
-        assert output_shape is l3.get_output_shape_for.return_value
-        l3.get_output_shape_for.assert_called_with(
-            l2.get_output_shape_for.return_value)
-        l2.get_output_shape_for.assert_called_with(
-            l1.shape)
+        # expected: l3.output_shape
+        assert output_shape is l3.output_shape
+        # l3.get_output_shape_for, l2.get_output_shape_for should not have been
+        # called
+        assert l3.get_output_shape_for.call_count == 0
+        assert l2.get_output_shape_for.call_count == 0
 
     def test_get_output_shape_with_single_argument(self, layers,
                                                    get_output_shape):
@@ -504,12 +504,12 @@ class TestGetOutputShape_Layer:
                                                         get_output_shape):
         l1, l2, l3 = layers
         output_shape = get_output_shape(l3, {})
-        # expected: l3.get_output_shape_for(l2.get_output_shape_for(l1.shape))
-        assert output_shape is l3.get_output_shape_for.return_value
-        l3.get_output_shape_for.assert_called_with(
-            l2.get_output_shape_for.return_value)
-        l2.get_output_shape_for.assert_called_with(
-            l1.shape)
+        # expected: l3.output_shape
+        assert output_shape is l3.output_shape
+        # l3.get_output_shape_for, l2.get_output_shape_for should not have been
+        # called
+        assert l3.get_output_shape_for.call_count == 0
+        assert l2.get_output_shape_for.call_count == 0
 
     def test_get_output_shape_input_is_a_mapping_for_layer(self, layers,
                                                            get_output_shape):
@@ -580,18 +580,13 @@ class TestGetOutputShape_MultipleInputsLayer:
                                                 get_output_shape):
         l1, l2, l3 = layers
         output = get_output_shape(l3)
-        # expected: l3.get_output_shape_for(
-        #     [l2[0].get_output_shape_for(l1[0].shape),
-        #      l2[1].get_output_shape_for(l1[1].shape)])
-        assert output is l3.get_output_shape_for.return_value
-        l3.get_output_shape_for.assert_called_with([
-            l2[0].get_output_shape_for.return_value,
-            l2[1].get_output_shape_for.return_value,
-            ])
-        l2[0].get_output_shape_for.assert_called_with(
-            l1[0].shape)
-        l2[1].get_output_shape_for.assert_called_with(
-            l1[1].shape)
+        # expected: l3.output_shape
+        assert get_output_shape(l3) is l3.output_shape
+        # l3.get_output_shape_for, l2[*].get_output_shape_for should not have
+        # been called
+        assert l3.get_output_shape_for.call_count == 0
+        assert l2[0].get_output_shape_for.call_count == 0
+        assert l2[1].get_output_shape_for.call_count == 0
 
     def test_get_output_shape_with_single_argument_fails(self, layers,
                                                          get_output_shape):
@@ -617,18 +612,13 @@ class TestGetOutputShape_MultipleInputsLayer:
                                                         get_output_shape):
         l1, l2, l3 = layers
         output = get_output_shape(l3, {})
-        # expected: l3.get_output_shape_for(
-        #   [l2[0].get_output_shape_for(l1[0].shape),
-        #    l2[1].get_output_shape_for(l1[1].shape)])
-        assert output is l3.get_output_shape_for.return_value
-        l3.get_output_shape_for.assert_called_with([
-            l2[0].get_output_shape_for.return_value,
-            l2[1].get_output_shape_for.return_value,
-            ])
-        l2[0].get_output_shape_for.assert_called_with(
-            l1[0].shape)
-        l2[1].get_output_shape_for.assert_called_with(
-            l1[1].shape)
+        # expected: l3.output_shape
+        assert get_output_shape(l3) is l3.output_shape
+        # l3.get_output_shape_for, l2[*].get_output_shape_for should not have
+        # been called
+        assert l3.get_output_shape_for.call_count == 0
+        assert l2[0].get_output_shape_for.call_count == 0
+        assert l2[1].get_output_shape_for.call_count == 0
 
     def test_get_output_shape_input_is_a_mapping_for_layer(self, layers,
                                                            get_output_shape):

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -210,6 +210,8 @@ class TestGetOutput_Layer:
     def test_get_output_input_is_a_mapping_for_input_layer(self, layers,
                                                            get_output):
         l1, l2, l3 = layers
+        p = PropertyMock()
+        type(l1).input_var = p
         input_expr, kwarg = theano.tensor.matrix(), object()
         inputs = {l1: input_expr}
         output = get_output(l3, inputs, kwarg=kwarg)
@@ -221,8 +223,8 @@ class TestGetOutput_Layer:
             l2.get_output_for.return_value, kwarg=kwarg)
         l2.get_output_for.assert_called_with(
             input_expr, kwarg=kwarg)
-        # l1.input_var was accessed in the beginning of get_output(),
-        # so here we cannot assert it was not.
+        # l1.input_var should not have been accessed
+        assert p.call_count == 0
 
     @pytest.fixture
     def layer_from_shape(self):
@@ -369,6 +371,8 @@ class TestGetOutput_MultipleInputsLayer:
     def test_get_output_input_is_a_mapping_for_input_layer(self, layers,
                                                            get_output):
         l1, l2, l3 = layers
+        p = PropertyMock()
+        type(l1[0]).input_var = p
         input_expr, kwarg = theano.tensor.matrix(), object()
         inputs = {l1[0]: input_expr}
         output = get_output(l3, inputs, kwarg=kwarg)
@@ -386,8 +390,8 @@ class TestGetOutput_MultipleInputsLayer:
             input_expr, kwarg=kwarg)
         l2[1].get_output_for.assert_called_with(
             l1[1].input_var, kwarg=kwarg)
-        # l1[0].input_var was accessed in the beginning of get_output(),
-        # so here we cannot assert it was not.
+        # l1[0].input_var should not have been accessed
+        assert p.call_count == 0
 
     @pytest.fixture
     def layer_from_shape(self):

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -523,8 +523,8 @@ class TestGetOutputShape_Layer:
         # l2.get_output_shape_for should not have been called
         assert l2.get_output_shape_for.call_count == 0
 
-    def test_get_output_shape_input_is_a_mapping_for_input_layer(self, layers,
-            get_output_shape):
+    def test_get_output_shape_input_is_a_mapping_for_input_layer(
+            self, layers, get_output_shape):
         l1, l2, l3 = layers
         shp = (4, 5, 6)
         input_shapes = {l1: shp}
@@ -645,8 +645,8 @@ class TestGetOutputShape_MultipleInputsLayer:
         # l2[0].get_output_shape_for should not have been called
         assert l2[0].get_output_shape_for.call_count == 0
 
-    def test_get_output_shape_input_is_a_mapping_for_input_layer(self, layers,
-            get_output_shape):
+    def test_get_output_shape_input_is_a_mapping_for_input_layer(
+            self, layers, get_output_shape):
         l1, l2, l3 = layers
         shp = (4, 5, 6)
         input_shapes = {l1[0]: shp}

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -24,6 +24,7 @@ class TestGetAllLayers:
                 else:
                     expected = []
                 assert get_all_layers(query) == expected
+        assert get_all_layers(l3, treat_as_input=[l2]) == [l2, l3]
 
     def test_merge(self):
         from lasagne.layers import (InputLayer, DenseLayer, ElemwiseSumLayer,
@@ -40,6 +41,9 @@ class TestGetAllLayers:
         assert get_all_layers([l4, l6]) == [l4, l1, l2, l3, l5, l6]
         assert get_all_layers([l5, l6]) == [l4, l5, l1, l2, l3, l6]
         assert get_all_layers([l4, l2, l5, l6]) == [l4, l1, l2, l5, l3, l6]
+        assert get_all_layers(l6, treat_as_input=[l2]) == [l2, l3, l4, l5, l6]
+        assert get_all_layers(l6, treat_as_input=[l3, l5]) == [l3, l5, l6]
+        assert get_all_layers([l6, l2], treat_as_input=[l6]) == [l6, l1, l2]
 
     def test_split(self):
         from lasagne.layers import InputLayer, DenseLayer, get_all_layers
@@ -53,6 +57,9 @@ class TestGetAllLayers:
         assert get_all_layers(l4) == [l1, l4]
         assert get_all_layers([l3, l4]) == [l1, l2, l3, l4]
         assert get_all_layers([l4, l3]) == [l1, l4, l2, l3]
+        assert get_all_layers(l3, treat_as_input=[l2]) == [l2, l3]
+        assert get_all_layers([l3, l4], treat_as_input=[l2]) == [l2, l3,
+                                                                 l1, l4]
 
     def test_bridge(self):
         from lasagne.layers import (InputLayer, DenseLayer, ElemwiseSumLayer,
@@ -65,3 +72,5 @@ class TestGetAllLayers:
         l4 = ElemwiseSumLayer([l2, l3])
         l5 = DenseLayer(l4, 40)
         assert get_all_layers(l5) == [l1, l2, l3, l4, l5]
+        assert get_all_layers(l5, treat_as_input=[l4]) == [l4, l5]
+        assert get_all_layers(l5, treat_as_input=[l3]) == [l1, l2, l3, l4, l5]

--- a/lasagne/tests/layers/test_input.py
+++ b/lasagne/tests/layers/test_input.py
@@ -12,8 +12,8 @@ class TestInputLayer:
     def test_input_var(self, layer):
         assert layer.input_var.ndim == 2
 
-    def test_get_output_shape(self, layer):
-        assert layer.get_output_shape() == (3, 2)
+    def test_shape(self, layer):
+        assert layer.shape == (3, 2)
 
     def test_input_var_name(self, layer):
         assert layer.input_var.name == "input"

--- a/lasagne/tests/layers/test_input.py
+++ b/lasagne/tests/layers/test_input.py
@@ -15,22 +15,6 @@ class TestInputLayer:
     def test_get_output_shape(self, layer):
         assert layer.get_output_shape() == (3, 2)
 
-    def test_get_output_without_arguments(self, layer):
-        assert layer.get_output() is layer.input_var
-
-    def test_get_output_input_is_variable(self, layer):
-        variable = theano.Variable("myvariable")
-        assert layer.get_output(variable) is variable
-
-    def test_get_output_input_is_array(self, layer):
-        input = [[1, 2, 3]]
-        output = layer.get_output(input)
-        assert numpy.all(output.eval() == input)
-
-    def test_get_output_input_is_a_mapping(self, layer):
-        input = {layer: theano.tensor.matrix()}
-        assert layer.get_output(input) is input[layer]
-
     def test_input_var_name(self, layer):
         assert layer.input_var.name == "input"
 

--- a/lasagne/tests/layers/test_noise.py
+++ b/lasagne/tests/layers/test_noise.py
@@ -7,7 +7,8 @@ import pytest
 class TestDropoutLayer:
     @pytest.fixture(params=[(100, 100), (None, 100)])
     def input_layer(self, request):
-        return Mock(get_output_shape=lambda: request.param)
+        from lasagne.layers.input import InputLayer
+        return InputLayer(request.param)
 
     @pytest.fixture
     def layer(self, input_layer):

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -117,7 +117,7 @@ class TestLocalResponseNormalization2DLayer:
 
     def test_normalization(self, input_data, input_layer, layer):
         X = input_layer.input_var
-        lrn = theano.function([X], layer.get_output(X))
+        lrn = theano.function([X], lasagne.layers.get_output(layer, X))
         out = lrn(input_data)
 
         # ground_truth_normalizer assumes c01b

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -77,7 +77,8 @@ class TestFeaturePoolLayer:
                 yield (pool_size, axis)
 
     def input_layer(self, output_shape):
-        return Mock(get_output_shape=lambda: output_shape)
+        from lasagne.layers.input import InputLayer
+        return InputLayer(output_shape)
 
     def layer(self, input_layer, pool_size, axis):
         from lasagne.layers.pool import FeaturePoolLayer

--- a/lasagne/tests/layers/test_shape.py
+++ b/lasagne/tests/layers/test_shape.py
@@ -2,6 +2,8 @@ import numpy
 import pytest
 import theano
 
+from lasagne.layers.helper import get_output_shape
+
 
 class TestReshapeLayer:
     @pytest.fixture
@@ -19,42 +21,42 @@ class TestReshapeLayer:
     def test_no_reference(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (16, 3, 5, 7, 2, 5))
-        assert layer.get_output_shape() == (16, 3, 5, 7, 2, 5)
+        assert get_output_shape(layer) == (16, 3, 5, 7, 2, 5)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 7, 2, 5)
 
     def test_reference_both(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (-1, [1], [2], [3], 2, 5))
-        assert layer.get_output_shape() == (16, 3, None, None, 2, 5)
+        assert get_output_shape(layer) == (16, 3, None, None, 2, 5)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 7, 2, 5)
 
     def test_reference_one(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (-1, [1], [2], 7, 2, 5))
-        assert layer.get_output_shape() == (None, 3, None, 7, 2, 5)
+        assert get_output_shape(layer) == (None, 3, None, 7, 2, 5)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 7, 2, 5)
 
     def test_reference_twice(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (-1, [1], [2], [3], 2, [2]))
-        assert layer.get_output_shape() == (None, 3, None, None, 2, None)
+        assert get_output_shape(layer) == (None, 3, None, None, 2, None)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 7, 2, 5)
 
     def test_merge_with_unknown(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, ([0], [1], [2], -1))
-        assert layer.get_output_shape() == (16, 3, None, None)
+        assert get_output_shape(layer) == (16, 3, None, None)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 70)
 
     def test_merge_two_unknowns(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, ([0], [1], -1, [4]))
-        assert layer.get_output_shape() == (16, 3, None, 10)
+        assert get_output_shape(layer) == (16, 3, None, 10)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 35, 10)
 
@@ -62,7 +64,7 @@ class TestReshapeLayer:
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (17, 3, [2], [3], -1))
         with pytest.raises(ValueError) as excinfo:
-            layer.get_output_shape() == (16, 3, None, 10)
+            get_output_shape(layer) == (16, 3, None, 10)
         assert 'match' in str(excinfo.value)
 
     def test_invalid_spec(self, layerclass, two_unknown):
@@ -130,14 +132,14 @@ class TestDimshuffleLayer:
     def test_rearrange(self, input_data, input_var, input_layer):
         from lasagne.layers.shape import DimshuffleLayer
         ds = DimshuffleLayer(input_layer, [4, 3, 2, 1, 0])
-        assert ds.get_output_shape() == (7, 5, 1, 3, 2)
+        assert get_output_shape(ds) == (7, 5, 1, 3, 2)
         assert ds.get_output_for(input_var).eval(
             {input_var: input_data}).shape == (7, 5, 1, 3, 2)
 
     def test_broadcast(self, input_data, input_var, input_layer):
         from lasagne.layers.shape import DimshuffleLayer
         ds = DimshuffleLayer(input_layer, [0, 1, 2, 3, 4, 'x'])
-        assert ds.get_output_shape() == (2, 3, 1, 5, 7, 1)
+        assert get_output_shape(ds) == (2, 3, 1, 5, 7, 1)
         assert ds.get_output_for(input_var).eval(
             {input_var: input_data}).shape == (2, 3, 1, 5, 7, 1)
 
@@ -145,21 +147,21 @@ class TestDimshuffleLayer:
         from lasagne.layers.shape import DimshuffleLayer
         ds_ok = DimshuffleLayer(input_layer, [0, 1, 3, 4])
         ds_bad = DimshuffleLayer(input_layer, [0, 1, 2, 4])
-        assert ds_ok.get_output_shape() == (2, 3, 5, 7)
+        assert get_output_shape(ds_ok) == (2, 3, 5, 7)
         assert ds_ok.get_output_for(input_var).eval(
             {input_var: input_data}).shape == (2, 3, 5, 7)
         with pytest.raises(ValueError):
-            ds_bad.get_output_shape()
+            get_output_shape(ds_bad)
 
     def test_collapse_None(self, input_data, input_var, input_layer_with_None):
         from lasagne.layers.shape import DimshuffleLayer
         ds_ok = DimshuffleLayer(input_layer_with_None, [0, 1, 3, 4])
         ds_bad = DimshuffleLayer(input_layer_with_None, [0, 1, 2, 4])
-        assert ds_ok.get_output_shape() == (2, 3, 5, 7)
+        assert get_output_shape(ds_ok) == (2, 3, 5, 7)
         assert ds_ok.get_output_for(input_var).eval(
             {input_var: input_data}).shape == (2, 3, 5, 7)
         with pytest.raises(ValueError):
-            ds_bad.get_output_shape()
+            get_output_shape(ds_bad)
 
     def test_invalid_pattern(self, input_data, input_var, input_layer):
         from lasagne.layers.shape import DimshuffleLayer
@@ -170,4 +172,4 @@ class TestDimshuffleLayer:
         # There is no dimension 42
         ds_bad = DimshuffleLayer(input_layer, [0, 1, 2, 4, 42])
         with pytest.raises(ValueError):
-            ds_bad.get_output_shape()
+            get_output_shape(ds_bad)

--- a/lasagne/tests/layers/test_shape.py
+++ b/lasagne/tests/layers/test_shape.py
@@ -2,8 +2,6 @@ import numpy
 import pytest
 import theano
 
-from lasagne.layers.helper import get_output_shape
-
 
 class TestReshapeLayer:
     @pytest.fixture
@@ -21,50 +19,49 @@ class TestReshapeLayer:
     def test_no_reference(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (16, 3, 5, 7, 2, 5))
-        assert get_output_shape(layer) == (16, 3, 5, 7, 2, 5)
+        assert layer.output_shape == (16, 3, 5, 7, 2, 5)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 7, 2, 5)
 
     def test_reference_both(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (-1, [1], [2], [3], 2, 5))
-        assert get_output_shape(layer) == (16, 3, None, None, 2, 5)
+        assert layer.output_shape == (16, 3, None, None, 2, 5)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 7, 2, 5)
 
     def test_reference_one(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (-1, [1], [2], 7, 2, 5))
-        assert get_output_shape(layer) == (None, 3, None, 7, 2, 5)
+        assert layer.output_shape == (None, 3, None, 7, 2, 5)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 7, 2, 5)
 
     def test_reference_twice(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, (-1, [1], [2], [3], 2, [2]))
-        assert get_output_shape(layer) == (None, 3, None, None, 2, None)
+        assert layer.output_shape == (None, 3, None, None, 2, None)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 7, 2, 5)
 
     def test_merge_with_unknown(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, ([0], [1], [2], -1))
-        assert get_output_shape(layer) == (16, 3, None, None)
+        assert layer.output_shape == (16, 3, None, None)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 5, 70)
 
     def test_merge_two_unknowns(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
         layer = layerclass(inputlayer, ([0], [1], -1, [4]))
-        assert get_output_shape(layer) == (16, 3, None, 10)
+        assert layer.output_shape == (16, 3, None, 10)
         result = layer.get_output_for(inputdata).eval()
         assert result.shape == (16, 3, 35, 10)
 
     def test_size_mismatch(self, layerclass, two_unknown):
         inputlayer, inputdata = two_unknown
-        layer = layerclass(inputlayer, (17, 3, [2], [3], -1))
         with pytest.raises(ValueError) as excinfo:
-            get_output_shape(layer) == (16, 3, None, 10)
+            layerclass(inputlayer, (17, 3, [2], [3], -1))
         assert 'match' in str(excinfo.value)
 
     def test_invalid_spec(self, layerclass, two_unknown):
@@ -79,12 +76,8 @@ class TestReshapeLayer:
             layerclass(inputlayer, ([0, 1], 3, 5, 7, 10))
         with pytest.raises(ValueError):
             layerclass(inputlayer, (None, 3, 5, 7, 10))
-
-    def test_reference_out_of_range(self, layerclass, two_unknown):
-        inputlayer, inputdata = two_unknown
-        layer = layerclass(inputlayer, (16, 3, 5, 7, [5]))
         with pytest.raises(ValueError):
-            layer.get_output_for(inputdata)
+            layerclass(inputlayer, (16, 3, 5, 7, [5]))
 
 
 class TestDimshuffleLayer:
@@ -132,36 +125,34 @@ class TestDimshuffleLayer:
     def test_rearrange(self, input_data, input_var, input_layer):
         from lasagne.layers.shape import DimshuffleLayer
         ds = DimshuffleLayer(input_layer, [4, 3, 2, 1, 0])
-        assert get_output_shape(ds) == (7, 5, 1, 3, 2)
+        assert ds.output_shape == (7, 5, 1, 3, 2)
         assert ds.get_output_for(input_var).eval(
             {input_var: input_data}).shape == (7, 5, 1, 3, 2)
 
     def test_broadcast(self, input_data, input_var, input_layer):
         from lasagne.layers.shape import DimshuffleLayer
         ds = DimshuffleLayer(input_layer, [0, 1, 2, 3, 4, 'x'])
-        assert get_output_shape(ds) == (2, 3, 1, 5, 7, 1)
+        assert ds.output_shape == (2, 3, 1, 5, 7, 1)
         assert ds.get_output_for(input_var).eval(
             {input_var: input_data}).shape == (2, 3, 1, 5, 7, 1)
 
     def test_collapse(self, input_data, input_var, input_layer):
         from lasagne.layers.shape import DimshuffleLayer
         ds_ok = DimshuffleLayer(input_layer, [0, 1, 3, 4])
-        ds_bad = DimshuffleLayer(input_layer, [0, 1, 2, 4])
-        assert get_output_shape(ds_ok) == (2, 3, 5, 7)
+        assert ds_ok.output_shape == (2, 3, 5, 7)
         assert ds_ok.get_output_for(input_var).eval(
             {input_var: input_data}).shape == (2, 3, 5, 7)
         with pytest.raises(ValueError):
-            get_output_shape(ds_bad)
+            DimshuffleLayer(input_layer, [0, 1, 2, 4])
 
     def test_collapse_None(self, input_data, input_var, input_layer_with_None):
         from lasagne.layers.shape import DimshuffleLayer
         ds_ok = DimshuffleLayer(input_layer_with_None, [0, 1, 3, 4])
-        ds_bad = DimshuffleLayer(input_layer_with_None, [0, 1, 2, 4])
-        assert get_output_shape(ds_ok) == (2, 3, 5, 7)
+        assert ds_ok.output_shape == (2, 3, 5, 7)
         assert ds_ok.get_output_for(input_var).eval(
             {input_var: input_data}).shape == (2, 3, 5, 7)
         with pytest.raises(ValueError):
-            get_output_shape(ds_bad)
+            DimshuffleLayer(input_layer_with_None, [0, 1, 2, 4])
 
     def test_invalid_pattern(self, input_data, input_var, input_layer):
         from lasagne.layers.shape import DimshuffleLayer
@@ -169,7 +160,6 @@ class TestDimshuffleLayer:
             DimshuffleLayer(input_layer, ['q'])
         with pytest.raises(ValueError):
             DimshuffleLayer(input_layer, [0, 0, 1, 3, 4])
-        # There is no dimension 42
-        ds_bad = DimshuffleLayer(input_layer, [0, 1, 2, 4, 42])
         with pytest.raises(ValueError):
-            get_output_shape(ds_bad)
+            # There is no dimension 42
+            DimshuffleLayer(input_layer, [0, 1, 2, 4, 42])

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -175,18 +175,21 @@ class TestObjectives:
 
     def test_objective(self):
         from lasagne.objectives import Objective
+        from lasagne.layers.input import Layer, InputLayer
 
-        input_layer = mock.Mock()
+        input_layer = mock.Mock(InputLayer((None,)))
+        layer = mock.Mock(Layer(input_layer))
+        layer.input_layer = input_layer
         loss_function = mock.Mock()
-        input, target, kwarg1 = object(), object(), object()
-        objective = Objective(input_layer, loss_function)
+        input, target, kwarg1 = theano.tensor.vector(), object(), object()
+        objective = Objective(layer, loss_function)
         result = objective.get_loss(input, target, 'mean', kwarg1=kwarg1)
 
-        # We expect that the input layer's `get_output` was called with
+        # We expect that the layer's `get_output_for` was called with
         # the `input` argument we provided, plus the extra positional and
         # keyword arguments.
-        input_layer.get_output.assert_called_with(input, kwarg1=kwarg1)
-        network_output = input_layer.get_output.return_value
+        layer.get_output_for.assert_called_with(input, kwarg1=kwarg1)
+        network_output = layer.get_output_for.return_value
 
         # The `network_output` and `target` are fed into the loss
         # function:
@@ -195,15 +198,18 @@ class TestObjectives:
 
     def test_objective_no_target(self):
         from lasagne.objectives import Objective
+        from lasagne.layers.input import Layer, InputLayer
 
-        input_layer = mock.Mock()
+        input_layer = mock.Mock(InputLayer((None,)))
+        layer = mock.Mock(Layer(input_layer))
+        layer.input_layer = input_layer
         loss_function = mock.Mock()
-        input = object()
-        objective = Objective(input_layer, loss_function)
+        input = theano.tensor.vector()
+        objective = Objective(layer, loss_function)
         result = objective.get_loss(input)
 
-        input_layer.get_output.assert_called_with(input)
-        network_output = input_layer.get_output.return_value
+        layer.get_output_for.assert_called_with(input)
+        network_output = layer.get_output_for.return_value
 
         loss_function.assert_called_with(network_output, objective.target_var)
         assert result == loss_function.return_value.mean.return_value

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -33,13 +33,13 @@ Usage
 >>> import theano.tensor as T
 >>> import theano
 >>> from lasagne.nonlinearities import softmax
->>> from lasagne.layers import InputLayer, DenseLayer
+>>> from lasagne.layers import InputLayer, DenseLayer, get_output
 >>> from lasagne.updates import sgd, apply_momentum
 >>> l_in = InputLayer((100, 20))
 >>> l1 = DenseLayer(l_in, num_units=3, nonlinearity=softmax)
 >>> x = T.matrix('x')  # shp: num_batch x num_features
 >>> y = T.ivector('y') # shp: num_batch
->>> l_out = l1.get_output(x)
+>>> l_out = get_output(l1, x)
 >>> params = lasagne.layers.get_all_params(l1)
 >>> loss = T.mean(T.nnet.categorical_crossentropy(l_out, y))
 >>> updates_sgd = sgd(loss, params, learning_rate=0.0001)


### PR DESCRIPTION
To address #104, this moves `get_output()` out of the layer class hierarchy and turns it into a helper function `lasagne.layers.get_output()`. This is work in progress.
TODO:
* [x] move `get_output()`
* [x] rewrite tests for `get_output()`
* [x] move `get_output_shape()`
* [x] rewrite tests for `get_output_shape()`
* [x] modify examples

The current tests don't run through because they rely on everything-goes `Mock()` instances. That is, they always have a `input_layers` attribute, which tricks `get_all_layers()`. Changing `get_all_layers()` to first check for the `input_layer` attribute isn't better either, because every `Mock()` instance also has a `input_layer` attribute which is a `Mock()` instance with an `input_layer` attribute. Changing the `Mock()` instances to only have the attributes they should makes the tests fail in other ways because they assume `get_output()` to be called where the new code calls `get_output_for()` or returns `input_var`. Long story short, the tests need to be rewritten, with the current test suite we cannot check whether the refactoring did any harm.