### PR TITLE
Add lasagne.__version__ which mirrors the package's version.

### DIFF
--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -9,3 +9,8 @@ from . import objectives
 from . import regularization
 from . import updates
 from . import utils
+
+
+import pkg_resources
+__version__ = pkg_resources.get_distribution("Lasagne").version
+del pkg_resources

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
-version = '0.1dev'
+version = '0.1.dev'
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:


### PR DESCRIPTION
As per the discussion in #263, this updates the version in setup.py to be pep440 compatible, and adds `lasagne.__version__`, which mirrors the package's version in setup.py.

I vaguely remember having some problems with `pkg_resources.get_version()` and readthedocs, but can't remember what it was.  I assume the Lasagne package is set up normally with readthedocs.  `get_version` would fail if it weren't.