### PR TITLE
Make lasagne.utils.create_param() accept iterables as shapes

### DIFF
--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -82,6 +82,13 @@ def test_create_param_bad_spec_raises():
         create_param({}, (1, 2, 3))
 
 
+def test_create_param_accepts_iterable_shape():
+    from lasagne.utils import create_param
+    factory = np.empty
+    create_param(factory, [2, 3])
+    create_param(factory, (x for x in [2, 3]))
+
+
 def test_create_param_numpy_bad_shape_raises_error():
     from lasagne.utils import create_param
 

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -214,9 +214,8 @@ def create_param(spec, shape, name=None):
 
     Parameters
     ----------
-
     spec : numpy array, Theano shared variable, or callable
-        One of three things:
+        Either of the following:
 
         * a numpy array with the initial parameter values
         * a Theano shared variable representing the parameters
@@ -224,9 +223,9 @@ def create_param(spec, shape, name=None):
           the parameter array as its single argument and returns
           a numpy array.
 
-    shape : tuple
-        a tuple of integers representing the desired shape of the
-        parameter array.
+    shape : iterable of int
+        a tuple or other iterable of integers representing the desired
+        shape of the parameter array.
 
     name : string, optional
         If a new variable is created, the name to give to the parameter
@@ -244,11 +243,13 @@ def create_param(spec, shape, name=None):
 
     Notes
     -----
-    This method should be used in the constructor when creating a
-    :class:`Layer` subclass that has parameters. This enables the layer to
+    This function is called by :meth:`Layer.add_param()` in the constructor
+    of most :class:`Layer` subclasses. This enables those layers to
     support initialization with numpy arrays, existing Theano shared
     variables, and callables for generating initial parameter values.
     """
+    shape = tuple(shape)  # convert to tuple if needed
+
     if isinstance(spec, theano.compile.SharedVariable):
         # We cannot check the shape here, the shared variable might not be
         # initialized correctly yet. We can check the dimensionality


### PR DESCRIPTION
This changes `lasagne.utils.create_param()` to accept arbitrary iterables as shapes, not only tuples. Before, when giving a `list` as a shape, the function would fail with an unhelpful "the provided callable did not return a value with the correct shape", because the list was later compared against a tuple. (I'd also be fine with a meaningful error message, but adding `shape = tuple(shape)` is easy enough and more convenient.)

Besides, I've changed the "Notes" section, which still assumed that `create_param()` was a `Layer` method.