### PR TITLE
rename MultipleInputsLayer to MergeLayer

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -22,7 +22,7 @@ Layer base classes
 .. autoclass:: Layer
    :members:
 
-.. autoclass:: MultipleInputsLayer
+.. autoclass:: MergeLayer
     :members:
 
 Layer classes: network input

--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -7,7 +7,7 @@ from .. import utils
 
 __all__ = [
     "Layer",
-    "MultipleInputsLayer",
+    "MergeLayer",
 ]
 
 
@@ -245,7 +245,7 @@ class Layer(object):
                                "callable")
 
 
-class MultipleInputsLayer(Layer):
+class MergeLayer(Layer):
     """
     This class represents a layer that aggregates input from multiple layers.
     It should be subclassed when implementing new types of layers that
@@ -323,7 +323,7 @@ class MultipleInputsLayer(Layer):
                 the output of this layer given the inputs to this layer
 
         :note:
-            This is called by the base :class:`MultipleInputsLayer`
+            This is called by the base :class:`MergeLayer`
             implementation to propagate data through a network in
             `get_output()`. While `get_output()` asks the underlying layers
             for input and thus returns an expression for a layer's output in

--- a/lasagne/layers/merge.py
+++ b/lasagne/layers/merge.py
@@ -1,6 +1,6 @@
 import theano.tensor as T
 
-from .base import MultipleInputsLayer
+from .base import MergeLayer
 
 
 __all__ = [
@@ -10,7 +10,7 @@ __all__ = [
 ]
 
 
-class ConcatLayer(MultipleInputsLayer):
+class ConcatLayer(MergeLayer):
     def __init__(self, incomings, axis=1, **kwargs):
         super(ConcatLayer, self).__init__(incomings, **kwargs)
         self.axis = axis
@@ -27,7 +27,7 @@ class ConcatLayer(MultipleInputsLayer):
 concat = ConcatLayer  # shortcut
 
 
-class ElemwiseSumLayer(MultipleInputsLayer):
+class ElemwiseSumLayer(MergeLayer):
     """
     This layer performs an elementwise sum of its input layers.
     It requires all input layers to have the same output shape.

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -112,11 +112,11 @@ class TestLayer:
         assert l.name == "foo"
 
 
-class TestMultipleInputsLayer:
+class TestMergeLayer:
     @pytest.fixture
     def layer(self):
-        from lasagne.layers.base import MultipleInputsLayer
-        return MultipleInputsLayer([Mock(), Mock()])
+        from lasagne.layers.base import MergeLayer
+        return MergeLayer([Mock(), Mock()])
 
     def test_get_output_shape(self, layer):
         layer.get_output_shape_for = Mock()
@@ -171,8 +171,8 @@ class TestMultipleInputsLayer:
 
     @pytest.fixture
     def layer_from_shape(self):
-        from lasagne.layers.base import MultipleInputsLayer
-        return MultipleInputsLayer([(None, 20), Mock()])
+        from lasagne.layers.base import MergeLayer
+        return MergeLayer([(None, 20), Mock()])
 
     def test_layer_from_shape(self, layer_from_shape):
         layer = layer_from_shape


### PR DESCRIPTION
This addresses #200. I grepped for `MultipleInputsLayer` and changed all instances, so hopefully I didn't miss any.

py.test is still broken on this machine so I wasn't able to run the tests. Counting on Travis! I'll try to sort that out tonight.