### PR TITLE
Make lasagne.layers.corrmm / dnn / cuda_convnet docs show up on readthedocs.org, attempt 2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -279,3 +279,10 @@ import theano.sandbox.cuda
 
 theano.config = Mock(device='gpu')
 theano.sandbox.cuda.dnn = Mock(dnn_available=lambda: True)
+
+import sys
+
+sys.modules['pylearn2.sandbox.cuda_convnet.filter_acts'] = \
+    Mock(FilterActs=None)
+
+sys.modules['theano.sandbox.cuda.blas'] = Mock(GpuCorrMM=None)


### PR DESCRIPTION
This is a second attempt to make the docs for the alternative convolutional layer implementations show up on readthedocs.org.

~~I 'fixed' the issue by moving the imports of `GpuCorrMM` (corrmm) and `FilterActs` (cuda_convnet) into the methods were they are used. This allows readthedocs.org to import the modules and grab the docstrings.~~

~~The downside of this fix is that `lasagne.layers.cuda_convnet` will now no longer fail at import time if pylearn2 is not available. That's not good. I don't know how else to fix it though, and having the docs show up seems a bit more important. If someone can come up with a good work-around, let me know.~~

(See #223 for the previous attempt - it didn't work but I think it was a necessary step.)

EDIT: I changed the approach to avoid having to import these modules at runtime, based on @dnouri's suggestion in #223. This avoids the problem with the other approach, hopefully it works correctly on readthedocs.org as well.