### PR TITLE
Docstring markup fixes: Section names, math and reference syntax

### DIFF
--- a/docs/modules/init.rst
+++ b/docs/modules/init.rst
@@ -6,13 +6,31 @@
 .. autoclass:: Initializer
    :members:
 
-.. autoclass:: Normal
-   :members:
-
 .. autoclass:: Constant
    :members:
 
+.. autoclass:: Normal
+   :members:
+
 .. autoclass:: Uniform
+   :members:
+
+.. autoclass:: Glorot
+   :members:
+
+.. autoclass:: GlorotNormal
+   :members:
+
+.. autoclass:: GlorotUniform
+   :members:
+
+.. autoclass:: He
+   :members:
+
+.. autoclass:: HeNormal
+   :members:
+
+.. autoclass:: HeUniform
    :members:
 
 .. autoclass:: Orthogonal

--- a/docs/modules/objectives.rst
+++ b/docs/modules/objectives.rst
@@ -4,8 +4,8 @@
 .. automodule:: lasagne.objectives
 
 .. autofunction:: mse
-.. autofunction:: crossentropy
-.. autofunction:: multinomial_nll
 
 .. autoclass:: Objective
+   :members:
+.. autoclass:: MaskedObjective
    :members:

--- a/docs/modules/updates.rst
+++ b/docs/modules/updates.rst
@@ -1,5 +1,5 @@
 :mod:`lasagne.updates`
-=====================
+======================
 
 .. automodule:: lasagne.updates
 
@@ -15,7 +15,14 @@ Update functions
 .. autofunction:: adadelta
 
 
-Other functions
----------------
+Update modification functions
+-----------------------------
+
+.. autofunction:: apply_momentum
+.. autofunction:: apply_nesterov_momentum
+
+
+Helper functions
+----------------
 
 .. autofunction:: norm_constraint

--- a/lasagne/init.py
+++ b/lasagne/init.py
@@ -1,8 +1,8 @@
 """
 Functions to create initializers for parameter variables.
 
-Usage
--------
+Examples
+--------
 >>> from lasagne.layers import DenseLayer
 >>> from lasagne.init import Constant, Glorot
 >>> l1 = DenseLayer((100,20), num_units=50, W=GlorotUniform(), b=Constant(0.0))
@@ -14,7 +14,7 @@ from .utils import floatX
 
 
 class Initializer(object):
-    """Initializer class
+    """Base class for parameter tensor initializers.
 
     The :class:`Initializer` class represents a weight initializer used
     to initialize weight parameters in a neural network layer. It should be
@@ -45,7 +45,7 @@ class Initializer(object):
 
 
 class Normal(Initializer):
-    """Sample initial weights from the Gaussian distribution
+    """Sample initial weights from the Gaussian distribution.
 
     Initial weight parameters are sampled from N(mean, std).
 
@@ -65,7 +65,7 @@ class Normal(Initializer):
 
 
 class Uniform(Initializer):
-    """Sample initial weights from the uniform distribution
+    """Sample initial weights from the uniform distribution.
 
     Parameters are sampled from U(a, b).
 
@@ -106,41 +106,46 @@ class Uniform(Initializer):
 
 
 class Glorot(Initializer):
-    """Glorot weight initialization [1]_
+    """Glorot weight initialization [1]_.
 
     This is also known as Xavier initialization.
 
     Parameters
     ----------
     initializer : lasagne.init.Initializer
-        Initializer used to sample the weights, must accept std in its
+        Initializer used to sample the weights, must accept `std` in its
         constructor to sample from a distribution with a given standard
         deviation.
     gain : float or 'relu'
-        When 'relu' the gain is set to sqrt(2), see notes.
+        Scaling factor for the weights. Set this to 1.0 for linear and sigmoid
+        units, to 'relu' or sqrt(2) for rectified linear units. Other transfer
+        functions may need different factors.
     c01b : bool
-        If lasagne.layers.cuda_convnet.Conv2DCCLayer is initialized with
-        dimshuffle=False, then c01b should be set to True.
+        For a :class:`lasagne.layers.cuda_convnet.Conv2DCCLayer` constructed
+        with ``dimshuffle=False``, `c01b` must be set to ``True`` to compute
+        the correct fan-in and fan-out.
 
     References
     ----------
-    [1] Glorot, Xavier, and Yoshua Bengio. "Understanding the difficulty of
-    training deep feedforward neural networks." International conference on
-    artificial intelligence and statistics. 2010.
+    .. [1] Xavier Glorot and Yoshua Bengio (2010):
+           Understanding the difficulty of training deep feedforward neural
+           networks. International conference on artificial intelligence and
+           statistics.
 
     Notes
-    ----------
-    For DenseLayers if gain='relu' and initializer is Uniform then the weights
-    are initialized as
+    -----
+    For a :class:`DenseLayer`, if ``gain='relu'`` and ``initializer=Uniform``,
+    the weights are initialized as
 
-    :math:`a = \frac{sqrt{6}}{\sqrt{fan_{in}+n_{hid}}}`
-    :nath: `W \sim U[-a, a]`.
+    .. math::
+       a &= \\sqrt{\\frac{6}{fan_{in}+fan_{out}}}\\\\
+       W &\sim U[-a, a]
 
-    If gain=1 and initializer is Normal then the weights are initialized
-    as
+    If ``gain=1`` and ``initializer=Normal``, the weights are initialized as
 
-    :math: `std = \sqrt{\frac{2}{fan_{in}+n_{hid}}}`
-    :math: `W \sim N(0, std)`.
+    .. math::
+       \\sigma &= \\sqrt{\\frac{2}{fan_{in}+fan_{out}}}\\\\
+       W &\sim N(0, \\sigma)
 
     See Also
     --------
@@ -176,47 +181,49 @@ class Glorot(Initializer):
 
 
 class GlorotNormal(Glorot):
-    """Glorot with weights sampled from Normal distribution
+    """Glorot with weights sampled from the Normal distribution.
 
-    See Glorot for description of parameters.
+    See :class:`Glorot` for a description of the parameters.
     """
     def __init__(self, gain=1.0, c01b=False):
         super(GlorotNormal, self).__init__(Normal, gain, c01b)
 
 
 class GlorotUniform(Glorot):
-    """Glorot with weights sampled from Uniform distribution
+    """Glorot with weights sampled from the Uniform distribution.
 
-    See Glorot for description of parameters.
+    See :class:`Glorot` for a description of the parameters.
     """
     def __init__(self, gain=1.0, c01b=False):
         super(GlorotUniform, self).__init__(Uniform, gain, c01b)
 
 
 class He(Initializer):
-    """He weight initialization [1]_
+    """He weight initialization [1]_.
 
-    Weights are initialized with std
-
-    :math:`\sigma = gain \sqrt{\frac{1}{fan_{in}}}`.
+    Weights are initialized with a standard deviation of
+    :math:`\\sigma = gain \\sqrt{\\frac{1}{fan_{in}}}`.
 
     Parameters
     ----------
     initializer : lasagne.init.Initializer
-        Initializer used to sample the weights, must accept std in its
+        Initializer used to sample the weights, must accept `std` in its
         constructor to sample from a distribution with a given standard
         deviation.
     gain : float or 'relu'
-        When 'relu' gain is set to sqrt(2).
+        Scaling factor for the weights. Set this to 1.0 for linear and sigmoid
+        units, to 'relu' or sqrt(2) for rectified linear units. Other transfer
+        functions may need different factors.
     c01b : bool
-        If lasagne.layers.cuda_convnet.Conv2DCCLayer is initialized with
-        dimshuffle=False, then c01b should be set to True.
+        For a :class:`lasagne.layers.cuda_convnet.Conv2DCCLayer` constructed
+        with ``dimshuffle=False``, `c01b` must be set to ``True`` to compute
+        the correct fan-in and fan-out.
 
     References
     ----------
-    [1] He, Kaiming, et al. Delving deep into rectifiers: Surpassing
-    human-level performance on imagenet classification.
-    arXiv preprint arXiv:1502.01852 (2015).
+    .. [1] Kaiming He et al. (2015):
+           Delving deep into rectifiers: Surpassing human-level performance on
+           imagenet classification. arXiv preprint arXiv:1502.01852.
 
     See Also
     ----------
@@ -252,18 +259,18 @@ class He(Initializer):
 
 
 class HeNormal(He):
-    """He initializer with weights sampled from Gaussian
+    """He initializer with weights sampled from the Normal distribution.
 
-    See He for description of parameters.
+    See :class:`He` for a description of the parameters.
     """
     def __init__(self, gain=1.0, c01b=False):
         super(HeNormal, self).__init__(Normal, gain, c01b)
 
 
 class HeUniform(He):
-    """He initializer with weights sampled from Gaussian
+    """He initializer with weights sampled from the Uniform distribution.
 
-    See He for description of parameters.
+    See :class:`He` for a description of the parameters.
     """
     def __init__(self, gain=1.0, c01b=False):
         super(HeUniform, self).__init__(Uniform, gain, c01b)

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -19,7 +19,7 @@ class DenseLayer(Layer):
     A fully connected layer.
 
     Parameters
-    -----------
+    ----------
     incoming : a :class:`Layer` instance or a tuple
         The layer feeding into this layer, or the expected input shape
 
@@ -37,16 +37,15 @@ class DenseLayer(Layer):
         If None is provided the layer will have no biases.
         See :meth:`Layer.create_param` for more information.
 
-
     nonlinearity : callable or None
         The nonlinearity that is applied to the layer activations. If None
         is provided, the layer will be linear.
 
-    Usage
-    -------
-        >>> from lasagne.layers import InputLayer, DenseLayer
-        >>> l_in = InputLayer((100, 20))
-        >>> l1 = DenseLayer(l_in, num_units=50)
+    Examples
+    --------
+    >>> from lasagne.layers import InputLayer, DenseLayer
+    >>> l_in = InputLayer((100, 20))
+    >>> l1 = DenseLayer(l_in, num_units=50)
     """
     def __init__(self, incoming, num_units, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
@@ -89,7 +88,7 @@ class NonlinearityLayer(Layer):
     A layer that just applies a nonlinearity.
 
     Parameters
-    -----------
+    ----------
     incoming : a :class:`Layer` instance or a tuple
         The layer feeding into this layer, or the expected input shape
 
@@ -116,7 +115,7 @@ class NINLayer(Layer):
     so NINLayer can be used to implement 1D, 2D, 3D, ... convolutions.
 
     Parameters
-    -----------
+    ----------
     incoming : a :class:`Layer` instance or a tuple
         The layer feeding into this layer, or the expected input shape
 
@@ -147,16 +146,16 @@ class NINLayer(Layer):
         The nonlinearity that is applied to the layer activations. If None
         is provided, the layer will be linear.
 
-    Usage
-    ----------
+    Examples
+    --------
     >>> from lasagne.layers import InputLayer, NINLayer
     >>> l_in = InputLayer((100, 20, 10, 3))
     >>> l1 = NINLayer(l_in, num_units=5)
 
     References
-    -----------
-    [1] Lin, Min, Qiang Chen, and Shuicheng Yan. "Network in network."
-    arXiv preprint arXiv:1312.4400 (2013).
+    ----------
+    .. [1] Lin, Min, Qiang Chen, and Shuicheng Yan (2013):
+           Network in network. arXiv preprint arXiv:1312.4400.
     """
     def __init__(self, incoming, num_units, untie_biases=False,
                  W=init.GlorotUniform(), b=init.Constant(0.),

--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 class DropoutLayer(Layer):
-    """Dropout layer [1]_,[2]_
+    """Dropout layer [1]_,[2]_.
 
     Sets values to zero with probability p. See notes for disabling dropout
     during testing.
@@ -31,27 +31,27 @@ class DropoutLayer(Layer):
         is False.
 
     Notes
-    ----------
+    -----
     The dropout layer is a regularizer that randomly sets input values to
-    zero, see [1,2] for a why this might improve generalization.
+    zero, see references for why this might improve generalization.
     During training you should set deterministic to false and during
     testing you should set deterministic to true.
 
     If rescale is true the input is scaled with input / (1-p) when
-    deterministic is false, see [1,2] for further discussion. Note that this
-    implementation scales the input at training time.
+    deterministic is false, see references for further discussion. Note that
+    this implementation scales the input at training time.
 
     References
     ----------
-    [1] Hinton, G., Srivastava, N., Krizhevsky, A., Sutskever, I.,
-    Salakhutdinov, R. R. (2012).
-    Improving neural networks by preventing co-adaptation of feature detectors.
-    arXiv Preprint, 1207.0580(Hinton, Geoffrey E., et al.
+    .. [1] Hinton, G., Srivastava, N., Krizhevsky, A., Sutskever, I.,
+           Salakhutdinov, R. R. (2012):
+           Improving neural networks by preventing co-adaptation of feature
+           detectors. arXiv preprint arXiv:1207.0580.
 
-    [2] Srivastava Nitish, Hinton, G., Krizhevsky, A., Sutskever,
-    I., & Salakhutdinov, R. R. (2014).
-    Dropout: A Simple Way to Prevent Neural Networks from Overfitting.
-    Journal of Machine Learning Research, 5(Jun)(2), 1929-1958.
+    .. [2] Srivastava Nitish, Hinton, G., Krizhevsky, A., Sutskever,
+           I., & Salakhutdinov, R. R. (2014):
+           Dropout: A Simple Way to Prevent Neural Networks from Overfitting.
+           Journal of Machine Learning Research, 5(Jun)(2), 1929-1958.
     """
     def __init__(self, incoming, p=0.5, rescale=True, **kwargs):
         super(DropoutLayer, self).__init__(incoming, **kwargs)
@@ -86,7 +86,7 @@ dropout = DropoutLayer  # shortcut
 
 
 class GaussianNoiseLayer(Layer):
-    """Gaussian noise layer [1]_
+    """Gaussian noise layer [1]_.
 
     Add zero Gaussian noise with mean 0 and std sigma to the input
 
@@ -98,18 +98,17 @@ class GaussianNoiseLayer(Layer):
             Std of added Gaussian noise
 
     Notes
-    ----------
+    -----
     The Gaussian noise layer is a regularizer. During training you should set
     deterministic to false and during testing you should set deterministic to
     true.
 
     References
     ----------
-    [1] K.-C. Jim, C. Giles, and B. Horne.
-    An analysis of noise in recurrent neural networks: convergence and
-    generalization.
-    Neural Networks, IEEE Trans- actions on, 7(6):1424-1438, 1996.
-
+    .. [1] K.-C. Jim, C. Giles, and B. Horne (1996):
+           An analysis of noise in recurrent neural networks: convergence and
+           generalization.
+           IEEE Transactions on Neural Networks, 7(6):1424-1438.
     """
     def __init__(self, incoming, sigma=0.1, **kwargs):
         super(GaussianNoiseLayer, self).__init__(incoming, **kwargs)

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -7,28 +7,28 @@ rate for use with stochastic gradient descent.
 Update functions take a loss expression or a list of gradient expressions and
 a list of parameters as input and return an ordered dictionary of updates:
 
- * sgd()
- * momentum()
- * nesterov_momentum()
- * adagrad()
- * rmsprop()
- * adadelta()
- * adam()
+* :func:`sgd()`
+* :func:`momentum()`
+* :func:`nesterov_momentum()`
+* :func:`adagrad()`
+* :func:`rmsprop()`
+* :func:`adadelta()`
+* :func:`adam()`
 
 Two functions can be used to further modify the updates to include momentum:
 
- * apply_momentum()
- * apply_nesterov_momentum()
+* :func:`apply_momentum()`
+* :func:`apply_nesterov_momentum()`
 
 Finally, we provide a helper function to constrain the norm of a
 tensor variable:
 
- * norm_constraint()
+* :func:`norm_constraint()`
 
 This can be used to constrain the norm of parameters (as an alternative
 to weight decay), or for a form of gradient clipping.
 
-Usage
+Examples
 --------
 >>> import lasagne
 >>> import theano.tensor as T
@@ -102,6 +102,7 @@ def sgd(loss_or_grads, params, learning_rate):
     """Stochastic Gradient Descent (SGD) updates.
 
     Generates update expressions of the form:
+
     * ``param := param - learning_rate * gradient``
 
     Parameters
@@ -131,6 +132,7 @@ def apply_momentum(updates, params=None, momentum=0.9):
     """Returns a modified update dictionary that includes momentum terms.
 
     Generates update expressions of the form:
+
     * ``velocity := momentum * velocity + updates[param] - param``
     * ``param := param + velocity``
 
@@ -178,6 +180,7 @@ def momentum(loss_or_grads, params, learning_rate, momentum=0.9):
     """Stochastic Gradient Descent (SGD) updates with momentum.
 
     Generates update expressions of the form:
+
     * ``velocity := momentum * velocity - learning_rate * gradient``
     * ``param := param + velocity``
 
@@ -196,7 +199,7 @@ def momentum(loss_or_grads, params, learning_rate, momentum=0.9):
     Returns
     -------
     OrderedDict
-         A dictionary mapping each parameter to its update expression
+        A dictionary mapping each parameter to its update expression
 
     Notes
     -----
@@ -216,6 +219,7 @@ def apply_nesterov_momentum(updates, params=None, momentum=0.9):
     """Returns a modified update dictionary including Nesterov momentum.
 
     Generates update expressions of the form:
+
     * ``velocity := momentum * velocity + updates[param] - param``
     * ``param := param + momentum * velocity + updates[param] - param``
 
@@ -269,6 +273,7 @@ def nesterov_momentum(loss_or_grads, params, learning_rate, momentum=0.9):
     """Stochastic Gradient Descent (SGD) updates with Nesterov momentum.
 
     Generates update expressions of the form:
+
     * ``velocity := momentum * velocity + updates[param] - param``
     * ``param := param + momentum * velocity + updates[param] - param``
 
@@ -287,7 +292,7 @@ def nesterov_momentum(loss_or_grads, params, learning_rate, momentum=0.9):
     Returns
     -------
     OrderedDict
-         A dictionary mapping each parameter to its update expression
+        A dictionary mapping each parameter to its update expression
 
     Notes
     -----
@@ -309,11 +314,10 @@ def nesterov_momentum(loss_or_grads, params, learning_rate, momentum=0.9):
 
 
 def adagrad(loss_or_grads, params, learning_rate=1.0, epsilon=1e-6):
-    """Adagrad updates [1]_
+    """Adagrad updates [1]_.
 
     Scale learning rates by dividing with the square root of accumulated
     squared gradients.
-
 
     Parameters
     ----------
@@ -329,30 +333,28 @@ def adagrad(loss_or_grads, params, learning_rate=1.0, epsilon=1e-6):
     Returns
     -------
     OrderedDict
-         A dictionary mapping each parameter to its update expression
+        A dictionary mapping each parameter to its update expression
 
     Notes
     -----
     Using step size eta Adagrad calculates the learning rate for feature i at
     time step t as:
 
-    :math:`\eta_{t,i} = \frac{\eta}
-      {\sqrt{\sum^t_{t^\prime} g^2_{t^\prime,i}+\epsilon } }g_{t,i}`
+    .. math:: \\eta_{t,i} = \\frac{\\eta}
+       {\\sqrt{\\sum^t_{t^\\prime} g^2_{t^\\prime,i}+\\epsilon}} g_{t,i}
 
     as such the learning rate is monotonically decreasing.
 
-    Epsilon is not included in the typical formula,
-    See "Notes on AdaGrad" by Chris Dyer for more info [2]_.
+    Epsilon is not included in the typical formula, see [2]_.
 
     References
     ----------
-    [1] Duchi, J., Hazan, E., & Singer, Y. (2011).
-    Adaptive subgradient methods for online learning and stochastic
-    optimization. JMLR, 12:2121-2159.
+    .. [1] Duchi, J., Hazan, E., & Singer, Y. (2011):
+           Adaptive subgradient methods for online learning and stochastic
+           optimization. JMLR, 12:2121-2159.
 
-    [2] Notes on AdaGrad, Chris Dyer
-    http://www.ark.cs.cmu.edu/cdyer/adagrad.pdf
-
+    .. [2] Chris Dyer:
+           Notes on AdaGrad. http://www.ark.cs.cmu.edu/cdyer/adagrad.pdf
     """
 
     grads = get_or_compute_grads(loss_or_grads, params)
@@ -371,11 +373,10 @@ def adagrad(loss_or_grads, params, learning_rate=1.0, epsilon=1e-6):
 
 
 def rmsprop(loss_or_grads, params, learning_rate=1.0, rho=0.9, epsilon=1e-6):
-    """RMSProp updates [1]_
+    """RMSProp updates [1]_.
 
     Scale learning rates by dividing with the moving average of the root mean
     squared (RMS) gradients.
-
 
     Parameters
     ----------
@@ -393,26 +394,26 @@ def rmsprop(loss_or_grads, params, learning_rate=1.0, rho=0.9, epsilon=1e-6):
     Returns
     -------
     OrderedDict
-         A dictionary mapping each parameter to its update expression
+        A dictionary mapping each parameter to its update expression
 
     Notes
     -----
-    rho should be between 0 and 1. A value of rho close to 1 will decay the
+    `rho` should be between 0 and 1. A value of `rho` close to 1 will decay the
     moving average slowly and a value close to 0 will decay the moving average
     fast.
 
-    Using the step size eta and a decay factor rho the learning rate is
-    calculated as:
+    Using the step size :math:`\\eta` and a decay factor :math:`\\rho` the
+    learning rate :math:`\\eta_t` is calculated as:
 
-    :math:`r_t = \rho r_{t-1} + (1-\rho)*g^2`
-    :math:`\eta_t = \frac{\eta}{\sqrt{r_t + \epsilon}}`
-
+    .. math::
+       r_t &= \\rho r_{t-1} + (1-\\rho)*g^2\\\\
+       \\eta_t &= \\frac{\\eta}{\\sqrt{r_t + \\epsilon}}
 
     References
     ----------
-    [1] Tieleman, T. and Hinton, G. (2012),
-    Lecture 6.5 - rmsprop, COURSERA: Neural Networks for Machine Learning
-    http://www.youtube.com/watch?v=O3sxAc4hxZU  (formula 5.20 min)
+    .. [1] Tieleman, T. and Hinton, G. (2012):
+           Neural Networks for Machine Learning, Lecture 6.5 - rmsprop.
+           Coursera. http://www.youtube.com/watch?v=O3sxAc4hxZU (formula @5:20)
     """
     grads = get_or_compute_grads(loss_or_grads, params)
     updates = OrderedDict()
@@ -430,11 +431,10 @@ def rmsprop(loss_or_grads, params, learning_rate=1.0, rho=0.9, epsilon=1e-6):
 
 
 def adadelta(loss_or_grads, params, learning_rate=1.0, rho=0.95, epsilon=1e-6):
-    """ Adadelta updates [1]_
+    """ Adadelta updates [1]_.
 
     Scale learning rates by a the ratio of accumulated gradients to accumulated
     step sizes, see notes for further description.
-
 
     Parameters
     ----------
@@ -452,7 +452,7 @@ def adadelta(loss_or_grads, params, learning_rate=1.0, rho=0.95, epsilon=1e-6):
     Returns
     -------
     OrderedDict
-         A dictionary mapping each parameter to its update expression
+        A dictionary mapping each parameter to its update expression
 
     Notes
     -----
@@ -471,18 +471,17 @@ def adadelta(loss_or_grads, params, learning_rate=1.0, rho=0.95, epsilon=1e-6):
     Using the step size eta and a decay factor rho the learning rate is
     calculated as:
 
-    :math:`r_t = \rho r_{t-1} + (1-\rho)*g^2`
-    :math:`\eta_t = \eta \frac{\sqrt{s_{t-1} + \epsilon}}
-                    {\sqrt{r_t + \epsilon}}`
-    :math:`s_t = \rho s_{t-1} + (1-\rho)*g^2`
-
-
+    .. math::
+       r_t &= \\rho r_{t-1} + (1-\\rho)*g^2\\\\
+       \\eta_t &= \\eta \\frac{\\sqrt{s_{t-1} + \\epsilon}}
+                             {\sqrt{r_t + \epsilon}}\\\\
+       s_t &= \\rho s_{t-1} + (1-\\rho)*g^2
 
     References
     ----------
-    [1] Zeiler, M. D. (2012). ADADELTA: An Adaptive Learning Rate Method.
-    arXiv Preprint arXiv:1212.5701.
-
+    .. [1] Zeiler, M. D. (2012):
+           ADADELTA: An Adaptive Learning Rate Method.
+           arXiv Preprint arXiv:1212.5701.
     """
     grads = get_or_compute_grads(loss_or_grads, params)
     updates = OrderedDict()
@@ -536,17 +535,17 @@ def adam(loss_or_grads, params, learning_rate=0.001, beta1=0.9,
     OrderedDict
         A dictionary mapping each parameter to its update expression
 
-    References
-    ----------
-    .. [1] Kingma, Diederik, and Jimmy Ba:
-           Adam: A Method for Stochastic Optimization.
-           arXiv preprint arXiv:1412.6980 (2014).
-
     Notes
     -----
-    The implementation does not include lambda as it is only used to
-    prove convergence of the algorithm (personal communication with the
-    authors of [1]_).
+    The paper [1]_ includes an additional hyperparameter lambda. This is only
+    needed to prove convergence of the algorithm and has no practical use
+    (personal communication with the authors), it is therefore omitted here.
+
+    References
+    ----------
+    .. [1] Kingma, Diederik, and Jimmy Ba (2014):
+           Adam: A Method for Stochastic Optimization.
+           arXiv preprint arXiv:1412.6980.
     """
     all_grads = get_or_compute_grads(loss_or_grads, params)
     t_prev = theano.shared(utils.floatX(0.))


### PR DESCRIPTION
Fixing several errors in the docstring markup. @skaae, please have a quick look at the diff to see what's important for future contributions!

Useful references:
* https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
* https://github.com/numpy/numpy/blob/master/numpy/fft/info.py
* http://docs.scipy.org/doc/numpy/reference/routines.fft.html

Something's still wrong with how the references render in Sphinx, as well as the parameter descriptions (I think they are rendered as block quotes, with a grey bar on the left and a larger font size).

/edit: The most important gotchas: Section names need to follow the first document, reference definitions need to follow the first document, math needs to have backslashes escaped in docstrings.