### PR TITLE
Handle scalars in count_params

### DIFF
--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -251,7 +251,7 @@ def count_params(layer):
     """
     params = get_all_params(layer)
     shapes = [p.get_value().shape for p in params]
-    counts = [np.prod(shape) for shape in shapes]
+    counts = [np.prod(shape) if shape != () else 1 for shape in shapes]
     return sum(counts)
 
 


### PR DESCRIPTION
Simply returns 1 for '()' shapes.