### PR TITLE
improve test coverage

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -91,7 +91,7 @@ class Layer(object):
 
         return result
 
-    def get_output_shape(self):
+    def get_output_shape(self):  # pragma: no cover
         """
         Deprecated. Use `layer.output_shape`.
         """
@@ -101,7 +101,7 @@ class Layer(object):
                       "layer.output_shape instead.")
         return self.output_shape
 
-    def get_output(self, input=None, **kwargs):
+    def get_output(self, input=None, **kwargs):  # pragma: no cover
         """
         Deprecated. Use `lasagne.layers.get_output(layer, input, **kwargs)`.
         """
@@ -233,7 +233,7 @@ class Layer(object):
 
         return param
 
-    def get_bias_params(self):
+    def get_bias_params(self):  # pragma: no cover
         import warnings
         warnings.warn("layer.get_bias_params() is deprecated and will be "
                       "removed for the first release of Lasagne. Please use "

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -93,6 +93,10 @@ class TestLayer:
         A = named_layer.add_param(a, a_shape, name='A')
         assert A.name == 'layer_name.A'
 
+    def test_get_output_for_notimplemented(self, layer):
+        with pytest.raises(NotImplementedError):
+            layer.get_output_for(Mock())
+
 
 class TestMergeLayer:
     @pytest.fixture
@@ -119,3 +123,11 @@ class TestMergeLayer:
 
     def test_get_params(self, layer):
         assert layer.get_params() == []
+
+    def test_get_output_shape_for_notimplemented(self, layer):
+        with pytest.raises(NotImplementedError):
+            layer.get_output_shape_for(Mock())
+
+    def test_get_output_for_notimplemented(self, layer):
+        with pytest.raises(NotImplementedError):
+            layer.get_output_for(Mock())


### PR DESCRIPTION
This is going to be a collection of tests to improve test coverage across the library. So far I've only done `base.py`, which should now be 100% covered when we get rid of the deprecated stuff. Other than that I'll be focusing mostly on the convolution implementations for now. If anyone wants to help we can try to divide the work a little. It would be nice to get the coverage up in the 90%+ range before we release the library :)

For clarity's sake, I'm of course aware that good coverage does not necessarily mean the tests are good - but it's an important first step!