### PR TITLE
rename MultipleInputsLayer to MergeLayer

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -22,7 +22,7 @@ Layer base classes
 .. autoclass:: Layer
    :members:
 
-.. autoclass:: MultipleInputsLayer
+.. autoclass:: MergeLayer
     :members:
 
 Layer classes: network input

--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -7,7 +7,7 @@ from .. import utils
 
 __all__ = [
     "Layer",
-    "MultipleInputsLayer",
+    "MergeLayer",
 ]
 
 
@@ -217,7 +217,7 @@ class Layer(object):
                                "callable")
 
 
-class MultipleInputsLayer(Layer):
+class MergeLayer(Layer):
     """
     This class represents a layer that aggregates input from multiple layers.
     It should be subclassed when implementing new types of layers that
@@ -282,7 +282,7 @@ class MultipleInputsLayer(Layer):
                 the output of this layer given the inputs to this layer
 
         :note:
-            This is called by the base :class:`MultipleInputsLayer`
+            This is called by the base :class:`MergeLayer`
             implementation to propagate data through a network in
             `get_output()`. While `get_output()` asks the underlying layers
             for input and thus returns an expression for a layer's output in

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -179,7 +179,7 @@ def get_output(layer_or_layers, inputs=None, **kwargs):
         both, while the latter will use two different dropout masks.
     """
     from .input import InputLayer
-    from .base import MultipleInputsLayer
+    from .base import MergeLayer
     # obtain topological ordering of all layers the output layer(s) depend on
     treat_as_input = inputs.keys() if isinstance(inputs, dict) else []
     all_layers = get_all_layers(layer_or_layers, treat_as_input)
@@ -204,7 +204,7 @@ def get_output(layer_or_layers, inputs=None, **kwargs):
     for layer in all_layers:
         if layer not in all_outputs:
             try:
-                if isinstance(layer, MultipleInputsLayer):
+                if isinstance(layer, MergeLayer):
                     layer_inputs = [all_outputs[input_layer]
                                     for input_layer in layer.input_layers]
                 else:
@@ -255,7 +255,7 @@ def get_output_shape(layer_or_layers, input_shapes=None):
             return layer_or_layers.output_shape
 
     from .input import InputLayer
-    from .base import MultipleInputsLayer
+    from .base import MergeLayer
     # obtain topological ordering of all layers the output layer(s) depend on
     if isinstance(input_shapes, dict):
         treat_as_input = input_shapes.keys()
@@ -283,7 +283,7 @@ def get_output_shape(layer_or_layers, input_shapes=None):
     for layer in all_layers:
         if layer not in all_shapes:
             try:
-                if isinstance(layer, MultipleInputsLayer):
+                if isinstance(layer, MergeLayer):
                     input_shapes = [all_shapes[input_layer]
                                     for input_layer in layer.input_layers]
                 else:

--- a/lasagne/layers/merge.py
+++ b/lasagne/layers/merge.py
@@ -1,6 +1,6 @@
 import theano.tensor as T
 
-from .base import MultipleInputsLayer
+from .base import MergeLayer
 
 
 __all__ = [
@@ -10,7 +10,7 @@ __all__ = [
 ]
 
 
-class ConcatLayer(MultipleInputsLayer):
+class ConcatLayer(MergeLayer):
     """
     Concatenates multiple inputs along the specified axis. Inputs should have
     the same shape except for the dimension specified in axis, which can have
@@ -45,7 +45,7 @@ class ConcatLayer(MultipleInputsLayer):
 concat = ConcatLayer  # shortcut
 
 
-class ElemwiseSumLayer(MultipleInputsLayer):
+class ElemwiseSumLayer(MergeLayer):
     """
     This layer performs an elementwise sum of its input layers.
     It requires all input layers to have the same output shape.

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -63,11 +63,11 @@ class TestLayer:
         assert l.name == "foo"
 
 
-class TestMultipleInputsLayer:
+class TestMergeLayer:
     @pytest.fixture
     def layer(self):
-        from lasagne.layers.base import MultipleInputsLayer
-        return MultipleInputsLayer([Mock(), Mock()])
+        from lasagne.layers.base import MergeLayer
+        return MergeLayer([Mock(), Mock()])
 
     def test_input_shapes(self, layer):
         assert layer.input_shapes == [l.output_shape
@@ -76,8 +76,8 @@ class TestMultipleInputsLayer:
     @pytest.fixture
     def layer_from_shape(self):
         from lasagne.layers.input import InputLayer
-        from lasagne.layers.base import MultipleInputsLayer
-        return MultipleInputsLayer([(None, 20), Mock(InputLayer((None,)))])
+        from lasagne.layers.base import MergeLayer
+        return MergeLayer([(None, 20), Mock(InputLayer((None,)))])
 
     def test_layer_from_shape(self, layer_from_shape):
         layer = layer_from_shape

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -252,7 +252,7 @@ class TestGetOutput_Layer:
         layer.get_output_for.assert_called_with(inputs[None])
 
 
-class TestGetOutput_MultipleInputsLayer:
+class TestGetOutput_MergeLayer:
     @pytest.fixture
     def get_output(self):
         from lasagne.layers.helper import get_output
@@ -260,7 +260,7 @@ class TestGetOutput_MultipleInputsLayer:
 
     @pytest.fixture
     def layers(self):
-        from lasagne.layers.base import Layer, MultipleInputsLayer
+        from lasagne.layers.base import Layer, MergeLayer
         from lasagne.layers.input import InputLayer
         # create two mocks of the same attributes as an InputLayer instance
         l1 = [Mock(InputLayer((None,))), Mock(InputLayer((None,)))]
@@ -269,8 +269,8 @@ class TestGetOutput_MultipleInputsLayer:
         # link them to the InputLayer mocks
         l2[0].input_layer = l1[0]
         l2[1].input_layer = l1[1]
-        # create a mock that has the same attributes as a MultipleInputsLayer
-        l3 = Mock(MultipleInputsLayer(l2))
+        # create a mock that has the same attributes as a MergeLayer
+        l3 = Mock(MergeLayer(l2))
         # link it to the two layer mocks, to get the following network:
         # l1[0] --> l2[0] --> l3
         # l1[1] --> l2[1] ----^
@@ -396,8 +396,8 @@ class TestGetOutput_MultipleInputsLayer:
     @pytest.fixture
     def layer_from_shape(self):
         from lasagne.layers.input import InputLayer
-        from lasagne.layers.base import MultipleInputsLayer
-        return MultipleInputsLayer([(None, 20), Mock(InputLayer((None,)))])
+        from lasagne.layers.base import MergeLayer
+        return MergeLayer([(None, 20), Mock(InputLayer((None,)))])
 
     def test_layer_from_shape_invalid_get_output(self, layer_from_shape,
                                                  get_output):
@@ -551,7 +551,7 @@ class TestGetOutputShape_Layer:
         layer.get_output_shape_for.assert_called_with(input_shapes[None])
 
 
-class TestGetOutputShape_MultipleInputsLayer:
+class TestGetOutputShape_MergeLayer:
     @pytest.fixture
     def get_output_shape(self):
         from lasagne.layers.helper import get_output_shape
@@ -559,7 +559,7 @@ class TestGetOutputShape_MultipleInputsLayer:
 
     @pytest.fixture
     def layers(self):
-        from lasagne.layers.base import Layer, MultipleInputsLayer
+        from lasagne.layers.base import Layer, MergeLayer
         from lasagne.layers.input import InputLayer
         # create two mocks of the same attributes as an InputLayer instance
         l1 = [Mock(InputLayer((None,))), Mock(InputLayer((None,)))]
@@ -568,8 +568,8 @@ class TestGetOutputShape_MultipleInputsLayer:
         # link them to the InputLayer mocks
         l2[0].input_layer = l1[0]
         l2[1].input_layer = l1[1]
-        # create a mock that has the same attributes as a MultipleInputsLayer
-        l3 = Mock(MultipleInputsLayer(l2))
+        # create a mock that has the same attributes as a MergeLayer
+        l3 = Mock(MergeLayer(l2))
         # link it to the two layer mocks, to get the following network:
         # l1[0] --> l2[0] --> l3
         # l1[1] --> l2[1] ----^
@@ -655,8 +655,8 @@ class TestGetOutputShape_MultipleInputsLayer:
     @pytest.fixture
     def layer_from_shape(self):
         from lasagne.layers.input import InputLayer
-        from lasagne.layers.base import MultipleInputsLayer
-        return MultipleInputsLayer([(None, 20), Mock(InputLayer((None,)))])
+        from lasagne.layers.base import MergeLayer
+        return MergeLayer([(None, 20), Mock(InputLayer((None,)))])
 
     def test_layer_from_shape_valid_get_output_shape(self, layer_from_shape,
                                                      get_output_shape):


### PR DESCRIPTION
With #182 we can now rename the confusing `MultipleInputsLayer` to `MergeLayer` (see #200) without ending up in rebase hell!