### PR TITLE
Unify keyword argument names for convolution and pooling

### DIFF
--- a/examples/mnist_conv.py
+++ b/examples/mnist_conv.py
@@ -56,7 +56,7 @@ def build_model(input_width, input_height, output_dim,
         nonlinearity=lasagne.nonlinearities.rectify,
         W=lasagne.init.GlorotUniform(),
         )
-    l_pool1 = lasagne.layers.MaxPool2DLayer(l_conv1, ds=(2, 2))
+    l_pool1 = lasagne.layers.MaxPool2DLayer(l_conv1, pool_size=(2, 2))
 
     l_conv2 = lasagne.layers.Conv2DLayer(
         l_pool1,
@@ -65,7 +65,7 @@ def build_model(input_width, input_height, output_dim,
         nonlinearity=lasagne.nonlinearities.rectify,
         W=lasagne.init.GlorotUniform(),
         )
-    l_pool2 = lasagne.layers.MaxPool2DLayer(l_conv2, ds=(2, 2))
+    l_pool2 = lasagne.layers.MaxPool2DLayer(l_conv2, pool_size=(2, 2))
 
     l_hidden1 = lasagne.layers.DenseLayer(
         l_pool2,

--- a/examples/mnist_conv_cc.py
+++ b/examples/mnist_conv_cc.py
@@ -63,7 +63,7 @@ def build_model(input_width, input_height, output_dim,
     )
     l_pool1 = cuda_convnet.MaxPool2DCCLayer(
         l_conv1,
-        ds=(2, 2),
+        pool_size=(2, 2),
         dimshuffle=dimshuffle,
     )
 
@@ -76,7 +76,7 @@ def build_model(input_width, input_height, output_dim,
     )
     l_pool2 = cuda_convnet.MaxPool2DCCLayer(
         l_conv2,
-        ds=(2, 2),
+        pool_size=(2, 2),
         dimshuffle=dimshuffle,
     )
 

--- a/examples/mnist_conv_dnn.py
+++ b/examples/mnist_conv_dnn.py
@@ -57,7 +57,7 @@ def build_model(input_width, input_height, output_dim,
         nonlinearity=lasagne.nonlinearities.rectify,
         W=lasagne.init.GlorotUniform(),
     )
-    l_pool1 = dnn.MaxPool2DDNNLayer(l_conv1, ds=(2, 2))
+    l_pool1 = dnn.MaxPool2DDNNLayer(l_conv1, pool_size=(2, 2))
 
     l_conv2 = dnn.Conv2DDNNLayer(
         l_pool1,
@@ -66,7 +66,7 @@ def build_model(input_width, input_height, output_dim,
         nonlinearity=lasagne.nonlinearities.rectify,
         W=lasagne.init.GlorotUniform(),
     )
-    l_pool2 = dnn.MaxPool2DDNNLayer(l_conv2, ds=(2, 2))
+    l_pool2 = dnn.MaxPool2DDNNLayer(l_conv2, pool_size=(2, 2))
 
     l_hidden1 = lasagne.layers.DenseLayer(
         l_pool2,

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -2,6 +2,7 @@ import theano.tensor as T
 
 from .. import init
 from .. import nonlinearities
+from ..utils import as_tuple
 from ..theano_extensions import conv
 
 from .base import Layer
@@ -133,8 +134,8 @@ class Conv2DLayer(Layer):
             self.nonlinearity = nonlinearity
 
         self.num_filters = num_filters
-        self.filter_size = filter_size
-        self.stride = stride
+        self.filter_size = as_tuple(filter_size, 2)
+        self.stride = as_tuple(stride, 2)
         self.border_mode = border_mode
         self.untie_biases = untie_biases
         self.convolution = convolution

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -10,6 +10,7 @@ from .. import nonlinearities
 from .base import Layer
 
 from .conv import conv_output_length
+from ..utils import as_tuple
 
 from theano.sandbox.cuda.basic_ops import gpu_contiguous
 from theano.sandbox.cuda.blas import GpuCorrMM
@@ -42,8 +43,8 @@ class Conv2DMMLayer(MMLayer):
             self.nonlinearity = nonlinearity
 
         self.num_filters = num_filters
-        self.filter_size = filter_size
-        self.stride = stride
+        self.filter_size = as_tuple(filter_size, 2)
+        self.stride = as_tuple(stride, 2)
         self.untie_biases = untie_biases
         self.flip_filters = flip_filters
 
@@ -68,7 +69,7 @@ class Conv2DMMLayer(MMLayer):
                 raise RuntimeError("Unsupported border_mode for "
                                    "Conv2DMMLayer: %s" % border_mode)
         else:
-            self.pad = pad
+            self.pad = as_tuple(pad, 2)
 
         self.W = self.create_param(W, self.get_W_shape(), name="W")
         if b is None:

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -31,7 +31,7 @@ class MMLayer(Layer):
 
 
 class Conv2DMMLayer(MMLayer):
-    def __init__(self, incoming, num_filters, filter_size, strides=(1, 1),
+    def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
                  border_mode=None, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  pad=None, flip_filters=False, **kwargs):
@@ -43,7 +43,7 @@ class Conv2DMMLayer(MMLayer):
 
         self.num_filters = num_filters
         self.filter_size = filter_size
-        self.strides = strides
+        self.stride = stride
         self.untie_biases = untie_biases
         self.flip_filters = flip_filters
 
@@ -80,7 +80,7 @@ class Conv2DMMLayer(MMLayer):
         else:
             self.b = self.create_param(b, (num_filters,), name="b")
 
-        self.corr_mm_op = GpuCorrMM(subsample=self.strides, pad=self.pad)
+        self.corr_mm_op = GpuCorrMM(subsample=self.stride, pad=self.pad)
 
     def get_W_shape(self):
         num_input_channels = self.input_shape[1]
@@ -98,12 +98,12 @@ class Conv2DMMLayer(MMLayer):
 
         output_rows = conv_output_length(input_shape[2],
                                          self.filter_size[0],
-                                         self.strides[0],
+                                         self.stride[0],
                                          'pad', self.pad[0])
 
         output_columns = conv_output_length(input_shape[3],
                                             self.filter_size[1],
-                                            self.strides[1],
+                                            self.stride[1],
                                             'pad', self.pad[1])
 
         return (batch_size, self.num_filters, output_rows, output_columns)

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -207,16 +207,19 @@ class MaxPool2DCCLayer(CCLayer):
         from pylearn2.sandbox.cuda_convnet.pool import MaxPool
 
         if 'pad' in kwargs:
-            raise NotImplementedError("MaxPool2DCCLayer does not "
-                                      "support padding")
+            pad = kwargs.pop('pad')
+            if as_tuple(pad, 2) != (0, 0):
+                raise NotImplementedError("MaxPool2DCCLayer does not "
+                                          "support padding")
 
         super(MaxPool2DCCLayer, self).__init__(incoming, **kwargs)
 
         pool_size = as_tuple(pool_size, 2)
 
         if pool_size[0] != pool_size[1]:
-            raise RuntimeError("MaxPool2DCCLayer only supports square pooling "
-                               "regions, but pool_size=(%d, %d)" % pool_size)
+            raise NotImplementedError("MaxPool2DCCLayer only supports square "
+                                      "pooling regions, but pool_size=(%d, %d)"
+                                      % pool_size)
 
         self.pool_size = pool_size[0]
 
@@ -225,16 +228,21 @@ class MaxPool2DCCLayer(CCLayer):
         else:
             stride = as_tuple(stride, 2)
             if stride[0] != stride[1]:
-                raise RuntimeError("MaxPool2DCCLayer only supports using the "
-                                   "same stride in both directions, but "
-                                   "stride=(%d, %d)" % stride)
+                raise NotImplementedError("MaxPool2DCCLayer only supports "
+                                          "using the same stride in both, "
+                                          "directions but stride=(%d, %d)"
+                                          % stride)
             self.stride = stride[0]
+
+        if self.stride > self.pool_size:
+            raise NotImplementedError("MaxPool2DCCLayer only supports "
+                                      "stride <= pool_size.")
 
         # ignore_border argument is for compatibility with MaxPool2DLayer.
         # it is not supported. Borders are never ignored.
         if ignore_border is not False:
-            raise RuntimeError("MaxPool2DCCLayer does not support "
-                               "ignore_border.")
+            raise NotImplementedError("MaxPool2DCCLayer does not support "
+                                      "ignore_border.")
 
         self.dimshuffle = dimshuffle
 
@@ -250,9 +258,9 @@ class MaxPool2DCCLayer(CCLayer):
             num_input_channels = input_shape[0]
             input_rows, input_columns = input_shape[1:3]
 
-        output_rows = int(np.ceil(float(input_rows - self.ds +
+        output_rows = int(np.ceil(float(input_rows - self.pool_size +
                                         self.stride) / self.stride))
-        output_columns = int(np.ceil(float(input_columns - self.ds +
+        output_columns = int(np.ceil(float(input_columns - self.pool_size +
                                            self.stride) / self.stride))
 
         if self.dimshuffle:

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -39,7 +39,7 @@ class CCLayer(Layer):
 
 
 class Conv2DCCLayer(CCLayer):
-    def __init__(self, incoming, num_filters, filter_size, strides=(1, 1),
+    def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
                  border_mode=None, untie_biases=False, W=None,
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  pad=None, dimshuffle=True, flip_filters=False, partial_sum=1,
@@ -54,9 +54,9 @@ class Conv2DCCLayer(CCLayer):
             raise RuntimeError("Conv2DCCLayer only supports square filters, "
                                "but filter_size=(%d, %d)" % filter_size)
 
-        if strides[0] != strides[1]:
+        if stride[0] != stride[1]:
             raise RuntimeError("Conv2DCCLayer only supports square strides, "
-                               "but strides=(%d, %d)" % strides)
+                               "but stride=(%d, %d)" % stride)
 
         if num_filters % 16 != 0:
             raise RuntimeError("Conv2DCCLayer requires num_filters to be a "
@@ -65,7 +65,7 @@ class Conv2DCCLayer(CCLayer):
 
         self.num_filters = num_filters
         self.filter_size = filter_size[0]
-        self.stride = strides[0]
+        self.stride = stride[0]
         self.untie_biases = untie_biases
         self.dimshuffle = dimshuffle
         self.flip_filters = flip_filters
@@ -198,7 +198,7 @@ class Conv2DCCLayer(CCLayer):
 
 
 class MaxPool2DCCLayer(CCLayer):
-    def __init__(self, incoming, ds, ignore_border=False, strides=None,
+    def __init__(self, incoming, ds, ignore_border=False, stride=None,
                  dimshuffle=True, **kwargs):
         from pylearn2.sandbox.cuda_convnet.pool import MaxPool
 
@@ -207,10 +207,10 @@ class MaxPool2DCCLayer(CCLayer):
             raise RuntimeError("MaxPool2DCCLayer only supports square pooling "
                                "regions, but ds=(%d, %d)" % ds)
 
-        if strides is not None and strides[0] != strides[1]:
+        if stride is not None and stride[0] != stride[1]:
             raise RuntimeError("MaxPool2DCCLayer only supports using the same "
                                "stride in both directions, but "
-                               "strides=(%d, %d)" % strides)
+                               "stride=(%d, %d)" % stride)
 
         # ignore_border argument is for compatibility with MaxPool2DLayer.
         # it is not supported. Borders are never ignored.
@@ -219,10 +219,10 @@ class MaxPool2DCCLayer(CCLayer):
                                "ignore_border.")
 
         self.ds = ds[0]
-        if strides is None:
+        if stride is None:
             self.stride = self.ds
         else:
-            self.stride = strides[0]
+            self.stride = stride[0]
         self.dimshuffle = dimshuffle
 
         self.pool_op = MaxPool(ds=self.ds, stride=self.stride)

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -206,6 +206,10 @@ class MaxPool2DCCLayer(CCLayer):
                  dimshuffle=True, **kwargs):
         from pylearn2.sandbox.cuda_convnet.pool import MaxPool
 
+        if 'pad' in kwargs:
+            raise NotImplementedError("MaxPool2DCCLayer does not "
+                                      "support padding")
+
         super(MaxPool2DCCLayer, self).__init__(incoming, **kwargs)
 
         pool_size = as_tuple(pool_size, 2)

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -25,32 +25,35 @@ class DNNLayer(Layer):
 
 class Pool2DDNNLayer(DNNLayer):
 
-    def __init__(self, incoming, pool_size, stride=None, mode='max', **kwargs):
-        if 'pad' in kwargs:
-            raise NotImplementedError("Pool2DDNNLayer does not "
-                                      "support padding")
+    def __init__(self, incoming, pool_size, stride=None, pad=(0, 0),
+                 mode='max', **kwargs):
         super(Pool2DDNNLayer, self).__init__(incoming, **kwargs)
         self.pool_size = as_tuple(pool_size, 2)
-        self.mode = mode
         self.stride = as_tuple(stride, 2) if stride is not None else pool_size
+        self.pad = as_tuple(pad, 2)
+        self.mode = mode
 
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)  # copy / convert to mutable list
         output_shape[2] = (
-            output_shape[2] - self.pool_size[0]) // self.stride[0] + 1
+            output_shape[2] + 2 * self.pad[0] - self.pool_size[0]
+            ) // self.stride[0] + 1
         output_shape[3] = (
-            output_shape[3] - self.pool_size[1]) // self.stride[1] + 1
+            output_shape[3] + 2 * self.pad[1] - self.pool_size[1]
+            ) // self.stride[1] + 1
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        return dnn.dnn_pool(input, self.pool_size, self.stride, self.mode)
+        return dnn.dnn_pool(input, self.pool_size, self.stride,
+                            self.mode, self.pad)
 
 
 class MaxPool2DDNNLayer(Pool2DDNNLayer):  # for consistency
 
-    def __init__(self, incoming, pool_size, stride=None, **kwargs):
+    def __init__(self, incoming, pool_size, stride=None,
+                 pad=(0, 0), **kwargs):
         super(MaxPool2DDNNLayer, self).__init__(incoming, pool_size, stride,
-                                                mode='max', **kwargs)
+                                                pad, mode='max', **kwargs)
 
 
 class Conv2DDNNLayer(DNNLayer):

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -24,30 +24,30 @@ class DNNLayer(Layer):
 
 
 class Pool2DDNNLayer(DNNLayer):
-    def __init__(self, incoming, ds, strides=None, mode='max', **kwargs):
+    def __init__(self, incoming, ds, stride=None, mode='max', **kwargs):
         super(Pool2DDNNLayer, self).__init__(incoming, **kwargs)
         self.ds = ds  # a tuple
         self.mode = mode
-        self.strides = strides if strides is not None else ds
+        self.stride = stride if stride is not None else ds
 
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)  # copy / convert to mutable list
-        output_shape[2] = (output_shape[2] - self.ds[0]) // self.strides[0] + 1
-        output_shape[3] = (output_shape[3] - self.ds[1]) // self.strides[1] + 1
+        output_shape[2] = (output_shape[2] - self.ds[0]) // self.stride[0] + 1
+        output_shape[3] = (output_shape[3] - self.ds[1]) // self.stride[1] + 1
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        return dnn.dnn_pool(input, self.ds, self.strides, self.mode)
+        return dnn.dnn_pool(input, self.ds, self.stride, self.mode)
 
 
 class MaxPool2DDNNLayer(Pool2DDNNLayer):  # for consistency
-    def __init__(self, incoming, ds, strides=None, **kwargs):
-        super(MaxPool2DDNNLayer, self).__init__(incoming, ds, strides,
+    def __init__(self, incoming, ds, stride=None, **kwargs):
+        super(MaxPool2DDNNLayer, self).__init__(incoming, ds, stride,
                                                 mode='max', **kwargs)
 
 
 class Conv2DDNNLayer(DNNLayer):
-    def __init__(self, incoming, num_filters, filter_size, strides=(1, 1),
+    def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
                  border_mode=None, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  pad=None, flip_filters=False, **kwargs):
@@ -59,9 +59,9 @@ class Conv2DDNNLayer(DNNLayer):
 
         self.num_filters = num_filters
         self.filter_size = filter_size
-        if isinstance(strides, int):
-            strides = (strides, strides)
-        self.strides = strides
+        if isinstance(stride, int):
+            stride = (stride, stride)
+        self.stride = stride
         self.untie_biases = untie_biases
         self.flip_filters = flip_filters
 
@@ -123,12 +123,12 @@ class Conv2DDNNLayer(DNNLayer):
 
         output_rows = conv_output_length(input_shape[2],
                                          self.filter_size[0],
-                                         self.strides[0],
+                                         self.stride[0],
                                          'pad', self.pad[0])
 
         output_columns = conv_output_length(input_shape[3],
                                             self.filter_size[1],
-                                            self.strides[1],
+                                            self.stride[1],
                                             'pad', self.pad[1])
 
         return (batch_size, self.num_filters, output_rows, output_columns)
@@ -143,7 +143,7 @@ class Conv2DDNNLayer(DNNLayer):
 
         conved = dnn.dnn_conv(img=input,
                               kerns=self.W,
-                              subsample=self.strides,
+                              subsample=self.stride,
                               border_mode=border_mode,
                               conv_mode=conv_mode
                               )

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -26,6 +26,9 @@ class DNNLayer(Layer):
 class Pool2DDNNLayer(DNNLayer):
 
     def __init__(self, incoming, pool_size, stride=None, mode='max', **kwargs):
+        if 'pad' in kwargs:
+            raise NotImplementedError("Pool2DDNNLayer does not "
+                                      "support padding")
         super(Pool2DDNNLayer, self).__init__(incoming, **kwargs)
         self.pool_size = as_tuple(pool_size, 2)
         self.mode = mode

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -106,19 +106,19 @@ class MaxPool1DLayer(Layer):
         always corresponds to some element in the unpadded input region.
         """
         super(MaxPool1DLayer, self).__init__(incoming, **kwargs)
-        self.pool_size = pool_size  # an integer
-        self.stride = pool_size if stride is None else stride
-        self.pad = pad
+        self.pool_size = as_tuple(pool_size, 1)
+        self.stride = self.pool_size if stride is None else as_tuple(stride, 1)
+        self.pad = as_tuple(pad, 1)
         self.ignore_border = ignore_border
 
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)  # copy / convert to mutable list
 
         output_shape[-1] = pool_output_length(input_shape[-1],
-                                              pool_size=self.pool_size,
-                                              stride=self.stride,
+                                              pool_size=self.pool_size[0],
+                                              stride=self.stride[0],
                                               ignore_border=self.ignore_border,
-                                              pad=self.pad,
+                                              pad=self.pad[0],
                                               )
 
         return tuple(output_shape)
@@ -127,10 +127,10 @@ class MaxPool1DLayer(Layer):
         input_4d = T.shape_padright(input, 1)
 
         pooled = downsample.max_pool_2d(input_4d,
-                                        ds=(self.pool_size, 1),
-                                        st=(self.stride, 1),
+                                        ds=(self.pool_size[0], 1),
+                                        st=(self.stride[0], 1),
                                         ignore_border=self.ignore_border,
-                                        padding=(self.pad, 0),
+                                        padding=(self.pad[0], 0),
                                         )
         return pooled[:, :, :, 0]
 

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -227,7 +227,7 @@ class FeaturePoolLayer(Layer):
     def __init__(self, incoming, pool_size, axis=1, pool_function=T.max,
                  **kwargs):
         """
-        Instrideantiates the layer.
+        Instantiates the layer.
 
         Parameters
         ----------

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -1,6 +1,7 @@
 import theano.tensor as T
 
 from .base import Layer
+from ..utils import as_tuple
 
 from theano.tensor.signal import downsample
 
@@ -171,32 +172,14 @@ class MaxPool2DLayer(Layer):
         """
         super(MaxPool2DLayer, self).__init__(incoming, **kwargs)
 
-        if (isinstance(pool_size, int)):
-            self.pool_size = (pool_size, pool_size)
-        else:
-            pool_size = tuple(pool_size)
-            if len(pool_size) != 2:
-                raise ValueError('pool_size must have len == 2')
-            self.pool_size = pool_size
+        self.pool_size = as_tuple(pool_size, 2)
 
         if stride is None:
             self.stride = self.pool_size
         else:
-            if (isinstance(stride, int)):
-                self.stride = (stride, stride)
-            else:
-                stride = tuple(stride)
-                if len(stride) != 2:
-                    raise ValueError('stride must have len == 2')
-                self.stride = stride
+            self.stride = as_tuple(stride, 2)
 
-        if (isinstance(pad, int)):
-            self.pad = (pad, pad)
-        else:
-            pad = tuple(pad)
-            if len(pad) != 2:
-                raise ValueError('pad must have len == 2')
-            self.pad = pad
+        self.pad = as_tuple(pad, 2)
 
         self.ignore_border = ignore_border
 

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -14,7 +14,8 @@ __all__ = [
 ]
 
 
-def pool_output_length(input_length, ds, st, ignore_border=True, pad=0):
+def pool_output_length(input_length, pool_size, stride,
+                       ignore_border=True, pad=0):
     """
     Compute the output length of a pooling operator
     along a single dimension.
@@ -23,9 +24,9 @@ def pool_output_length(input_length, ds, st, ignore_border=True, pad=0):
     ----------
     input_length : integer
         The length of the input in the pooling dimension
-    ds : integer
+    pool_size : integer
         The length of the pooling region
-    st : integer
+    stride : integer
         The stride between successive pooling regions
     pad : integer
         The number of elements to be added to the input on each side.
@@ -48,34 +49,36 @@ def pool_output_length(input_length, ds, st, ignore_border=True, pad=0):
     If `ignore_border == False`, a single partial pooling region is
     appended if at least one input element would be left uncovered otherwise.
     """
-    if input_length is None or ds is None:
+    if input_length is None or pool_size is None:
         return None
 
     if ignore_border:
-        output_length = input_length + 2 * pad - ds + 1
-        output_length = (output_length + st - 1) // st
+        output_length = input_length + 2 * pad - pool_size + 1
+        output_length = (output_length + stride - 1) // stride
 
     # output length calculation taken from:
     # https://github.com/Theano/Theano/blob/master/theano/tensor/signal/downsample.py
     else:
         assert pad == 0
 
-        if st >= ds:
-            output_length = (input_length + st - 1) // st
+        if stride >= pool_size:
+            output_length = (input_length + stride - 1) // stride
         else:
             output_length = max(
-                0, (input_length - ds + st - 1) // st) + 1
+                0, (input_length - pool_size + stride - 1) // stride) + 1
 
     return output_length
 
 
 class MaxPool1DLayer(Layer):
+
     """
     This layer performs max pooling over the final dimension
     of a 3D tensor.
     """
-    def __init__(self, incoming, ds, st=None, pad=0, ignore_border=False,
-                 **kwargs):
+
+    def __init__(self, incoming, pool_size, stride=None, pad=0,
+                 ignore_border=False, **kwargs):
         """
         Instantiates the layer.
 
@@ -83,14 +86,14 @@ class MaxPool1DLayer(Layer):
         ----------
         incoming : a :class:`Layer` instance or tuple
             The layer feeding into this layer, or the expected input shape.
-        ds : integer
+        pool_size : integer
             The length of the pooling region
-        st : integer or None
+        stride : integer or None
             The stride between sucessive pooling regions.
-            If None, st = ds.
+            If None, stride = pool_size.
         pad : integer
             The number of elements to be added to the input on each side.
-            Must be less than st.
+            Must be less than stride.
         ignore_border : bool
             If True, partial pooling regions will be ignored.
             Must be True if pad != 0.
@@ -102,8 +105,8 @@ class MaxPool1DLayer(Layer):
         always corresponds to some element in the unpadded input region.
         """
         super(MaxPool1DLayer, self).__init__(incoming, **kwargs)
-        self.ds = ds  # an integer
-        self.st = ds if st is None else st
+        self.pool_size = pool_size  # an integer
+        self.stride = pool_size if stride is None else stride
         self.pad = pad
         self.ignore_border = ignore_border
 
@@ -111,8 +114,8 @@ class MaxPool1DLayer(Layer):
         output_shape = list(input_shape)  # copy / convert to mutable list
 
         output_shape[-1] = pool_output_length(input_shape[-1],
-                                              ds=self.ds,
-                                              st=self.st,
+                                              pool_size=self.pool_size,
+                                              stride=self.stride,
                                               ignore_border=self.ignore_border,
                                               pad=self.pad,
                                               )
@@ -123,8 +126,8 @@ class MaxPool1DLayer(Layer):
         input_4d = T.shape_padright(input, 1)
 
         pooled = downsample.max_pool_2d(input_4d,
-                                        ds=(self.ds, 1),
-                                        st=(self.st, 1),
+                                        ds=(self.pool_size, 1),
+                                        st=(self.stride, 1),
                                         ignore_border=self.ignore_border,
                                         padding=(self.pad, 0),
                                         )
@@ -132,11 +135,13 @@ class MaxPool1DLayer(Layer):
 
 
 class MaxPool2DLayer(Layer):
+
     """
     This layer performs max pooling over the last two dimensions
     of a 4D tensor.
     """
-    def __init__(self, incoming, ds, st=None,
+
+    def __init__(self, incoming, pool_size, stride=None,
                  ignore_border=False, pad=(0, 0), **kwargs):
         """
         Instantiates the layer.
@@ -145,11 +150,11 @@ class MaxPool2DLayer(Layer):
         ----------
         incoming : a :class:`Layer` instance or tuple
             The layer feeding into this layer, or the expected input shape.
-        ds : integer or iterable
+        pool_size : integer or iterable
             The length of the pooling region in each dimension
-        st : integer, iterable or None
+        stride : integer, iterable or None
             The strides between sucessive pooling regions in each dimension.
-            If None, st = ds.
+            If None, stride = pool_size.
         pad : integer or iterable
             Number of elements to be added on each side of the input
             in each dimension. Each value must be less than
@@ -166,24 +171,24 @@ class MaxPool2DLayer(Layer):
         """
         super(MaxPool2DLayer, self).__init__(incoming, **kwargs)
 
-        if (isinstance(ds, int)):
-            self.ds = (ds, ds)
+        if (isinstance(pool_size, int)):
+            self.pool_size = (pool_size, pool_size)
         else:
-            ds = tuple(ds)
-            if len(ds) != 2:
-                raise ValueError('ds must have len == 2')
-            self.ds = ds
+            pool_size = tuple(pool_size)
+            if len(pool_size) != 2:
+                raise ValueError('pool_size must have len == 2')
+            self.pool_size = pool_size
 
-        if st is None:
-            self.st = self.ds
+        if stride is None:
+            self.stride = self.pool_size
         else:
-            if (isinstance(st, int)):
-                self.st = (st, st)
+            if (isinstance(stride, int)):
+                self.stride = (stride, stride)
             else:
-                st = tuple(st)
-                if len(st) != 2:
-                    raise ValueError('st must have len == 2')
-                self.st = st
+                stride = tuple(stride)
+                if len(stride) != 2:
+                    raise ValueError('stride must have len == 2')
+                self.stride = stride
 
         if (isinstance(pad, int)):
             self.pad = (pad, pad)
@@ -199,15 +204,15 @@ class MaxPool2DLayer(Layer):
         output_shape = list(input_shape)  # copy / convert to mutable list
 
         output_shape[2] = pool_output_length(input_shape[2],
-                                             ds=self.ds[0],
-                                             st=self.st[0],
+                                             pool_size=self.pool_size[0],
+                                             stride=self.stride[0],
                                              ignore_border=self.ignore_border,
                                              pad=self.pad[0],
                                              )
 
         output_shape[3] = pool_output_length(input_shape[3],
-                                             ds=self.ds[1],
-                                             st=self.st[1],
+                                             pool_size=self.pool_size[1],
+                                             stride=self.stride[1],
                                              ignore_border=self.ignore_border,
                                              pad=self.pad[1],
                                              )
@@ -216,8 +221,8 @@ class MaxPool2DLayer(Layer):
 
     def get_output_for(self, input, **kwargs):
         pooled = downsample.max_pool_2d(input,
-                                        ds=self.ds,
-                                        st=self.st,
+                                        ds=self.pool_size,
+                                        st=self.stride,
                                         ignore_border=self.ignore_border,
                                         padding=self.pad,
                                         )
@@ -236,38 +241,45 @@ class FeaturePoolLayer(Layer):
     a multiple of the pool size.
     """
 
-    def __init__(self, incoming, ds, axis=1, pool_function=T.max, **kwargs):
+    def __init__(self, incoming, pool_size, axis=1, pool_function=T.max,
+                 **kwargs):
         """
-        ds: the number of feature maps to be pooled together
-        axis: the axis along which to pool. The default value of 1 works
-        for DenseLayer and Conv*DLayers
-        pool_function: the pooling function to use
+        Instrideantiates the layer.
+
+        Parameters
+        ----------
+        pool_size : integer
+            the number of feature maps to be pooled together
+        axis : integer
+            the axis along which to pool. The default value of 1 works
+            for DenseLayer and Conv*DLayers
+        pool_function : the pooling function to use
         """
         super(FeaturePoolLayer, self).__init__(incoming, **kwargs)
-        self.ds = ds
+        self.pool_size = pool_size
         self.axis = axis
         self.pool_function = pool_function
 
         num_feature_maps = self.input_shape[self.axis]
-        if num_feature_maps % self.ds != 0:
+        if num_feature_maps % self.pool_size != 0:
             raise RuntimeError("Number of input feature maps (%d) is not a "
-                               "multiple of the pool size (ds=%d)" %
-                               (num_feature_maps, self.ds))
+                               "multiple of the pool size (pool_size=%d)" %
+                               (num_feature_maps, self.pool_size))
 
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)  # make a mutable copy
         output_shape[self.axis] = pool_output_length(input_shape[self.axis],
-                                                     self.ds)
+                                                     self.pool_size)
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
         num_feature_maps = input.shape[self.axis]
-        num_feature_maps_out = num_feature_maps // self.ds
+        num_feature_maps_out = num_feature_maps // self.pool_size
 
         pool_shape = ()
         for k in range(self.axis):
             pool_shape += (input.shape[k],)
-        pool_shape += (num_feature_maps_out, self.ds)
+        pool_shape += (num_feature_maps_out, self.pool_size)
         for k in range(self.axis + 1, input.ndim):
             pool_shape += (input.shape[k],)
 
@@ -284,26 +296,30 @@ class FeatureWTALayer(Layer):
     a multiple of the pool size.
     """
 
-    def __init__(self, incoming, ds, axis=1, **kwargs):
+    def __init__(self, incoming, pool_size, axis=1, **kwargs):
         """
-        ds: the number of feature maps per group. This is called 'ds'
-        for consistency with the pooling layers, even though this
-        layer does not actually perform a downsampling operation.
-        axis: the axis along which the groups are formed.
+        Instantiates the layer.
+
+        Parameters
+        ----------
+        pool_size : integer
+            the number of feature maps per group.
+        axis : integer
+            the axis along which the groups are formed.
         """
         super(FeatureWTALayer, self).__init__(incoming, **kwargs)
-        self.ds = ds
+        self.pool_size = pool_size
         self.axis = axis
 
         num_feature_maps = self.input_shape[self.axis]
-        if num_feature_maps % self.ds != 0:
+        if num_feature_maps % self.pool_size != 0:
             raise RuntimeError("Number of input feature maps (%d) is not a "
-                               "multiple of the group size (ds=%d)" %
-                               (num_feature_maps, self.ds))
+                               "multiple of the group size (pool_size=%d)" %
+                               (num_feature_maps, self.pool_size))
 
     def get_output_for(self, input, **kwargs):
         num_feature_maps = input.shape[self.axis]
-        num_pools = num_feature_maps // self.ds
+        num_pools = num_feature_maps // self.pool_size
 
         pool_shape = ()
         arange_shuffle_pattern = ()
@@ -311,7 +327,7 @@ class FeatureWTALayer(Layer):
             pool_shape += (input.shape[k],)
             arange_shuffle_pattern += ('x',)
 
-        pool_shape += (num_pools, self.ds)
+        pool_shape += (num_pools, self.pool_size)
         arange_shuffle_pattern += ('x', 0)
 
         for k in range(self.axis + 1, input.ndim):
@@ -322,7 +338,7 @@ class FeatureWTALayer(Layer):
         max_indices = T.argmax(input_reshaped, axis=self.axis + 1,
                                keepdims=True)
 
-        arange = T.arange(self.ds).dimshuffle(*arange_shuffle_pattern)
+        arange = T.arange(self.pool_size).dimshuffle(*arange_shuffle_pattern)
         mask = T.eq(max_indices, arange).reshape(input.shape)
 
         return input * mask

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -59,7 +59,8 @@ def conv1d_test_sets():
             for b in input:
                 temp = []
                 for c in kernel:
-                    temp.append(np.convolve(b[0,:], c[0,:], mode=border_mode))
+                    temp.append(
+                        np.convolve(b[0, :], c[0, :], mode=border_mode))
                 output.append(temp)
             output = np.array(output)
             output = output[:, :, ::stride]
@@ -68,24 +69,24 @@ def conv1d_test_sets():
                                                    })
 
 
-
 @pytest.fixture
 def DummyInputLayer():
     def factory(get_output_shape):
         return Mock(
             get_output_shape=lambda: get_output_shape,
             get_output=lambda input: input,
-            )
+        )
     return factory
 
 
 class TestConv1DLayer:
+
     @pytest.mark.parametrize(
         "input, kernel, output, kwargs", list(conv1d_test_sets()))
     @pytest.mark.parametrize("extra_kwargs", [
         {},
         {'untie_biases': True},
-        ])
+    ])
     def test_defaults(self, DummyInputLayer,
                       input, kernel, output, kwargs, extra_kwargs):
         kwargs.update(extra_kwargs)
@@ -99,7 +100,7 @@ class TestConv1DLayer:
                 filter_size=kernel.shape[2],
                 W=kernel,
                 **kwargs
-                )
+            )
             actual = layer.get_output(input).eval()
             assert actual.shape == output.shape
             assert actual.shape == layer.get_output_shape()
@@ -110,6 +111,7 @@ class TestConv1DLayer:
 
 
 class TestConv2DLayerImplementations:
+
     @pytest.fixture(
         params=[
             ('lasagne.layers', 'Conv2DLayer', {}),
@@ -118,8 +120,8 @@ class TestConv2DLayerImplementations:
              {'flip_filters': True}),
             ('lasagne.layers.corrmm', 'Conv2DMMLayer', {'flip_filters': True}),
             ('lasagne.layers.dnn', 'Conv2DDNNLayer', {'flip_filters': True}),
-            ],
-        )
+        ],
+    )
     def Conv2DImpl(self, request):
         impl_module_name, impl_name, impl_default_kwargs = request.param
         try:
@@ -142,7 +144,7 @@ class TestConv2DLayerImplementations:
     @pytest.mark.parametrize("extra_kwargs", [
         {},
         {'untie_biases': True},
-        ])
+    ])
     def test_defaults(self, Conv2DImpl, DummyInputLayer,
                       input, kernel, output, kwargs, extra_kwargs):
         kwargs.update(extra_kwargs)
@@ -155,7 +157,7 @@ class TestConv2DLayerImplementations:
                 filter_size=kernel.shape[2:],
                 W=kernel,
                 **kwargs
-                )
+            )
             actual = layer.get_output(input).eval()
             assert actual.shape == output.shape
             assert actual.shape == layer.get_output_shape()
@@ -177,7 +179,7 @@ class TestConv2DLayerImplementations:
                 filter_size=kernel.shape[2:],
                 W=kernel,
                 **kwargs
-                )
+            )
             actual = layer.get_output(input).eval()
 
             assert layer.get_output_shape() == (None,

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -28,7 +28,7 @@ def conv2d_test_sets():
                                 shift_y:input.shape[3] + shift_y]
             output = output[:, :, ::stride, ::stride]
             yield _convert(input, kernel, output, {'border_mode': border_mode,
-                                                   'strides': (stride, stride)
+                                                   'stride': (stride, stride)
                                                    })
 
             input = np.random.random((3, 3, 16, 23))
@@ -43,7 +43,7 @@ def conv2d_test_sets():
                                 shift_y:input.shape[3] + shift_y]
             output = output[:, :, ::stride, ::stride]
             yield _convert(input, kernel, output, {'border_mode': border_mode,
-                                                   'strides': (stride, stride)
+                                                   'stride': (stride, stride)
                                                    })
 
 

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -4,8 +4,8 @@ import pytest
 import theano
 
 
-def max_pool_1d(data, ds, st=None):
-    st = ds if st is None else st
+def max_pool_1d(data, pool_size, stride=None):
+    stride = pool_size if stride is None else stride
 
     idx = range(data.shape[-1])
     used_idx = set([])
@@ -13,12 +13,12 @@ def max_pool_1d(data, ds, st=None):
 
     i = 0
     while i < data.shape[-1]:
-        idx_set = set(range(i, i + ds))
+        idx_set = set(range(i, i + pool_size))
         idx_set = idx_set.intersection(idx)
         if not idx_set.issubset(used_idx):
             idx_sets.append(list(idx_set))
             used_idx = used_idx.union(idx_set)
-        i += st
+        i += stride
 
     data_pooled = np.array(
         [data[..., idx_set].max(axis=-1) for idx_set in idx_sets])
@@ -27,56 +27,58 @@ def max_pool_1d(data, ds, st=None):
     return data_pooled
 
 
-def max_pool_1d_ignoreborder(data, ds, st=None, pad=0):
-    st = ds if st is None else st
+def max_pool_1d_ignoreborder(data, pool_size, stride=None, pad=0):
+    stride = pool_size if stride is None else stride
 
     pads = [(0, 0), ] * len(data.shape)
     pads[-1] = (pad, pad)
     data = np.pad(data, pads, mode='constant', constant_values=(-np.inf,))
 
-    data_shifted = np.zeros((ds,) + data.shape)
-    data_shifted = data_shifted[..., :data.shape[-1] - ds + 1]
-    for i in range(ds):
-        data_shifted[i] = data[..., i:i + data.shape[-1] - ds + 1]
+    data_shifted = np.zeros((pool_size,) + data.shape)
+    data_shifted = data_shifted[..., :data.shape[-1] - pool_size + 1]
+    for i in range(pool_size):
+        data_shifted[i] = data[..., i:i + data.shape[-1] - pool_size + 1]
     data_pooled = data_shifted.max(axis=0)
 
-    if st:
-        data_pooled = data_pooled[..., ::st]
+    if stride:
+        data_pooled = data_pooled[..., ::stride]
 
     return data_pooled
 
 
-def max_pool_2d(data, ds, st):
-    data_pooled = max_pool_1d(data, ds[1], st[1])
+def max_pool_2d(data, pool_size, stride):
+    data_pooled = max_pool_1d(data, pool_size[1], stride[1])
 
     data_pooled = np.swapaxes(data_pooled, -1, -2)
-    data_pooled = max_pool_1d(data_pooled, ds[0], st[0])
+    data_pooled = max_pool_1d(data_pooled, pool_size[0], stride[0])
     data_pooled = np.swapaxes(data_pooled, -1, -2)
 
     return data_pooled
 
 
-def max_pool_2d_ignoreborder(data, ds, st, pad):
-    data_pooled = max_pool_1d_ignoreborder(data, ds[1], st[1], pad[1])
+def max_pool_2d_ignoreborder(data, pool_size, stride, pad):
+    data_pooled = max_pool_1d_ignoreborder(
+        data, pool_size[1], stride[1], pad[1])
 
     data_pooled = np.swapaxes(data_pooled, -1, -2)
-    data_pooled = max_pool_1d_ignoreborder(data_pooled, ds[0], st[0], pad[0])
+    data_pooled = max_pool_1d_ignoreborder(
+        data_pooled, pool_size[0], stride[0], pad[0])
     data_pooled = np.swapaxes(data_pooled, -1, -2)
 
     return data_pooled
 
 
 def pool_test_sets():
-    for ds in [2, 3]:
-        for st in [1, 2, 3, 4]:
-            yield (ds, st)
+    for pool_size in [2, 3]:
+        for stride in [1, 2, 3, 4]:
+            yield (pool_size, stride)
 
 
 def pool_test_sets_ignoreborder():
-    for ds in [2, 3]:
-        for st in [1, 2, 3, 4]:
-            for pad in range(ds):
-                yield (ds, st, pad)
+    for pool_size in [2, 3]:
+        for stride in [1, 2, 3, 4]:
+            for pad in range(pool_size):
+                yield (pool_size, stride, pad)
 
 
 class TestMaxPool1DLayer:
@@ -84,48 +86,48 @@ class TestMaxPool1DLayer:
     def input_layer(self, output_shape):
         return Mock(get_output_shape=lambda: output_shape)
 
-    def layer(self, input_layer, ds, st=None, pad=0):
+    def layer(self, input_layer, pool_size, stride=None, pad=0):
         from lasagne.layers.pool import MaxPool1DLayer
         return MaxPool1DLayer(
             input_layer,
-            ds=ds,
-            st=st,
+            pool_size=pool_size,
+            stride=stride,
             ignore_border=False,
         )
 
-    def layer_ignoreborder(self, input_layer, ds, st=None, pad=0):
+    def layer_ignoreborder(self, input_layer, pool_size, stride=None, pad=0):
         from lasagne.layers.pool import MaxPool1DLayer
         return MaxPool1DLayer(
             input_layer,
-            ds=ds,
-            st=st,
+            pool_size=pool_size,
+            stride=stride,
             pad=pad,
             ignore_border=True,
         )
 
     @pytest.mark.parametrize(
-        "ds, st", list(pool_test_sets()))
-    def test_get_output_for(self, ds, st):
+        "pool_size, stride", list(pool_test_sets()))
+    def test_get_output_for(self, pool_size, stride):
         input = np.random.randn(8, 16, 23)
         input_layer = self.input_layer(input.shape)
         input_theano = theano.shared(input)
         layer_output = self.layer(
-            input_layer, ds, st).get_output_for(input_theano)
+            input_layer, pool_size, stride).get_output_for(input_theano)
         layer_result = layer_output.eval()
-        numpy_result = max_pool_1d(input, ds, st)
+        numpy_result = max_pool_1d(input, pool_size, stride)
         assert np.all(numpy_result.shape == layer_result.shape)
         assert np.allclose(numpy_result, layer_result)
 
     @pytest.mark.parametrize(
-        "ds, st, pad", list(pool_test_sets_ignoreborder()))
-    def test_get_output_for_ignoreborder(self, ds, st, pad):
+        "pool_size, stride, pad", list(pool_test_sets_ignoreborder()))
+    def test_get_output_for_ignoreborder(self, pool_size, stride, pad):
         input = np.random.randn(8, 16, 23)
         input_layer = self.input_layer(input.shape)
         input_theano = theano.shared(input)
         layer_output = self.layer_ignoreborder(
-            input_layer, ds, st, pad).get_output_for(input_theano)
+            input_layer, pool_size, stride, pad).get_output_for(input_theano)
         layer_result = layer_output.eval()
-        numpy_result = max_pool_1d_ignoreborder(input, ds, st, pad)
+        numpy_result = max_pool_1d_ignoreborder(input, pool_size, stride, pad)
         assert np.all(numpy_result.shape == layer_result.shape)
         assert np.allclose(numpy_result, layer_result)
 
@@ -133,7 +135,7 @@ class TestMaxPool1DLayer:
         "input_shape", [(32, 64, 128), (None, 64, 128), (32, None, 128)])
     def test_get_output_shape_for(self, input_shape):
         input_layer = self.input_layer(input_shape)
-        layer = self.layer_ignoreborder(input_layer, ds=2)
+        layer = self.layer_ignoreborder(input_layer, pool_size=2)
         assert layer.get_output_shape_for((None, 64, 128)) == (None, 64, 64)
         assert layer.get_output_shape_for((32, 64, 128)) == (32, 64, 64)
 
@@ -143,61 +145,63 @@ class TestMaxPool2DLayer:
     def input_layer(self, output_shape):
         return Mock(get_output_shape=lambda: output_shape)
 
-    def layer(self, input_layer, ds, st=None):
+    def layer(self, input_layer, pool_size, stride=None):
         from lasagne.layers.pool import MaxPool2DLayer
         return MaxPool2DLayer(
             input_layer,
-            ds=ds,
-            st=st,
+            pool_size=pool_size,
+            stride=stride,
             ignore_border=False,
         )
 
-    def layer_ignoreborder(self, input_layer, ds, st=None, pad=(0, 0)):
+    def layer_ignoreborder(self, input_layer, pool_size,
+                           stride=None, pad=(0, 0)):
         from lasagne.layers.pool import MaxPool2DLayer
         return MaxPool2DLayer(
             input_layer,
-            ds=ds,
-            st=st,
+            pool_size=pool_size,
+            stride=stride,
             pad=pad,
             ignore_border=True,
         )
 
     @pytest.mark.parametrize(
-        "ds, st", list(pool_test_sets()))
-    def test_get_output_for(self, ds, st):
+        "pool_size, stride", list(pool_test_sets()))
+    def test_get_output_for(self, pool_size, stride):
         input = np.random.randn(8, 16, 17, 13)
         input_layer = self.input_layer(input.shape)
         input_theano = theano.shared(input)
         result = self.layer(
             input_layer,
-            (ds, ds),
-            (st, st),
+            (pool_size, pool_size),
+            (stride, stride),
         ).get_output_for(input_theano)
 
         result_eval = result.eval()
 
-        numpy_result = max_pool_2d(input, (ds, ds), (st, st))
+        numpy_result = max_pool_2d(
+            input, (pool_size, pool_size), (stride, stride))
 
         assert np.all(numpy_result.shape == result_eval.shape)
         assert np.allclose(result_eval, numpy_result)
 
     @pytest.mark.parametrize(
-        "ds, st, pad", list(pool_test_sets_ignoreborder()))
-    def test_get_output_for_ignoreborder(self, ds, st, pad):
+        "pool_size, stride, pad", list(pool_test_sets_ignoreborder()))
+    def test_get_output_for_ignoreborder(self, pool_size, stride, pad):
         input = np.random.randn(8, 16, 17, 13)
         input_layer = self.input_layer(input.shape)
         input_theano = theano.shared(input)
 
         result = self.layer_ignoreborder(
             input_layer,
-            ds,
-            st,
+            pool_size,
+            stride,
             pad,
         ).get_output_for(input_theano)
 
         result_eval = result.eval()
         numpy_result = max_pool_2d_ignoreborder(
-            input, (ds, ds), (st, st), (pad, pad))
+            input, (pool_size, pool_size), (stride, stride), (pad, pad))
 
         assert np.all(numpy_result.shape == result_eval.shape)
         assert np.allclose(result_eval, numpy_result)
@@ -208,7 +212,7 @@ class TestMaxPool2DLayer:
     )
     def test_get_output_shape_for(self, input_shape):
         input_layer = self.input_layer(input_shape)
-        layer = self.layer_ignoreborder(input_layer, ds=(2, 2))
+        layer = self.layer_ignoreborder(input_layer, pool_size=(2, 2))
         assert layer.get_output_shape_for(
             (None, 64, 24, 24)) == (None, 64, 12, 12)
         assert layer.get_output_shape_for(

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -75,6 +75,11 @@ def as_tuple(x, N):
     x : value or iterable
     N : integer
         length of the desired tuple
+
+    Returns:
+    --------
+    tuple
+        ``tuple(x)`` if `x` is iterable, ``(x,) * N`` otherwise.
     """
     try:
         X = tuple(x)

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -66,6 +66,28 @@ def unique(l):
     return new_list
 
 
+def as_tuple(x, N):
+    """
+    Coerce a value to a tuple of length N.
+
+    Parameters:
+    -----------
+    x : value or iterable
+    N : integer
+        length of the desired tuple
+    """
+    try:
+        X = tuple(x)
+    except TypeError:
+        X = (x,) * N
+
+    if len(X) != N:
+        raise ValueError("input must be a single value "
+                         "or an iterable with length {0}".format(N))
+
+    return X
+
+
 def compute_norms(array, norm_axes=None):
     """
     Compute incoming weight vector norms.


### PR DESCRIPTION
This is to close #207 

I've made changes to use `filter_size`, `pool_size` and `stride` throughout all conv and pooling layers. 

Added a helper function `as_tuple` in `utils.py` which takes an input and a length and returns a tuple of that length, and use it in the 2D layers to accept either a number or tuple for `pool_size` and `stride`. 

I also added some tests for the cuda_convnet and dnn pooling layers, and updated the examples to use `pool_size`.