### PR TITLE
remove travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ install:
   - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy
   - travis_retry pip install -r requirements.txt
   - travis_retry python setup.py dev
-script: travis_wait py.test --runslow
+script: py.test --runslow
 cache: apt


### PR DESCRIPTION
`travis_wait` isn't needed since none of the tests exceed 10 minute runtime, and its 20 minute timeout caused the last build to fail.

Off topic but does anyone know why 3.4 is so much slower than 2.7?