### PR TITLE
Shape error message

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -41,6 +41,12 @@ class Layer(object):
         self.name = name
         self.params = OrderedDict()
 
+        if any(d is not None and d <= 0 for d in self.input_shape):
+            raise ValueError((
+                "Cannot create Layer with a non-positive input_shape "
+                "dimension. input_shape=%r, self.name=%r") % (
+                    self.input_shape, self.name))
+
     @property
     def output_shape(self):
         return self.get_output_shape_for(self.input_shape)

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -8,12 +8,12 @@ class TestLayer:
     @pytest.fixture
     def layer(self):
         from lasagne.layers.base import Layer
-        return Layer(Mock())
+        return Layer(Mock(output_shape=(None,)))
 
     @pytest.fixture
     def named_layer(self):
         from lasagne.layers.base import Layer
-        return Layer(Mock(), name='layer_name')
+        return Layer(Mock(output_shape=(None,)), name='layer_name')
 
     def test_input_shape(self, layer):
         assert layer.input_shape == layer.input_layer.output_shape
@@ -97,6 +97,17 @@ class TestLayer:
         with pytest.raises(NotImplementedError):
             layer.get_output_for(Mock())
 
+    def test_nonpositive_input_dims_raises_value_error(self, layer):
+        from lasagne.layers.base import Layer
+        neg_input_layer = Mock(output_shape=(None, -1, -1))
+        zero_input_layer = Mock(output_shape=(None, 0, 0))
+        pos_input_layer = Mock(output_shape=(None, 1, 1))
+        with pytest.raises(ValueError):
+            Layer(neg_input_layer)
+        with pytest.raises(ValueError):
+            Layer(zero_input_layer)
+        Layer(pos_input_layer)
+
 
 class TestMergeLayer:
     @pytest.fixture
@@ -112,7 +123,10 @@ class TestMergeLayer:
     def layer_from_shape(self):
         from lasagne.layers.input import InputLayer
         from lasagne.layers.base import MergeLayer
-        return MergeLayer([(None, 20), Mock(InputLayer((None,)))])
+        return MergeLayer(
+            [(None, 20),
+             Mock(InputLayer((None,)), output_shape=(None,))]
+        )
 
     def test_layer_from_shape(self, layer_from_shape):
         layer = layer_from_shape

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -122,13 +122,13 @@ class TestGetOutput_Layer:
         from lasagne.layers.base import Layer
         from lasagne.layers.input import InputLayer
         # create a mock that has the same attributes as an InputLayer instance
-        l1 = Mock(InputLayer((None,)))
+        l1 = Mock(InputLayer((None,)), output_shape=(None,))
         # create a mock that has the same attributes as a Layer instance
-        l2 = Mock(Layer(l1))
+        l2 = Mock(Layer(l1), output_shape=(None,))
         # link it to the InputLayer mock
         l2.input_layer = l1
         # create another mock that has the same attributes as a Layer instance
-        l3 = Mock(Layer(l2))
+        l3 = Mock(Layer(l2), output_shape=(None,))
         # link it to the first mock, to get an "l1 --> l2 --> l3" chain
         l3.input_layer = l2
         return l1, l2, l3
@@ -263,9 +263,11 @@ class TestGetOutput_MergeLayer:
         from lasagne.layers.base import Layer, MergeLayer
         from lasagne.layers.input import InputLayer
         # create two mocks of the same attributes as an InputLayer instance
-        l1 = [Mock(InputLayer((None,))), Mock(InputLayer((None,)))]
+        l1 = [Mock(InputLayer((None,)), output_shape=(None,)),
+              Mock(InputLayer((None,)), output_shape=(None,))]
         # create two mocks of the same attributes as a Layer instance
-        l2 = [Mock(Layer(l1[0])), Mock(Layer(l1[1]))]
+        l2 = [Mock(Layer(l1[0]), output_shape=(None,)),
+              Mock(Layer(l1[1]), output_shape=(None,))]
         # link them to the InputLayer mocks
         l2[0].input_layer = l1[0]
         l2[1].input_layer = l1[1]
@@ -397,7 +399,9 @@ class TestGetOutput_MergeLayer:
     def layer_from_shape(self):
         from lasagne.layers.input import InputLayer
         from lasagne.layers.base import MergeLayer
-        return MergeLayer([(None, 20), Mock(InputLayer((None,)))])
+        return MergeLayer([
+            (None, 20),
+            Mock(InputLayer((None,)), output_shape=(None,))])
 
     def test_layer_from_shape_invalid_get_output(self, layer_from_shape,
                                                  get_output):
@@ -456,13 +460,13 @@ class TestGetOutputShape_Layer:
         from lasagne.layers.base import Layer
         from lasagne.layers.input import InputLayer
         # create a mock that has the same attributes as an InputLayer instance
-        l1 = Mock(InputLayer((None,)))
+        l1 = Mock(InputLayer((None,)), output_shape=(None,))
         # create a mock that has the same attributes as a Layer instance
-        l2 = Mock(Layer(l1))
+        l2 = Mock(Layer(l1), output_shape=(None,))
         # link it to the InputLayer mock
         l2.input_layer = l1
         # create another mock that has the same attributes as a Layer instance
-        l3 = Mock(Layer(l2))
+        l3 = Mock(Layer(l2), output_shape=(None,))
         # link it to the first mock, to get an "l1 --> l2 --> l3" chain
         l3.input_layer = l2
         return l1, l2, l3
@@ -562,9 +566,11 @@ class TestGetOutputShape_MergeLayer:
         from lasagne.layers.base import Layer, MergeLayer
         from lasagne.layers.input import InputLayer
         # create two mocks of the same attributes as an InputLayer instance
-        l1 = [Mock(InputLayer((None,))), Mock(InputLayer((None,)))]
+        l1 = [Mock(InputLayer((None,)), output_shape=(None,)),
+              Mock(InputLayer((None,)), output_shape=(None,))]
         # create two mocks of the same attributes as a Layer instance
-        l2 = [Mock(Layer(l1[0])), Mock(Layer(l1[1]))]
+        l2 = [Mock(Layer(l1[0]), output_shape=(None,)),
+              Mock(Layer(l1[1]), output_shape=(None,))]
         # link them to the InputLayer mocks
         l2[0].input_layer = l1[0]
         l2[1].input_layer = l1[1]
@@ -656,7 +662,9 @@ class TestGetOutputShape_MergeLayer:
     def layer_from_shape(self):
         from lasagne.layers.input import InputLayer
         from lasagne.layers.base import MergeLayer
-        return MergeLayer([(None, 20), Mock(InputLayer((None,)))])
+        return MergeLayer([
+            (None, 20),
+            Mock(InputLayer((None,)), output_shape=(None,))])
 
     def test_layer_from_shape_valid_get_output_shape(self, layer_from_shape,
                                                      get_output_shape):

--- a/lasagne/tests/layers/test_noise.py
+++ b/lasagne/tests/layers/test_noise.py
@@ -57,7 +57,7 @@ class TestGaussianNoiseLayer:
     @pytest.fixture
     def layer(self):
         from lasagne.layers.noise import GaussianNoiseLayer
-        return GaussianNoiseLayer(Mock())
+        return GaussianNoiseLayer(Mock(output_shape=(None,)))
 
     def test_get_output_for_non_deterministic(self, layer):
         input = theano.shared(numpy.ones((100, 100)))

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -126,7 +126,7 @@ class TestMaxPool1DLayer:
                     yield (pool_size, stride, pad)
 
     def input_layer(self, output_shape):
-        return Mock(get_output_shape=lambda: output_shape)
+        return Mock(output_shape=output_shape)
 
     def layer(self, input_layer, pool_size, stride=None, pad=0):
         from lasagne.layers.pool import MaxPool1DLayer
@@ -202,7 +202,8 @@ class TestMaxPool2DLayer:
                     yield (pool_size, stride, pad)
 
     def input_layer(self, output_shape):
-        return Mock(get_output_shape=lambda: output_shape)
+        return Mock(get_output_shape=lambda: output_shape,
+                    output_shape=output_shape)
 
     def layer(self, input_layer, pool_size, stride=None,
               pad=(0, 0), ignore_border=False):
@@ -288,7 +289,8 @@ class TestMaxPool2DCCLayer:
                 yield (pool_size, stride)
 
     def input_layer(self, output_shape):
-        return Mock(get_output_shape=lambda: output_shape)
+        return Mock(get_output_shape=lambda: output_shape,
+                    output_shape=output_shape)
 
     def layer(self, input_layer, pool_size, stride):
         try:
@@ -398,7 +400,8 @@ class TestMaxPool2DNNLayer:
                     yield (pool_size, stride, pad)
 
     def input_layer(self, output_shape):
-        return Mock(get_output_shape=lambda: output_shape)
+        return Mock(get_output_shape=lambda: output_shape,
+                    output_shape=output_shape)
 
     def layer(self, input_layer, pool_size, stride, pad):
         try:
@@ -494,7 +497,7 @@ class TestGlobalPoolLayer(object):
 
     @pytest.fixture
     def layer(self, GlobalPoolLayer):
-        return GlobalPoolLayer(Mock())
+        return GlobalPoolLayer(Mock(output_shape=(None,)))
 
     def test_get_output_shape_for(self, layer):
         assert layer.get_output_shape_for((2, 3, 4, 5)) == (2, 3)

--- a/lasagne/tests/layers/test_shape.py
+++ b/lasagne/tests/layers/test_shape.py
@@ -9,7 +9,7 @@ class TestFlattenLayer:
     @pytest.fixture
     def layer(self):
         from lasagne.layers.shape import FlattenLayer
-        return FlattenLayer(Mock())
+        return FlattenLayer(Mock(output_shape=(None,)))
 
     def test_get_output_shape_for(self, layer):
         input_shape = (2, 3, 4, 5)
@@ -25,7 +25,7 @@ class TestPadLayer:
     @pytest.fixture
     def layer(self):
         from lasagne.layers.shape import PadLayer
-        return PadLayer(Mock(), width=2)
+        return PadLayer(Mock(output_shape=(None,)), width=2)
 
     def test_get_output_shape_for(self, layer):
         input_shape = (2, 3, 4, 5)

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -177,8 +177,8 @@ class TestObjectives:
         from lasagne.objectives import Objective
         from lasagne.layers.input import Layer, InputLayer
 
-        input_layer = mock.Mock(InputLayer((None,)))
-        layer = mock.Mock(Layer(input_layer))
+        input_layer = mock.Mock(InputLayer((None,)), output_shape=(None,))
+        layer = mock.Mock(Layer(input_layer), output_shape=(None,))
         layer.input_layer = input_layer
         loss_function = mock.Mock()
         input, target, kwarg1 = theano.tensor.vector(), object(), object()
@@ -200,8 +200,8 @@ class TestObjectives:
         from lasagne.objectives import Objective
         from lasagne.layers.input import Layer, InputLayer
 
-        input_layer = mock.Mock(InputLayer((None,)))
-        layer = mock.Mock(Layer(input_layer))
+        input_layer = mock.Mock(InputLayer((None,)), output_shape=(None,))
+        layer = mock.Mock(Layer(input_layer), output_shape=(None,))
         layer.input_layer = input_layer
         loss_function = mock.Mock()
         input = theano.tensor.vector()

--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -132,3 +132,16 @@ def test_create_param_callable_returns_return_value():
     result = create_param(factory, (2, 3))
     assert (result.get_value() == array).all()
     factory.assert_called_with((2, 3))
+
+
+def test_nonpositive_dims_raises_value_error():
+    from lasagne.utils import create_param
+    neg_shape = (-1, -1)
+    zero_shape = (0, 0)
+    pos_shape = (1, 1)
+    spec = np.empty
+    with pytest.raises(ValueError):
+        create_param(spec, neg_shape)
+    with pytest.raises(ValueError):
+        create_param(spec, zero_shape)
+    create_param(spec, pos_shape)

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -249,6 +249,10 @@ def create_param(spec, shape, name=None):
     variables, and callables for generating initial parameter values.
     """
     shape = tuple(shape)  # convert to tuple if needed
+    if any(d <= 0 for d in shape):
+        raise ValueError((
+            "Cannot create param with a non-positive shape dimension. "
+            "Tried to create param with shape=%r, name=%r") % (shape, name))
 
     if isinstance(spec, theano.compile.SharedVariable):
         # We cannot check the shape here, the shared variable might not be


### PR DESCRIPTION
This is a small change, I'm not sure if there are guidelines for contributions and how involved they should be. If small changes like this are ok, then I'll continue to make pull requests as I modify the library. If larger changes are preferred I'll hold off until I feel I've made a more substantial progress.  

I added an error message to catch the scenario where the conv+max pooling layers reduce an image size to 0 for smaller images. 

Previous error messages looked like this, and had a delay due to the SVD call during orthogonal initialization. 

```
  ...
  File "/home/joncrall/code/ibeis_cnn/ibeis_cnn/models.py", line 1012, in build_model
    W=init.Orthogonal(),
  File "/home/joncrall/code/Lasagne/lasagne/layers/dense.py", line 72, in __init__
    self.W = self.add_param(W, (num_inputs, num_units), name="W")
  File "/home/joncrall/code/Lasagne/lasagne/layers/base.py", line 228, in add_param
    param = utils.create_param(spec, shape, name)
  File "/home/joncrall/code/Lasagne/lasagne/utils.py", line 271, in create_param
    arr = spec(shape)
  File "/home/joncrall/code/Lasagne/lasagne/init.py", line 29, in __call__
    return self.sample(shape)
  File "/home/joncrall/code/Lasagne/lasagne/init.py", line 354, in sample
    u, _, v = np.linalg.svd(a, full_matrices=False)
  File "/usr/local/lib/python2.7/dist-packages/numpy/linalg/linalg.py", line 1306, in svd
    _assertNoEmpty2d(a)
  File "/usr/local/lib/python2.7/dist-packages/numpy/linalg/linalg.py", line 222, in _assertNoEmpty2d
    raise LinAlgError("Arrays cannot be empty")
LinAlgError: Arrays cannot be empty
 ```

They the error messages are shorter and there is no delay. 

```
  ...
  File "/home/joncrall/code/ibeis_cnn/ibeis_cnn/models.py", line 1142, in build_model
    W=init.Orthogonal(),
  File "lasagne/layers/dense.py", line 72, in __init__
    self.W = self.add_param(W, (num_inputs, num_units), name="W")
  File "lasagne/layers/base.py", line 229, in add_param
    param = utils.create_param(spec, shape, name)
  File "lasagne/utils.py", line 253, in create_param
    raise RuntimeError('An element in param shape is 0. shape=%r, name=%r' % (shape, name))
RuntimeError: An element in param shape is 0. shape=(0, 512), name='W'
```


