### PR TITLE
generalize embedding

### DIFF
--- a/lasagne/layers/embedding.py
+++ b/lasagne/layers/embedding.py
@@ -12,8 +12,8 @@ __all__ = [
 
 class EmbeddingLayer(Layer):
     """
-    A layer for word embeddings. The input should be a `theano.Tensor.ivector``
-    specifying which embeddings to use.
+    A layer for word embeddings. The input should be an integer type
+    Tensor variable.
 
     Parameters
     ----------
@@ -34,16 +34,19 @@ class EmbeddingLayer(Layer):
     --------
     >>> from lasagne.layers import EmbeddingLayer, InputLayer, get_output
     >>> import theano
-    >>> x = T.ivector()
+    >>> x = T.imatrix()
     >>> l_in = InputLayer((3, ))
     >>> W = np.arange(3*5).reshape((3, 5)).astype('float32')
     >>> l1 = EmbeddingLayer(l_in, input_size=3, output_size=5, W=W)
     >>> output = get_output(l1, x)
     >>> f = theano.function([x], output)
-    >>> x_test = np.array([0, 2]).astype('int32')
+    >>> x_test = np.array([[0, 2], [1, 2]]).astype('int32')
     >>> f(x_test)
-    array([[  0.,   1.,   2.,   3.,   4.],
-           [ 10.,  11.,  12.,  13.,  14.]], dtype=float32)
+    array([[[  0.,   1.,   2.,   3.,   4.],
+            [ 10.,  11.,  12.,  13.,  14.]],
+    <BLANKLINE>
+           [[  5.,   6.,   7.,   8.,   9.],
+            [ 10.,  11.,  12.,  13.,  14.]]], dtype=float32)
     """
     def __init__(self, incoming, input_size, output_size,
                  W=init.Normal(), **kwargs):
@@ -55,7 +58,7 @@ class EmbeddingLayer(Layer):
         self.W = self.add_param(W, (input_size, output_size), name="W")
 
     def get_output_shape_for(self, input_shape):
-        return (input_shape[0], self.output_size)
+        return input_shape + (self.output_size, )
 
     def get_output_for(self, input, **kwargs):
         return self.W[input]

--- a/lasagne/tests/layers/test_embedding.py
+++ b/lasagne/tests/layers/test_embedding.py
@@ -3,7 +3,7 @@ import pytest
 import theano
 
 
-def test_embedding():
+def test_embedding_2D_input():
     import numpy as np
     import theano
     import theano.tensor as T
@@ -24,6 +24,32 @@ def test_embedding():
     # check output shape
     assert helper.get_output_shape(
         l1, (batch_size, seq_len)) == (batch_size, seq_len, emb_size)
+
+    output = helper.get_output(l1, x)
+    f = theano.function([x], output)
+    np.testing.assert_array_almost_equal(f(x_test), W[x_test])
+
+
+def test_embedding_1D_input():
+    import numpy as np
+    import theano
+    import theano.tensor as T
+    from lasagne.layers import EmbeddingLayer, InputLayer, helper
+    x = T.ivector()
+    batch_size = 2
+    emb_size = 10
+    vocab_size = 3
+    l_in = InputLayer((None,))
+    W = np.arange(
+        vocab_size*emb_size).reshape((vocab_size, emb_size)).astype('float32')
+    l1 = EmbeddingLayer(l_in, input_size=vocab_size, output_size=emb_size,
+                        W=W)
+
+    x_test = np.array([0, 1, 2], dtype='int32')
+
+    # check output shape
+    assert helper.get_output_shape(
+        l1, (batch_size, )) == (batch_size, emb_size)
 
     output = helper.get_output(l1, x)
     f = theano.function([x], output)


### PR DESCRIPTION
The previous version of the embedding layer did only handle 1d output. Minor change that generalize it 
to any dimension input.
