### PR TITLE
Increase test coverage

### DIFF
--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -176,11 +176,13 @@ class NINLayer(Layer):
         self.W = self.add_param(W, (num_input_channels, num_units), name="W")
         if b is None:
             self.b = None
-        elif self.untie_biases:
-            biases_shape = (num_units,) + self.output_shape[2:]
         else:
-            biases_shape = (num_units,)
-        self.b = self.add_param(b, biases_shape, name="b", regularizable=False)
+            if self.untie_biases:
+                biases_shape = (num_units,) + self.output_shape[2:]
+            else:
+                biases_shape = (num_units,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
 
     def get_output_shape_for(self, input_shape):
         return (input_shape[0], self.num_units) + input_shape[2:]

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -236,7 +236,7 @@ class DimshuffleLayer(Layer):
             elif p == 'x':
                 # Broadcast; will be of size 1
                 o = 1
-            else:
+            else:  # pragma no cover
                 raise RuntimeError("invalid pattern entry, should have "
                                    "caught in the constructor")
             output_shape.append(o)

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -236,9 +236,6 @@ class DimshuffleLayer(Layer):
             elif p == 'x':
                 # Broadcast; will be of size 1
                 o = 1
-            else:  # pragma no cover
-                raise RuntimeError("invalid pattern entry, should have "
-                                   "caught in the constructor")
             output_shape.append(o)
 
         for i, (dim_size, used) in enumerate(zip(input_shape, dims_used)):

--- a/lasagne/tests/layers/test_dense.py
+++ b/lasagne/tests/layers/test_dense.py
@@ -99,8 +99,8 @@ class TestDenseLayer:
         # Check that the input to the nonlinearity was what we expect
         # from dense layer, i.e. the dot product plus bias
         nonlinearity_arg = nonlinearity.call_args[0][0]
-        assert (nonlinearity_arg.eval() ==
-                np.dot(input.get_value().reshape(2, -1), W) + b).all()
+        assert np.allclose(nonlinearity_arg.eval(),
+                           np.dot(input.get_value().reshape(2, -1), W) + b)
 
     def test_param_names(self, layer):
         assert layer.W.name == "W"
@@ -270,7 +270,7 @@ class TestNINLayer:
             else:
                 X += layer.b.get_value()
         X = np.rollaxis(X.T, 0, 2)
-        assert (nonlinearity_arg.eval() == X).all()
+        assert np.allclose(nonlinearity_arg.eval(), X)
 
     def test_param_names(self, layer):
         assert layer.W.name == "W"

--- a/lasagne/tests/layers/test_dense.py
+++ b/lasagne/tests/layers/test_dense.py
@@ -1,5 +1,5 @@
 from mock import Mock
-import numpy
+import numpy as np
 import pytest
 import theano
 
@@ -20,8 +20,8 @@ class TestDenseLayer:
         b = Mock()
         nonlinearity = Mock()
 
-        W.return_value = numpy.ones((12, 3))
-        b.return_value = numpy.ones((3,)) * 3
+        W.return_value = np.ones((12, 3))
+        b.return_value = np.ones((3,)) * 3
         layer = DenseLayer(
             dummy_input_layer,
             num_units=3,
@@ -48,13 +48,15 @@ class TestDenseLayer:
         layer_vars['W'].assert_called_with((12, 3))
         layer_vars['b'].assert_called_with((3,))
 
-    def test_init_none_nonlinearity(self, DenseLayer, dummy_input_layer):
+    def test_init_none_nonlinearity_bias(self, DenseLayer, dummy_input_layer):
         layer = DenseLayer(
             dummy_input_layer,
             num_units=3,
             nonlinearity=None,
+            b=None,
             )
         assert layer.nonlinearity == lasagne.nonlinearities.identity
+        assert layer.b is None
 
     def test_get_params(self, layer):
         assert layer.get_params() == [layer.W, layer.b]
@@ -74,7 +76,7 @@ class TestDenseLayer:
         W = layer_vars['W']()
         b = layer_vars['b']()
 
-        input = theano.shared(numpy.ones((2, 12)))
+        input = theano.shared(np.ones((2, 12)))
         result = layer.get_output_for(input)
         assert result is nonlinearity.return_value
 
@@ -82,7 +84,7 @@ class TestDenseLayer:
         # from dense layer, i.e. the dot product plus bias
         nonlinearity_arg = nonlinearity.call_args[0][0]
         assert (nonlinearity_arg.eval() ==
-                numpy.dot(input.get_value(), W) + b).all()
+                np.dot(input.get_value(), W) + b).all()
 
     def test_get_output_for_flattens_input(self, layer_vars):
         layer = layer_vars['layer']
@@ -90,7 +92,7 @@ class TestDenseLayer:
         W = layer_vars['W']()
         b = layer_vars['b']()
 
-        input = theano.shared(numpy.ones((2, 3, 4)))
+        input = theano.shared(np.ones((2, 3, 4)))
         result = layer.get_output_for(input)
         assert result is nonlinearity.return_value
 
@@ -98,7 +100,7 @@ class TestDenseLayer:
         # from dense layer, i.e. the dot product plus bias
         nonlinearity_arg = nonlinearity.call_args[0][0]
         assert (nonlinearity_arg.eval() ==
-                numpy.dot(input.get_value().reshape(2, -1), W) + b).all()
+                np.dot(input.get_value().reshape(2, -1), W) + b).all()
 
     def test_param_names(self, layer):
         assert layer.W.name == "W"
@@ -106,6 +108,176 @@ class TestDenseLayer:
 
     def test_named_layer_param_names(self, DenseLayer, dummy_input_layer):
         layer = DenseLayer(
+            dummy_input_layer,
+            num_units=3,
+            name="foo"
+            )
+
+        assert layer.W.name == "foo.W"
+        assert layer.b.name == "foo.b"
+
+
+class TestNonlinearityLayer:
+    @pytest.fixture
+    def NonlinearityLayer(self):
+        from lasagne.layers.dense import NonlinearityLayer
+        return NonlinearityLayer
+
+    @pytest.fixture
+    def layer_vars(self, dummy_input_layer):
+        from lasagne.layers.dense import NonlinearityLayer
+        nonlinearity = Mock()
+
+        layer = NonlinearityLayer(
+            dummy_input_layer,
+            nonlinearity=nonlinearity,
+            )
+
+        return {
+            'nonlinearity': nonlinearity,
+            'layer': layer,
+            }
+
+    @pytest.fixture
+    def layer(self, layer_vars):
+        return layer_vars['layer']
+
+    def test_init_none_nonlinearity(self, NonlinearityLayer,
+                                    dummy_input_layer):
+        layer = NonlinearityLayer(
+            dummy_input_layer,
+            nonlinearity=None,
+            )
+        assert layer.nonlinearity == lasagne.nonlinearities.identity
+
+    def test_get_output_for(self, layer_vars):
+        layer = layer_vars['layer']
+        nonlinearity = layer_vars['nonlinearity']
+
+        input = theano.shared(np.random.uniform(-1, 1, (2, 12)))
+        result = layer.get_output_for(input)
+        assert result is nonlinearity.return_value
+
+
+class TestNINLayer:
+    @pytest.fixture
+    def dummy_input_layer(self):
+        from lasagne.layers.input import InputLayer
+        input_layer = InputLayer((2, 3, 4, 5))
+        mock = Mock(input_layer)
+        mock.shape = input_layer.shape
+        mock.input_var = input_layer.input_var
+        mock.output_shape = input_layer.output_shape
+        return mock
+
+    @pytest.fixture
+    def NINLayer(self):
+        from lasagne.layers.dense import NINLayer
+        return NINLayer
+
+    @pytest.fixture
+    def layer_vars(self, dummy_input_layer):
+        from lasagne.layers.dense import NINLayer
+        W = Mock()
+        b = Mock()
+        nonlinearity = Mock()
+
+        W.return_value = np.ones((3, 5))
+        b.return_value = np.ones((5,))
+        layer = NINLayer(
+            dummy_input_layer,
+            num_units=5,
+            W=W,
+            b=b,
+            nonlinearity=nonlinearity,
+            )
+
+        return {
+            'W': W,
+            'b': b,
+            'nonlinearity': nonlinearity,
+            'layer': layer,
+            }
+
+    @pytest.fixture
+    def layer(self, layer_vars):
+        return layer_vars['layer']
+
+    def test_init(self, layer_vars):
+        layer = layer_vars['layer']
+        assert (layer.W.get_value() == layer_vars['W'].return_value).all()
+        assert (layer.b.get_value() == layer_vars['b'].return_value).all()
+        layer_vars['W'].assert_called_with((3, 5))
+        layer_vars['b'].assert_called_with((5,))
+
+    def test_init_none_nonlinearity_bias(self, NINLayer, dummy_input_layer):
+        layer = NINLayer(
+            dummy_input_layer,
+            num_units=3,
+            nonlinearity=None,
+            b=None,
+            )
+        assert layer.nonlinearity == lasagne.nonlinearities.identity
+        assert layer.b is None
+
+    def test_init_untie_biases(self, NINLayer, dummy_input_layer):
+        layer = NINLayer(
+            dummy_input_layer,
+            num_units=5,
+            untie_biases=True,
+            )
+        assert (layer.b.shape.eval() == (5, 4, 5)).all()
+
+    def test_get_params(self, layer):
+        assert layer.get_params() == [layer.W, layer.b]
+        assert layer.get_params(regularizable=False) == [layer.b]
+        assert layer.get_params(regularizable=True) == [layer.W]
+        assert layer.get_params(trainable=True) == [layer.W, layer.b]
+        assert layer.get_params(trainable=False) == []
+        assert layer.get_params(_nonexistent_tag=True) == []
+        assert layer.get_params(_nonexistent_tag=False) == [layer.W, layer.b]
+
+    def test_get_output_shape_for(self, layer):
+        assert layer.get_output_shape_for((5, 6, 7, 8)) == (5, 5, 7, 8)
+
+    @pytest.mark.parametrize("extra_kwargs", [
+        {},
+        {'untie_biases': True},
+        {'b': None},
+    ])
+    def test_get_output_for(self, dummy_input_layer, extra_kwargs):
+        from lasagne.layers.dense import NINLayer
+        nonlinearity = Mock()
+
+        layer = NINLayer(
+            dummy_input_layer,
+            num_units=6,
+            nonlinearity=nonlinearity,
+            **extra_kwargs
+            )
+
+        input = theano.shared(np.random.uniform(-1, 1, (2, 3, 4, 5)))
+        result = layer.get_output_for(input)
+        assert result is nonlinearity.return_value
+
+        nonlinearity_arg = nonlinearity.call_args[0][0]
+        X = input.get_value()
+        X = np.rollaxis(X, 1).T
+        X = np.dot(X, layer.W.get_value())
+        if layer.b is not None:
+            if layer.untie_biases:
+                X += layer.b.get_value()[:, np.newaxis].T
+            else:
+                X += layer.b.get_value()
+        X = np.rollaxis(X.T, 0, 2)
+        assert (nonlinearity_arg.eval() == X).all()
+
+    def test_param_names(self, layer):
+        assert layer.W.name == "W"
+        assert layer.b.name == "b"
+
+    def test_named_layer_param_names(self, NINLayer, dummy_input_layer):
+        layer = NINLayer(
             dummy_input_layer,
             num_units=3,
             name="foo"

--- a/lasagne/tests/layers/test_input.py
+++ b/lasagne/tests/layers/test_input.py
@@ -1,4 +1,3 @@
-import numpy
 import pytest
 import theano
 
@@ -25,3 +24,10 @@ class TestInputLayer:
 
     def test_get_params(self, layer):
         assert layer.get_params() == []
+
+    def test_bad_shape_fails(self):
+        from lasagne.layers.input import InputLayer
+        input_var = theano.tensor.tensor4()
+
+        with pytest.raises(ValueError):
+            InputLayer((3, 2), input_var)

--- a/lasagne/tests/layers/test_merge.py
+++ b/lasagne/tests/layers/test_merge.py
@@ -10,6 +10,11 @@ class TestConcatLayer:
         from lasagne.layers.merge import ConcatLayer
         return ConcatLayer([Mock(), Mock()], axis=1)
 
+    def test_get_output_shape_for(self, layer):
+        input_shapes = [(3, 2), (3, 5)]
+        result = layer.get_output_shape_for(input_shapes)
+        assert result == (3, 7)
+
     def test_get_output_for(self, layer):
         inputs = [theano.shared(numpy.ones((3, 3))),
                   theano.shared(numpy.ones((3, 2)))]
@@ -34,3 +39,13 @@ class TestElemwiseSumLayer:
         result_eval = result.eval()
         desired_result = 2*a - b
         assert (result_eval == desired_result).all()
+
+    def test_bad_coeffs_fails(self, layer):
+        from lasagne.layers.merge import ElemwiseSumLayer
+        with pytest.raises(ValueError):
+            ElemwiseSumLayer([Mock(), Mock()], coeffs=[2, 3, -1])
+
+    def test_get_output_shape_for_fails(self, layer):
+        input_shapes = [(3, 2), (3, 5)]
+        with pytest.raises(ValueError):
+            layer.get_output_shape_for(input_shapes)

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -83,17 +83,19 @@ class TestLocalResponseNormalization2DLayer:
         return np.random.RandomState([2013, 2])
 
     @pytest.fixture
-    def input_data(self, input_layer, rng):
-        return rng.randn(*input_layer.shape).astype(theano.config.floatX)
-
-    @pytest.fixture
-    def input_layer(self):
-        from lasagne.layers.input import InputLayer
+    def input_data(self, rng):
         channels = 15
         rows = 3
         cols = 4
         batch_size = 2
         shape = (batch_size, channels, rows, cols)
+        return rng.randn(*shape).astype(theano.config.floatX)
+
+    @pytest.fixture
+    def input_layer(self, input_data):
+        from lasagne.layers.input import InputLayer
+        shape = list(input_data.shape)
+        shape[0] = None
         return InputLayer(shape)
 
     @pytest.fixture
@@ -111,6 +113,16 @@ class TestLocalResponseNormalization2DLayer:
 
     def test_get_params(self, layer):
         assert layer.get_params() == []
+
+    def test_get_output_shape_for(self, layer):
+        assert layer.get_output_shape_for((1, 2, 3, 4)) == (1, 2, 3, 4)
+
+    def test_even_n_fails(self, input_layer):
+        from lasagne.layers.normalization import\
+                LocalResponseNormalization2DLayer
+
+        with pytest.raises(NotImplementedError):
+            LocalResponseNormalization2DLayer(input_layer, n=4)
 
     def test_normalization(self, input_data, input_layer, layer):
         X = input_layer.input_var

--- a/lasagne/tests/test_nonlinearities.py
+++ b/lasagne/tests/test_nonlinearities.py
@@ -1,17 +1,50 @@
+import pytest
 import numpy as np
+import theano.tensor as T
 
 
-def test_rectify():
-    from lasagne.nonlinearities import rectify
-    assert [rectify(x) for x in (-1, 0, 1, 2)] == [0, 0, 1, 2]
+class TestNonlinearities(object):
+    def linear(self, x):
+        return x
 
+    def rectify(self, x):
+        return x * (x > 0)
 
-def test_leaky_rectify():
-    from lasagne.nonlinearities import LeakyRectify
-    lr = LeakyRectify(0.1)
-    assert np.allclose(lr(np.array([-1, 0, 1, 2])), [-.1, 0, 1, 2])
+    def leaky_rectify(self, x):
+        return x * (x > 0) + 0.01 * x * (x < 0)
 
+    def leaky_rectify_0(self, x):
+        return self.rectify(x)
 
-def test_linear():
-    from lasagne.nonlinearities import linear
-    assert [linear(x) for x in (-1, 0, 1, 2)] == [-1, 0, 1, 2]
+    def sigmoid(self, x):
+        return 1 / (1 + np.exp(-x))
+
+    def tanh(self, x):
+        return np.tanh(x)
+
+    def softmax(self, x):
+        return (np.exp(x).T / np.exp(x).sum(-1)).T
+
+    @pytest.mark.parametrize('nonlinearity',
+                             ['linear', 'rectify',
+                              'leaky_rectify', 'sigmoid',
+                              'tanh', 'softmax',
+                              'leaky_rectify_0'])
+    def test_nonlinearity(self, nonlinearity):
+        import lasagne.nonlinearities
+
+        if nonlinearity == 'leaky_rectify_0':
+            from lasagne.nonlinearities import LeakyRectify
+            theano_nonlinearity = LeakyRectify(leakiness=0)
+        else:
+            theano_nonlinearity = getattr(lasagne.nonlinearities,
+                                          nonlinearity)
+        np_nonlinearity = getattr(self, nonlinearity)
+
+        X = T.matrix()
+        X0 = lasagne.utils.floatX(np.random.uniform(-3, 3, (10, 10)))
+
+        theano_result = theano_nonlinearity(X).eval({X: X0})
+        np_result = np_nonlinearity(X0)
+
+        assert np.allclose(theano_result, np_result)

--- a/lasagne/tests/test_theano_extensions.py
+++ b/lasagne/tests/test_theano_extensions.py
@@ -1,0 +1,100 @@
+import pytest
+import numpy as np
+import theano.tensor as T
+import lasagne
+
+
+@pytest.mark.parametrize('impl', ['conv1d_sc', 'conv1d_mc0',
+                                  'conv1d_mc1', 'conv1d_unstrided',
+                                  'conv1d_sd', 'conv1d_md'])
+@pytest.mark.parametrize('stride', [1, 2])
+def test_conv(impl, stride):
+    import lasagne.theano_extensions.conv
+    conv = getattr(lasagne.theano_extensions.conv, impl)
+
+    X = T.tensor3()
+    W = T.tensor3()
+    input = lasagne.utils.floatX(np.ones((1, 1, 10)))
+    kernel = lasagne.utils.floatX(np.random.uniform(-1, 1, (2, 1, 6)))
+
+    conv_theano = conv(X, W, input.shape, kernel.shape, subsample=(stride,)
+                       ).eval({X: input, W: kernel})
+
+    output = []
+    for b in input:
+        temp = []
+        for c in kernel:
+            temp.append(
+                np.convolve(b[0, :], c[0, :], mode='valid'))
+        output.append(temp)
+    conv_np = np.array(output)[:, :, ::stride]
+
+    assert np.allclose(conv_theano, conv_np)
+
+
+@pytest.mark.parametrize('impl', ['conv1d_sc', 'conv1d_mc0', 'conv1d_mc1'])
+def test_conv_nones(impl):
+    import lasagne.theano_extensions.conv
+    conv = getattr(lasagne.theano_extensions.conv, impl)
+
+    X = T.tensor3()
+    W = T.tensor3()
+    input = lasagne.utils.floatX(np.ones((1, 1, 12)))
+    kernel = lasagne.utils.floatX(np.random.uniform(-1, 1, (2, 1, 3)))
+
+    conv_theano = conv(X, W, None, None).eval({
+        X: input, W: kernel
+        })
+
+    output = []
+    for b in input:
+        temp = []
+        for c in kernel:
+            temp.append(
+                np.convolve(b[0, :], c[0, :], mode='valid'))
+        output.append(temp)
+    conv_np = np.array(output)
+
+    assert np.allclose(conv_theano, conv_np)
+
+
+@pytest.mark.parametrize('impl', ['conv1d_sc', 'conv1d_mc0',
+                                  'conv1d_mc1', 'conv1d_unstrided',
+                                  'conv1d_sd', 'conv1d_md'])
+def test_conv_border_mode(impl):
+    import lasagne.theano_extensions.conv
+    conv = getattr(lasagne.theano_extensions.conv, impl)
+
+    X = T.tensor3()
+    W = T.tensor3()
+
+    with pytest.raises(Exception):
+        conv(X, W, (1, 1, 10), (2, 1, 3), border_mode=None)
+
+
+@pytest.mark.parametrize('impl', ['conv1d_unstrided', 'conv1d_sd',
+                                  'conv1d_md'])
+def test_conv_stride(impl):
+    import lasagne.theano_extensions.conv
+    conv = getattr(lasagne.theano_extensions.conv, impl)
+
+    X = T.tensor3()
+    W = T.tensor3()
+
+    with pytest.raises(Exception):
+        conv(X, W, (1, 1, 10), (2, 1, 3), subsample=(2,))
+
+
+@pytest.mark.parametrize('val', [0, 7])
+def test_pad(val, width=3, batch_ndim=2):
+    from lasagne.theano_extensions.padding import pad
+
+    X = T.tensor4()
+    X0 = lasagne.utils.floatX(np.ones((2, 3, 4, 5)))
+    X_pad_theano = pad(X, width, val, batch_ndim).eval({X: X0})
+
+    pads = tuple((width, width) if i >= batch_ndim else (0, 0)
+                 for i, _ in enumerate(X0.shape))
+    X_pad_np = np.pad(X0, pads, mode='constant', constant_values=val)
+
+    assert (X_pad_theano == X_pad_np).all()

--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -4,6 +4,35 @@ import numpy as np
 import theano
 
 
+def test_shared_empty():
+    from lasagne.utils import shared_empty
+
+    X = shared_empty(3)
+    assert (np.zeros((1, 1, 1)) == X.eval()).all()
+
+
+def test_as_theano_expression_fails():
+    from lasagne.utils import as_theano_expression
+    with pytest.raises(TypeError):
+        as_theano_expression({})
+
+
+def test_one_hot():
+    from lasagne.utils import one_hot
+    a = np.random.randint(0, 10, 20)
+    b = np.zeros((a.size, a.max()+1))
+    b[np.arange(a.size), a] = 1
+
+    result = one_hot(a).eval()
+    assert (result == b).all()
+
+
+def test_as_tuple_fails():
+    from lasagne.utils import as_tuple
+    with pytest.raises(ValueError):
+        as_tuple([1, 2, 3], 4)
+
+
 def test_compute_norms():
     from lasagne.utils import compute_norms
 
@@ -35,6 +64,22 @@ def test_compute_norms_ndim6_raises():
         compute_norms(array)
 
     assert "Unsupported tensor dimensionality" in str(excinfo.value)
+
+
+def test_create_param_bad_callable_raises():
+    from lasagne.utils import create_param
+
+    with pytest.raises(RuntimeError):
+        create_param(lambda x: {}, (1, 2, 3))
+    with pytest.raises(RuntimeError):
+        create_param(lambda x: np.array(1), (1, 2, 3))
+
+
+def test_create_param_bad_spec_raises():
+    from lasagne.utils import create_param
+
+    with pytest.raises(RuntimeError):
+        create_param({}, (1, 2, 3))
 
 
 def test_create_param_numpy_bad_shape_raises_error():


### PR DESCRIPTION
This brings the coverage of `dense.py` to 100%, adding tests for `NINLayer` and `NonlinearityLayer` and some small additions to `DenseLayer`. 

Also fixes a minor bug in `NINLayer`.