### PR TITLE
Coverage for pool.py, helper.py

### DIFF
--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -116,7 +116,7 @@ def get_all_layers(layer, treat_as_input=None):
     return result
 
 
-def get_all_layers_old(layer):
+def get_all_layers_old(layer):  # pragma no cover
     """
     Earlier implementation of `get_all_layers()` that does a breadth-first
     search. Kept here to ease converting old models that rely on the order of
@@ -358,7 +358,7 @@ def get_all_params(layer, **tags):
     return utils.unique(params)
 
 
-def get_all_bias_params(layer):
+def get_all_bias_params(layer):  # pragma no cover
     import warnings
     warnings.warn("get_all_bias_params(layer) is deprecated and will be "
                   "removed for the first release of Lasagne. Please use "
@@ -366,7 +366,7 @@ def get_all_bias_params(layer):
     return get_all_params(layer, regularizable=False)
 
 
-def get_all_non_bias_params(layer):
+def get_all_non_bias_params(layer):  # pragma no cover
     import warnings
     warnings.warn("get_all_non_bias_params(layer) is deprecated and will be "
                   "removed for the first release of Lasagne. Please use "

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -293,18 +293,11 @@ def get_output_shape(layer_or_layers, input_shapes=None):
     # update layer-to-shape mapping by propagating the input shapes
     for layer in all_layers:
         if layer not in all_shapes:
-            try:
-                if isinstance(layer, MergeLayer):
-                    input_shapes = [all_shapes[input_layer]
-                                    for input_layer in layer.input_layers]
-                else:
-                    input_shapes = all_shapes[layer.input_layer]
-            except KeyError:
-                raise ValueError("get_output() was called without giving an "
-                                 "input shape for the free-floating layer %r. "
-                                 "Please call it with a dictionary mapping "
-                                 "this layer to an input shape."
-                                 % layer)
+            if isinstance(layer, MergeLayer):
+                input_shapes = [all_shapes[input_layer]
+                                for input_layer in layer.input_layers]
+            else:
+                input_shapes = all_shapes[layer.input_layer]
             all_shapes[layer] = layer.get_output_shape_for(input_shapes)
     # return the output shape(s) of the requested layer(s) only
     try:

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -278,9 +278,9 @@ class FeaturePoolLayer(Layer):
 
         num_feature_maps = self.input_shape[self.axis]
         if num_feature_maps % self.pool_size != 0:
-            raise RuntimeError("Number of input feature maps (%d) is not a "
-                               "multiple of the pool size (pool_size=%d)" %
-                               (num_feature_maps, self.pool_size))
+            raise ValueError("Number of input feature maps (%d) is not a "
+                             "multiple of the pool size (pool_size=%d)" %
+                             (num_feature_maps, self.pool_size))
 
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)  # make a mutable copy
@@ -335,9 +335,9 @@ class FeatureWTALayer(Layer):
 
         num_feature_maps = self.input_shape[self.axis]
         if num_feature_maps % self.pool_size != 0:
-            raise RuntimeError("Number of input feature maps (%d) is not a "
-                               "multiple of the region size (pool_size=%d)" %
-                               (num_feature_maps, self.pool_size))
+            raise ValueError("Number of input feature maps (%d) is not a "
+                             "multiple of the region size (pool_size=%d)" %
+                             (num_feature_maps, self.pool_size))
 
     def get_output_for(self, input, **kwargs):
         num_feature_maps = input.shape[self.axis]


### PR DESCRIPTION
Adds a few tests to complete coverage for pool.py, and adds `pragma no cover` for the deprecated helper functions.