### PR TITLE
Featurepool

### DIFF
--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -256,15 +256,13 @@ class FeaturePoolLayer(Layer):
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        num_feature_maps = input.shape[self.axis]
+        input_shape = tuple(input.shape)
+        num_feature_maps = input_shape[self.axis]
         num_feature_maps_out = num_feature_maps // self.pool_size
 
-        pool_shape = ()
-        for axis, length in enumerate(input.shape):
-            if axis == self.axis:
-                pool_shape += (num_feature_maps_out, self.pool_size)
-            else:
-                pool_shape += (length,)
+        pool_shape = (input_shape[:self.axis] +
+                      (num_feature_maps_out, self.pool_size) +
+                      input_shape[self.axis+1:])
 
         input_reshaped = input.reshape(pool_shape)
         return self.pool_function(input_reshaped, axis=self.axis + 1)

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -70,6 +70,36 @@ def max_pool_2d_ignoreborder(data, pool_size, stride, pad):
     return data_pooled
 
 
+class TestFeaturePoolLayer:
+    def input_layer(self, output_shape):
+        return Mock(get_output_shape=lambda: output_shape)
+
+    def layer(self, input_layer, pool_size):
+        from lasagne.layers.pool import FeaturePoolLayer
+        return FeaturePoolLayer(
+            input_layer,
+            pool_size=pool_size,
+        )
+
+    @pytest.mark.parametrize(
+        "pool_size", [2, 3, 4])
+    def test_layer(self, pool_size):
+        input = floatX(np.random.randn(3, 12, 16, 23))
+        input_layer = self.input_layer(input.shape)
+        input_theano = theano.shared(input)
+
+        layer = self.layer(input_layer, pool_size)
+        layer_result = layer.get_output_for(input_theano).eval()
+
+        numpy_result = np.swapaxes(input, 1, -1)
+        numpy_result = max_pool_1d(numpy_result, pool_size)
+        numpy_result = np.swapaxes(numpy_result, -1, 1)
+
+        assert np.all(numpy_result.shape == layer.get_output_shape())
+        assert np.all(numpy_result.shape == layer_result.shape)
+        assert np.allclose(numpy_result, layer_result)
+
+
 class TestMaxPool1DLayer:
     def pool_test_sets():
         for pool_size in [2, 3]:


### PR DESCRIPTION
This is to close https://github.com/Lasagne/Lasagne/issues/208

I decided to simply remove the call to pool_output_length instead of changing its defaults because
- I'd prefer that function to require explicit parameters (and I removed the defaults that were there), since that avoids duplicating code for default handling and may help expose any bugs in layers calling it.

- Since `FeaturePoolLayer` doesn't use any of the more complicated parameters (and it doesn't seem like it will in the future) there's no real need for the helper function.

- The simple division is a bit easier to understand if you're just reading the code and aren't familiar with the helper function.

I also added a test for this layer, and rewrote some of the docstring and `get_output_for` to be a bit cleaner (in my opinion). 