### PR TITLE
Change stacklevel for deprecation warnings to point at function call

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -98,7 +98,7 @@ class Layer(object):
         import warnings
         warnings.warn("layer.get_output_shape() is deprecated and will be "
                       "removed for the first release of Lasagne. Please use "
-                      "layer.output_shape instead.")
+                      "layer.output_shape instead.", stacklevel=2)
         return self.output_shape
 
     def get_output(self, input=None, **kwargs):  # pragma: no cover
@@ -108,7 +108,8 @@ class Layer(object):
         import warnings
         warnings.warn("layer.get_output(...) is deprecated and will be "
                       "removed for the first release of Lasagne. Please use "
-                      "lasagne.layers.get_output(layer, ...) instead.")
+                      "lasagne.layers.get_output(layer, ...) instead.",
+                      stacklevel=2)
         from .helper import get_output
         return get_output(self, input, **kwargs)
 
@@ -237,7 +238,8 @@ class Layer(object):
         import warnings
         warnings.warn("layer.get_bias_params() is deprecated and will be "
                       "removed for the first release of Lasagne. Please use "
-                      "layer.get_params(regularizable=False) instead.")
+                      "layer.get_params(regularizable=False) instead.",
+                      stacklevel=2)
         return self.get_params(regularizable=False)
 
 

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -362,7 +362,8 @@ def get_all_bias_params(layer):
     import warnings
     warnings.warn("get_all_bias_params(layer) is deprecated and will be "
                   "removed for the first release of Lasagne. Please use "
-                  "get_all_params(layer, regularizable=False) instead.")
+                  "get_all_params(layer, regularizable=False) instead.",
+                  stacklevel=2)
     return get_all_params(layer, regularizable=False)
 
 
@@ -370,7 +371,8 @@ def get_all_non_bias_params(layer):
     import warnings
     warnings.warn("get_all_non_bias_params(layer) is deprecated and will be "
                   "removed for the first release of Lasagne. Please use "
-                  "get_all_params(layer, regularizable=True) instead.")
+                  "get_all_params(layer, regularizable=True) instead.",
+                  stacklevel=2)
     return get_all_params(layer, regularizable=True)
 
 


### PR DESCRIPTION
This sets `stacklevel=2` for the `get_output`, `get_output_shape` and `get_bias_params` deprecation warnings so they point at the offending deprecated function call (i.e., the point in code where you call a deprecated function) rather than the `warnings.warn` call (i.e., the point in Lasagne where we raise the warning). This makes it much easier to track down any remnants of the good old days, err, the old API in user code.