### PR TITLE
Mock theano.config so GPU-dependent modules show up on readhtedocs.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -275,4 +275,7 @@ except ImportError:
     from mock import Mock
 
 import theano
+import theano.sandbox.cuda
+
 theano.config = Mock(device='gpu')
+theano.sandbox.cuda.dnn = Mock(dnn_available=lambda: True)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,3 +266,13 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
+
+
+# fool rtd into thinking a GPU is available, so all modules are importable
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
+import theano
+theano.config = Mock(device='gpu')

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ Jinja2==2.7.3
 Sphinx==1.2.3
 sphinx-bootstrap-theme
 numpydoc
-
+mock


### PR DESCRIPTION
I have no way to test this, I think... unless readthedocs.org can build docs off a branch as a test, I'll look into that (but I doubt it). Suggestions to maximize the chance of this working are very welcome :)