### PR TITLE
lasagne.layers.cuda_convnet documentation

### DIFF
--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -105,10 +105,10 @@ class Conv1DLayer(Layer):
     num_filters : int
         The number of learnable convolutional filters this layer has.
 
-    filter_size : int or tuple of int
+    filter_size : int or iterable
         An integer or a 1-element tuple specifying the size of the filters.
 
-    stride : int or tuple of int
+    stride : int or iterable
         An integer or a 1-element tuple specifying the stride of the
         convolution operation.
 
@@ -276,15 +276,15 @@ class Conv2DLayer(Layer):
     incoming : a :class:`Layer` instance or a tuple
         The layer feeding into this layer, or the expected input shape. The
         output of this layer should be a 4D tensor, with shape
-        ``(batch_size, num_input_channels, input_height, input_width)``.
+        ``(batch_size, num_input_channels, input_rows, input_columns)``.
 
     num_filters : int
         The number of learnable convolutional filters this layer has.
 
-    filter_size : int or tuple of int
+    filter_size : int or iterable
         An integer or a 2-element tuple specifying the size of the filters.
 
-    stride : int or tuple of int
+    stride : int or iterable
         An integer or a 2-element tuple specifying the stride of the
         convolution operation.
 
@@ -316,7 +316,7 @@ class Conv2DLayer(Layer):
     W : Theano shared variable, numpy array or callable
         An initializer for the weights of the layer. This should initialize the
         layer weights to a 4D array with shape
-        ``(num_filters, num_input_channels, filter_height, filter_width)``.
+        ``(num_filters, num_input_channels, filter_rows, filter_columns)``.
         See :func:`lasagne.utils.create_param` for more information.
 
     b : Theano shared variable, numpy array, callable or None
@@ -324,7 +324,7 @@ class Conv2DLayer(Layer):
         layer will have no biases. This should initialize the layer biases to
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
-        ``(num_filters, input_height, input_width)`` instead.
+        ``(num_filters, input_rows, input_columns)`` instead.
         See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -81,7 +81,7 @@ class Conv2DMMLayer(MMLayer):
         An initializer for the weights of the layer. This should initialize the
         layer weights to a 4D array with shape
         ``(num_filters, num_input_channels, filter_height, filter_width)``.
-        See :meth:`Layer.create_param` for more information.
+        See :func:`lasagne.utils.create_param` for more information.
 
     b : Theano shared variable, numpy array, callable or None
         An initializer for the biases of the layer. If None is provided, the
@@ -89,7 +89,7 @@ class Conv2DMMLayer(MMLayer):
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
         ``(num_filters, input_height, input_width)`` instead.
-        See :meth:`Layer.create_param` for more information.
+        See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
         The nonlinearity that is applied to the layer activations. If None

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -40,15 +40,15 @@ class Conv2DMMLayer(MMLayer):
     incoming : a :class:`Layer` instance or a tuple
         The layer feeding into this layer, or the expected input shape. The
         output of this layer should be a 4D tensor, with shape
-        ``(batch_size, num_input_channels, input_height, input_width)``.
+        ``(batch_size, num_input_channels, input_rows, input_columns)``.
 
     num_filters : int
         The number of learnable convolutional filters this layer has.
 
-    filter_size : int or tuple of int
+    filter_size : int or iterable
         An integer or a 2-element tuple specifying the size of the filters.
 
-    stride : int or tuple of int
+    stride : int or iterable
         An integer or a 2-element tuple specifying the stride of the
         convolution operation.
 
@@ -80,7 +80,7 @@ class Conv2DMMLayer(MMLayer):
     W : Theano shared variable, numpy array or callable
         An initializer for the weights of the layer. This should initialize the
         layer weights to a 4D array with shape
-        ``(num_filters, num_input_channels, filter_height, filter_width)``.
+        ``(num_filters, num_input_channels, filter_rows, filter_columns)``.
         See :func:`lasagne.utils.create_param` for more information.
 
     b : Theano shared variable, numpy array, callable or None
@@ -88,14 +88,14 @@ class Conv2DMMLayer(MMLayer):
         layer will have no biases. This should initialize the layer biases to
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
-        ``(num_filters, input_height, input_width)`` instead.
+        ``(num_filters, input_rows, input_columns)`` instead.
         See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
         The nonlinearity that is applied to the layer activations. If None
         is provided, the layer will be linear.
 
-    pad : int, tuple of int or None
+    pad : int, iterable or None
         An integer or a 2-element tuple specifying the amount of zero-padding
         on each side. This may also be ``None``, in which case the correct
         amount of padding will be inferred from the specified ``border_mode``.

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -46,6 +46,13 @@ class DenseLayer(Layer):
     >>> from lasagne.layers import InputLayer, DenseLayer
     >>> l_in = InputLayer((100, 20))
     >>> l1 = DenseLayer(l_in, num_units=50)
+
+    Notes
+    -----
+    If the input to this layer has more than two axes, it will flatten the
+    trailing axes. This is useful for when a dense layer follows a
+    convolutional layer, for example. It is not necessary to insert a
+    :class:`FlattenLayer` in this case.
     """
     def __init__(self, incoming, num_units, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
@@ -128,7 +135,7 @@ class NINLayer(Layer):
         An initializer for the weights of the layer. If a shared variable or a
         numpy array is provided the shape should be (num_inputs, num_units),
         where num_units is the size of the 2nd. dimension of the input.
-        See :meth:`Layer.create_param` for more information.
+        See :func:`lasagne.utils.create_param` for more information.
 
     b : Theano shared variable, numpy array, callable or None
         An initializer for the biases of the layer. If a shared variable or a
@@ -137,7 +144,7 @@ class NINLayer(Layer):
         be (num_units, ). If untie_biases is True then the shape should be
         (num_units, input_dim[2], ..., input_dim[-1]). If None is provided the
         layer will have no biases.
-        See :meth:`Layer.create_param` for more information.
+        See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
         The nonlinearity that is applied to the layer activations. If None

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -152,7 +152,7 @@ class Conv2DDNNLayer(DNNLayer):
         An initializer for the weights of the layer. This should initialize the
         layer weights to a 4D array with shape
         ``(num_filters, num_input_channels, filter_height, filter_width)``.
-        See :meth:`Layer.create_param` for more information.
+        See :func:`lasagne.utils.create_param` for more information.
 
     b : Theano shared variable, numpy array, callable or None
         An initializer for the biases of the layer. If None is provided, the
@@ -160,7 +160,7 @@ class Conv2DDNNLayer(DNNLayer):
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
         ``(num_filters, input_height, input_width)`` instead.
-        See :meth:`Layer.create_param` for more information.
+        See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
         The nonlinearity that is applied to the layer activations. If None

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -111,15 +111,15 @@ class Conv2DDNNLayer(DNNLayer):
     incoming : a :class:`Layer` instance or a tuple
         The layer feeding into this layer, or the expected input shape. The
         output of this layer should be a 4D tensor, with shape
-        ``(batch_size, num_input_channels, input_height, input_width)``.
+        ``(batch_size, num_input_channels, input_rows, input_columns)``.
 
     num_filters : int
         The number of learnable convolutional filters this layer has.
 
-    filter_size : int or tuple of int
+    filter_size : int or iterable
         An integer or a 2-element tuple specifying the size of the filters.
 
-    stride : int or tuple of int
+    stride : int or iterable
         An integer or a 2-element tuple specifying the stride of the
         convolution operation.
 
@@ -151,7 +151,7 @@ class Conv2DDNNLayer(DNNLayer):
     W : Theano shared variable, numpy array or callable
         An initializer for the weights of the layer. This should initialize the
         layer weights to a 4D array with shape
-        ``(num_filters, num_input_channels, filter_height, filter_width)``.
+        ``(num_filters, num_input_channels, filter_rows, filter_columns)``.
         See :func:`lasagne.utils.create_param` for more information.
 
     b : Theano shared variable, numpy array, callable or None
@@ -159,14 +159,14 @@ class Conv2DDNNLayer(DNNLayer):
         layer will have no biases. This should initialize the layer biases to
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
-        ``(num_filters, input_height, input_width)`` instead.
+        ``(num_filters, input_rows, input_columns)`` instead.
         See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
         The nonlinearity that is applied to the layer activations. If None
         is provided, the layer will be linear.
 
-    pad : int, tuple of int or None
+    pad : int, iterable or None
         An integer or a 2-element tuple specifying the amount of zero-padding
         on each side. This may also be ``None``, in which case the correct
         amount of padding will be inferred from the specified ``border_mode``.


### PR DESCRIPTION
I've only done the convolution layer so far. It was mostly copy paste from the other implementations, but the `dimshuffle` and `partial_sum` arguments required some extra work. The notes section is also quite beefy because all the limitations of the cuda-convnet convolution implementation need to be explained.

I'll do the pooling layer and the bc01/c01b shuffle layers next.