### PR TITLE
increase coverage for convolution layers

### DIFF
--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -203,14 +203,19 @@ class Conv1DLayer(Layer):
         self.untie_biases = untie_biases
         self.convolution = convolution
 
+        if self.border_mode not in ['valid', 'full', 'same']:
+            raise RuntimeError("Invalid border mode: '%s'" % self.border_mode)
+
         self.W = self.add_param(W, self.get_W_shape(), name="W")
         if b is None:
             self.b = None
-        elif self.untie_biases:
-            biases_shape = (num_filters, self.output_shape[2])
         else:
-            biases_shape = (num_filters,)
-        self.b = self.add_param(b, biases_shape, name="b", regularizable=False)
+            if self.untie_biases:
+                biases_shape = (num_filters, self.output_shape[2])
+            else:
+                biases_shape = (num_filters,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
 
     def get_W_shape(self):
         """Get the shape of the weight matrix `W`.
@@ -256,8 +261,6 @@ class Conv1DLayer(Layer):
                                       border_mode='full')
             shift = (self.filter_size[0] - 1) // 2
             conved = conved[:, :, shift:input.shape[2] + shift]
-        else:
-            raise RuntimeError("Invalid border mode: '%s'" % self.border_mode)
 
         if self.b is None:
             activation = conved
@@ -382,15 +385,20 @@ class Conv2DLayer(Layer):
         self.untie_biases = untie_biases
         self.convolution = convolution
 
+        if self.border_mode not in ['valid', 'full', 'same']:
+            raise RuntimeError("Invalid border mode: '%s'" % self.border_mode)
+
         self.W = self.add_param(W, self.get_W_shape(), name="W")
         if b is None:
             self.b = None
-        elif self.untie_biases:
-            biases_shape = (num_filters, self.output_shape[2], self.
-                            output_shape[3])
         else:
-            biases_shape = (num_filters,)
-        self.b = self.add_param(b, biases_shape, name="b", regularizable=False)
+            if self.untie_biases:
+                biases_shape = (num_filters, self.output_shape[2], self.
+                                output_shape[3])
+            else:
+                biases_shape = (num_filters,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
 
     def get_W_shape(self):
         """Get the shape of the weight matrix `W`.
@@ -444,8 +452,6 @@ class Conv2DLayer(Layer):
             shift_y = (self.filter_size[1] - 1) // 2
             conved = conved[:, :, shift_x:input.shape[2] + shift_x,
                             shift_y:input.shape[3] + shift_y]
-        else:
-            raise RuntimeError("Invalid border mode: '%s'" % self.border_mode)
 
         if self.b is None:
             activation = conved

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 
-if not theano.config.device.startswith("gpu"):
+if not theano.config.device.startswith("gpu"):  # pragma: no cover
     raise ImportError("requires a GPU to work")
 
 

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -167,20 +167,21 @@ class Conv2DMMLayer(MMLayer):
                 self.pad = ((self.filter_size[0] - 1) // 2,
                             (self.filter_size[1] - 1) // 2)
             else:
-                raise RuntimeError("Unsupported border_mode for "
-                                   "Conv2DMMLayer: %s" % border_mode)
+                raise RuntimeError("Invalid border mode: '%s'" % border_mode)
         else:
             self.pad = as_tuple(pad, 2)
 
         self.W = self.add_param(W, self.get_W_shape(), name="W")
         if b is None:
             self.b = None
-        elif self.untie_biases:
-            biases_shape = (num_filters, self.output_shape[2],
-                            self.output_shape[3])
         else:
-            biases_shape = (num_filters,)
-        self.b = self.add_param(b, biases_shape, name="b", regularizable=False)
+            if self.untie_biases:
+                biases_shape = (num_filters, self.output_shape[2],
+                                self.output_shape[3])
+            else:
+                biases_shape = (num_filters,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
 
         self.corr_mm_op = GpuCorrMM(subsample=self.stride, pad=self.pad)
 

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -19,7 +19,7 @@ __all__ = [
 
 
 if not theano.config.device.startswith("gpu"):
-    raise ImportError("requires a GPU to work")
+    raise ImportError("requires a GPU to work")  # pragma: no cover
 
 
 # base class for all layers that rely on GpuCorrMM directly

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 
-if not theano.config.device.startswith("gpu"):  # pragma: no cover
+if not theano.config.device.startswith("gpu"):
     raise ImportError("requires a GPU to work")
 
 

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -466,7 +466,7 @@ class MaxPool2DCCLayer(CCLayer):
             stride = as_tuple(stride, 2)
             if stride[0] != stride[1]:
                 raise NotImplementedError("MaxPool2DCCLayer only supports "
-                                          "using the same stride in both, "
+                                          "using the same stride in both "
                                           "directions but stride=(%d, %d)"
                                           % stride)
             self.stride = stride[0]

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -26,7 +26,7 @@ __all__ = [
 
 
 if not theano.config.device.startswith("gpu"):
-    raise ImportError("requires a GPU to work")
+    raise ImportError("requires a GPU to work")  # pragma: no cover
 
 
 # base class for all layers that use ops from pylearn2.sandbox.cuda_convnet

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -256,7 +256,11 @@ class Conv2DCCLayer(CCLayer):
             else:
                 raise RuntimeError("Invalid border mode: '%s'" % border_mode)
         else:
-            self.pad = pad
+            pad = as_tuple(pad, 2)
+            if pad[0] != pad[1]:
+                raise RuntimeError("Conv2DCCLayer only supports square "
+                                   "padding, but pad=(%d, %d)" % pad)
+            self.pad = pad[0]
 
         if W is None:
             if dimshuffle:

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -254,8 +254,7 @@ class Conv2DCCLayer(CCLayer):
                 # is probably not worth supporting.
                 self.pad = (self.filter_size - 1) // 2
             else:
-                raise RuntimeError("Unsupported border_mode for "
-                                   "Conv2DCCLayer: %s" % border_mode)
+                raise RuntimeError("Invalid border mode: '%s'" % border_mode)
         else:
             self.pad = pad
 
@@ -268,16 +267,18 @@ class Conv2DCCLayer(CCLayer):
         self.W = self.add_param(W, self.get_W_shape(), name="W")
         if b is None:
             self.b = None
-        elif self.untie_biases:
-            if self.dimshuffle:
-                biases_shape = (num_filters, self.output_shape[2],
-                                self.output_shape[3])
-            else:
-                biases_shape = (num_filters, self.output_shape[1],
-                                self.output_shape[2])
         else:
-            biases_shape = (num_filters,)
-        self.b = self.add_param(b, biases_shape, name="b", regularizable=False)
+            if self.untie_biases:
+                if self.dimshuffle:
+                    biases_shape = (num_filters, self.output_shape[2],
+                                    self.output_shape[3])
+                else:
+                    biases_shape = (num_filters, self.output_shape[1],
+                                    self.output_shape[2])
+            else:
+                biases_shape = (num_filters,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
 
         self.filter_acts_op = FilterActs(
             stride=self.stride, partial_sum=self.partial_sum, pad=self.pad)

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -622,7 +622,7 @@ class NINLayer_c01b(Layer):
         Any additional keyword arguments are passed to the `Layer` superclass.
     """
     def __init__(self, incoming, num_units, untie_biases=False,
-                 W=init.GlorotUniform(c01b=True), b=init.Constant(0.),
+                 W=init.GlorotUniform(), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify, **kwargs):
         super(NINLayer_c01b, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
@@ -638,11 +638,13 @@ class NINLayer_c01b(Layer):
         self.W = self.add_param(W, (num_units, num_input_channels), name="W")
         if b is None:
             self.b = None
-        elif self.untie_biases:
-            biases_shape = (num_units,) + self.output_shape[1:-1]
         else:
-            biases_shape = (num_units,)
-        self.b = self.add_param(b, biases_shape, name="b", regularizable=False)
+            if self.untie_biases:
+                biases_shape = (num_units,) + self.output_shape[1:-1]
+            else:
+                biases_shape = (num_units,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
 
     def get_output_shape_for(self, input_shape):
         return (self.num_units,) + input_shape[1:]

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -9,7 +9,7 @@ from .conv import conv_output_length
 from ..utils import as_tuple
 
 if not theano.config.device.startswith("gpu") or not dnn.dnn_available():
-    raise ImportError("dnn not available")
+    raise ImportError("dnn not available")  # pragma: no cover
 
 
 __all__ = [

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -244,8 +244,7 @@ class Conv2DDNNLayer(DNNLayer):
                             (self.filter_size[1] - 1) // 2)
                 self.border_mode = None
             else:
-                raise RuntimeError("Unsupported border_mode for "
-                                   "Conv2DDNNLayer: %s" % border_mode)
+                raise RuntimeError("Invalid border mode: '%s'" % border_mode)
         else:
             self.pad = as_tuple(pad, 2)
             self.border_mode = None
@@ -253,12 +252,14 @@ class Conv2DDNNLayer(DNNLayer):
         self.W = self.add_param(W, self.get_W_shape(), name="W")
         if b is None:
             self.b = None
-        elif self.untie_biases:
-            biases_shape = (num_filters, self.output_shape[2],
-                            self.output_shape[3])
         else:
-            biases_shape = (num_filters,)
-        self.b = self.add_param(b, biases_shape, name="b", regularizable=False)
+            if self.untie_biases:
+                biases_shape = (num_filters, self.output_shape[2],
+                                self.output_shape[3])
+            else:
+                biases_shape = (num_filters,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
 
     def get_W_shape(self):
         num_input_channels = self.input_shape[1]

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -124,7 +124,7 @@ class TestConv1DLayer:
         with pytest.raises(RuntimeError) as exc:
             layer = Conv1DLayer(input_layer, num_filters=16, filter_size=(3,),
                                 border_mode='_nonexistent_mode')
-        assert "Invalid border mode" in exc.value.message
+        assert "Invalid border mode" in exc.value.args[0]
 
 
 class TestConv2DLayerImplementations:
@@ -221,7 +221,7 @@ class TestConv2DLayerImplementations:
         with pytest.raises(RuntimeError) as exc:
             layer = Conv2DImpl(input_layer, num_filters=16, filter_size=(3, 3),
                                border_mode='_nonexistent_mode')
-        assert "Invalid border mode" in exc.value.message
+        assert "Invalid border mode" in exc.value.args[0]
 
 
 class TestConvOutputLength:
@@ -229,4 +229,4 @@ class TestConvOutputLength:
         from lasagne.layers.conv import conv_output_length
         with pytest.raises(RuntimeError) as exc:
             conv_output_length(5, 3, 1, border_mode='_nonexistent_mode')
-        assert "Invalid border mode" in exc.value.message
+        assert "Invalid border mode" in exc.value.args[0]

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -259,6 +259,34 @@ class TestConvOutputLength:
         assert "Invalid border mode" in exc.value.args[0]
 
 
+class TestConv2DDNNLayer:
+    def test_import_without_gpu_or_cudnn_raises(self):
+        from theano.sandbox.cuda import dnn
+        if theano.config.device.startswith("gpu") and dnn.dnn_available():
+            pytest.skip()
+        else:
+            with pytest.raises(ImportError):
+                import lasagne.layers.dnn
+
+    def test_pad(self, DummyInputLayer):
+        try:
+            from lasagne.layers.dnn import Conv2DDNNLayer
+        except ImportError:
+            pytest.skip("dnn not available")
+
+        input_layer = DummyInputLayer((1, 2, 3, 3))
+        with pytest.raises(RuntimeError) as exc:
+            layer = Conv2DDNNLayer(input_layer, num_filters=1,
+                                   filter_size=(3, 3), border_mode='valid',
+                                   pad=(1, 1))
+        assert ("You cannot specify both 'border_mode' and 'pad'" in
+                exc.value.args[0])
+
+        layer = Conv2DDNNLayer(input_layer, num_filters=4, filter_size=(3, 3),
+                               pad=(3, 3))
+        assert layer.output_shape == (1, 4, 7, 7)
+
+
 class TestConv2DMMLayer:
     def test_import_without_gpu_raises(self):
         if theano.config.device.startswith("gpu"):

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -391,7 +391,10 @@ class TestConv2DCCLayer:
 class TestShuffleLayers:
     def test_bc01_to_c01b(self):
         from lasagne.layers.input import InputLayer
-        from lasagne.layers.cuda_convnet import ShuffleBC01ToC01BLayer
+        try:
+            from lasagne.layers.cuda_convnet import ShuffleBC01ToC01BLayer
+        except ImportError:
+            pytest.skip("cuda_convnet not available")
 
         input_layer = InputLayer((1, 2, 3, 4))
         layer = ShuffleBC01ToC01BLayer(input_layer)
@@ -404,7 +407,10 @@ class TestShuffleLayers:
 
     def test_c01b_to_bc01(self):
         from lasagne.layers.input import InputLayer
-        from lasagne.layers.cuda_convnet import ShuffleC01BToBC01Layer
+        try:
+            from lasagne.layers.cuda_convnet import ShuffleC01BToBC01Layer
+        except ImportError:
+            pytest.skip("cuda_convnet not available")
 
         input_layer = InputLayer((1, 2, 3, 4))
         layer = ShuffleC01BToBC01Layer(input_layer)

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -354,6 +354,14 @@ class TestConv2DCCLayer:
         assert ("Conv2DCCLayer only supports square padding" in
                 exc.value.args[0])
 
+        input_layer = DummyInputLayer((128, 7, 32, 32))
+
+        with pytest.raises(RuntimeError) as exc:
+            layer = Conv2DCCLayer(input_layer, num_filters=16,
+                                  filter_size=(3, 3))
+        assert ("Conv2DCCLayer requires the number of input channels to be "
+                "1, 2, 3 or a multiple of 4" in exc.value.args[0])
+
     def test_pad(self, DummyInputLayer):
         try:
             from lasagne.layers.cuda_convnet import Conv2DCCLayer
@@ -395,7 +403,9 @@ class TestConv2DCCLayer:
         except ImportError:
             pytest.skip("cuda_convnet not available")
 
-        # this implementation needs to be
+        # this implementation is tested against FilterActs instead of
+        # theano.tensor.nnet.conv.conv2d because using the latter leads to
+        # numerical precision errors.
         from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs
         filter_acts = FilterActs(stride=1, pad=0, partial_sum=1)
 


### PR DESCRIPTION
This PR does a few things:
* fixes a bug in all convolution implementations which made bias-less layers unusable (the same one that @ebenolson fixed in `NINLayer`, see https://github.com/ebenolson/Lasagne/commit/ffce108e87d4f14a7e2c2499bb4ccb1c9c86f02e)
* moves the `border_mode` validity check into the constructor for all layers, so constructing a layer with an invalid border mode string fails as early as possible (previously this check was in `get_output_for()` and `get_output_shape_for()` for a few implementations)
* adds tests for bias-less layers (`b=None`), linear layers (`nonlinearity=None`) and invalid border mode checks

It brings coverage for `lasagne/layers/conv.py` up to almost 100%. It falls just two lines short of that: the `b=None` case in `get_output_for()` is not covered for `Conv1DLayer` and `Conv2DLayer`. I'm not sure how to go about covering these two lines effectively. Adding the `b=None` case to all test configurations in `conv2d_test_sets()` seems wasteful, it will increase the test duration by a lot and the benefit is negligible. It seems like a single "output test" should be sufficient. Any ideas?

I'll try to get the coverage for `corrmm`, `dnn` and `cuda-convnet` up to 100% as well in this PR (at least the convolution parts, might leave the pooling parts for later).