### PR TITLE
added NonlinearityOnlyLayer for use with MultipleInputLayer

### DIFF
--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -10,7 +10,7 @@ from .base import Layer
 __all__ = [
     "DenseLayer",
     "NINLayer",
-    "NonlinearityOnlyLayer"
+    "NonlinearityLayer"
 ]
 
 
@@ -19,7 +19,7 @@ class DenseLayer(Layer):
     A fully connected layer.
 
     :parameters:
-        - input_layer : `Layer` instance
+        - incoming : `Layer` instance
             The layer from which this layer will obtain its input
 
         - num_units : int
@@ -88,19 +88,11 @@ class DenseLayer(Layer):
         return self.nonlinearity(activation)
 
 
-class NonlinearityOnlyLayer(Layer):
+class NonlinearityLayer(Layer):
     """
-    A layer that just performs a nonlinearity.
-    This is for use in conjunction with MultipleInputsLayer subclasses,
-    which just add or concatenate outputs from layers.  For example, one
-    might want to take inputs of length n and m, perform linear transformations
-    on them using DenseLayer objects, then add the transformed outputs with an
-    ElemwiseSumLayer, and then use this class to apply a nonlinearity
-    (note that this would be different from applying the nonlinearity and
-    then adding).  Alternatively, one could use a ConcatLayer followed by
-    a DenseLayer, but concatenation is less efficient than adding.
+    A layer that just applies a nonlinearity.
 
-    - input_layer : `Layer` instance
+    - incoming : `Layer` instance
         The layer from which this layer will obtain its input
 
     - nonlinearity : callable or None
@@ -109,7 +101,7 @@ class NonlinearityOnlyLayer(Layer):
     """
     def __init__(self, incoming, nonlinearity=nonlinearities.rectify,
                  **kwargs):
-        super(NonlinearityOnlyLayer, self).__init__(incoming, **kwargs)
+        super(NonlinearityLayer, self).__init__(incoming, **kwargs)
         self.nonlinearity = (nonlinearities.identity if nonlinearity is None
                              else nonlinearity)
 

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -19,8 +19,8 @@ class DenseLayer(Layer):
     A fully connected layer.
 
     :parameters:
-        - incoming : `Layer` instance
-            The layer from which this layer will obtain its input
+        - incoming : a :class:`Layer` instance or a tuple
+            the layer feeding into this layer, or the expected input shape
 
         - num_units : int
             The number of units of the layer
@@ -92,8 +92,8 @@ class NonlinearityLayer(Layer):
     """
     A layer that just applies a nonlinearity.
 
-    - incoming : `Layer` instance
-        The layer from which this layer will obtain its input
+    - incoming : a :class:`Layer` instance or a tuple
+        the layer feeding into this layer, or the expected input shape
 
     - nonlinearity : callable or None
         The nonlinearity that is applied to the layer activations. If None

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -10,6 +10,7 @@ from .base import Layer
 __all__ = [
     "DenseLayer",
     "NINLayer",
+    "NonlinearityOnlyLayer"
 ]
 
 
@@ -55,10 +56,8 @@ class DenseLayer(Layer):
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  **kwargs):
         super(DenseLayer, self).__init__(incoming, **kwargs)
-        if nonlinearity is None:
-            self.nonlinearity = nonlinearities.identity
-        else:
-            self.nonlinearity = nonlinearity
+        self.nonlinearity = (nonlinearities.identity if nonlinearity is None
+                             else nonlinearity)
 
         self.num_units = num_units
 
@@ -89,6 +88,35 @@ class DenseLayer(Layer):
         return self.nonlinearity(activation)
 
 
+class NonlinearityOnlyLayer(Layer):
+    """
+    A layer that just performs a nonlinearity.
+    This is for use in conjunction with MultipleInputsLayer subclasses,
+    which just add or concatenate outputs from layers.  For example, one
+    might want to take inputs of length n and m, perform linear transformations
+    on them using DenseLayer objects, then add the transformed outputs with an
+    ElemwiseSumLayer, and then use this class to apply a nonlinearity
+    (note that this would be different from applying the nonlinearity and
+    then adding).  Alternatively, one could use a ConcatLayer followed by
+    a DenseLayer, but concatenation is less efficient than adding.
+
+    - input_layer : `Layer` instance
+        The layer from which this layer will obtain its input
+
+    - nonlinearity : callable or None
+        The nonlinearity that is applied to the layer activations. If None
+        is provided, the layer will be linear.
+    """
+    def __init__(self, incoming, nonlinearity=nonlinearities.rectify,
+                 **kwargs):
+        super(NonlinearityOnlyLayer, self).__init__(incoming, **kwargs)
+        self.nonlinearity = (nonlinearities.identity if nonlinearity is None
+                             else nonlinearity)
+
+    def get_output_for(self, input, **kwargs):
+        return self.nonlinearity(input)
+
+
 class NINLayer(Layer):
     """
     Network-in-network layer.
@@ -101,10 +129,8 @@ class NINLayer(Layer):
                  W=init.GlorotUniform(), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify, **kwargs):
         super(NINLayer, self).__init__(incoming, **kwargs)
-        if nonlinearity is None:
-            self.nonlinearity = nonlinearities.identity
-        else:
-            self.nonlinearity = nonlinearity
+        self.nonlinearity = (nonlinearities.identity if nonlinearity is None
+                             else nonlinearity)
 
         self.num_units = num_units
         self.untie_biases = untie_biases


### PR DESCRIPTION
This adds a layer class that just performs a nonlinearity.
This is for use in conjunction with MultipleInputsLayer subclasses, which just add or concatenate outputs from layers.  For example, one might want to take inputs of length n and m, perform linear transformations on them using DenseLayer objects, then add the transformed outputs with an ElemwiseSumLayer, and then use this class to apply a nonlinearity (note that this would be different from applying the nonlinearity and then adding).  Alternatively, one could use a ConcatLayer followed by a DenseLayer, but concatenation is less efficient than adding.