### PR TITLE
Updates test coverage

### DIFF
--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -1,6 +1,63 @@
 import pytest
+import numpy as np
+import theano
+import lasagne
 
 PCT_TOLERANCE = 1E-5
+
+
+class TestUpdateFunctions(object):
+    # These tests compare results on a toy problem
+    # to values calculated by the torch.optim package
+    torch_values = {'sgd': [0.81707280688755,
+                            0.6648326359915,
+                            0.5386151140949],
+                    'momentum': [0.6848486952183,
+                                 0.44803321781003,
+                                 0.27431190123502],
+                    'nesterov_momentum': [0.67466543592725,
+                                          0.44108468114241,
+                                          0.2769002108997],
+                    'adagrad': [0.55373120047759,
+                                0.55373120041518,
+                                0.55373120039438],
+                    'rmsprop': [0.83205403985348,
+                                0.83205322744821,
+                                0.83205295664444],
+                    'adadelta': [0.95453237704725,
+                                 0.9545237471374,
+                                 0.95452214847397],
+                    'adam': [0.90034972009036,
+                             0.90034967993061,
+                             0.90034966654402],
+                    }
+
+    def f(self, X):
+        return ([0.1, 0.2, 0.3] * X**2).sum()
+
+    @pytest.mark.parametrize('method, kwargs', [
+        ['sgd', {'learning_rate': 0.1}],
+        ['momentum', {'learning_rate': 0.1, 'momentum': 0.5}],
+        ['nesterov_momentum', {'learning_rate': 0.1, 'momentum': 0.5}],
+        ['adagrad', {'learning_rate': 0.1}],
+        ['rmsprop', {'learning_rate': 0.01}],
+        ['adadelta', {}],
+        ['adam', {'learning_rate': 0.01}],
+        ])
+    def test_updates(self, method, kwargs):
+        A = theano.shared(lasagne.utils.floatX([1, 1, 1]))
+        B = theano.shared(lasagne.utils.floatX([1, 1, 1]))
+        update_func = getattr(lasagne.updates, method)
+        updates = update_func(self.f(A) + self.f(B),
+                              [A, B],
+                              **kwargs)
+        do_update = theano.function([], [], updates=updates)
+
+        for _ in range(10):
+            do_update()
+
+        assert np.allclose(A.get_value(), B.get_value())
+        assert np.allclose(A.get_value(), self.torch_values[method])
 
 
 def test_norm_constraint():

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -559,7 +559,7 @@ def adam(loss_or_grads, params, learning_rate=0.001, beta1=0.9,
         t = t_prev + 1
         m_t = beta1*m_prev + (1-beta1)*g_t
         v_t = beta2*v_prev + (1-beta2)*g_t**2
-        a_t = learning_rate*T.sqrt(1-beta2**2)/(1-beta1**2)
+        a_t = learning_rate*T.sqrt(1-beta2**t)/(1-beta1**t)
         step = a_t*m_t/(T.sqrt(v_t) + epsilon)
 
         updates.append((m_prev, m_t))


### PR DESCRIPTION
To add some coverage of the update rules, I wrote a test comparing their results to values calculated using the Torch optim package. 

In the process, I found a discrepancy with the ADAM updates, after looking at the paper I think the Torch version is correct but I'd appreciate a second opinion.