### PR TITLE
use numpy for conv2d test sets

### DIFF
--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -23,6 +23,11 @@ def conv2d(input, kernel, border_mode):
         trim = (kernel.shape[2] - 1, kernel.shape[3] - 1)
         output = output[:, :, trim[0]:-trim[0], trim[1]:-trim[1]]
 
+    elif border_mode == 'same':
+        shift_x = (kernel.shape[2] - 1) // 2
+        shift_y = (kernel.shape[3] - 1) // 2
+        output = output[:, :, shift_x:input.shape[2] + shift_x,
+                        shift_y:input.shape[3] + shift_y]
     return output
 
 
@@ -31,17 +36,10 @@ def conv2d_test_sets():
         return [theano.shared(floatX(input)), floatX(kernel), output, kwargs]
 
     for border_mode in ['valid', 'full', 'same']:
-        conv_mode = 'full' if border_mode == 'same' else border_mode
-
         for stride in [1, 2, 3]:
             input = np.random.random((3, 1, 16, 23))
             kernel = np.random.random((16, 1, 3, 3))
-            output = conv2d(input, kernel, border_mode=conv_mode)
-            if border_mode == 'same':
-                shift_x = (kernel.shape[2] - 1) // 2
-                shift_y = (kernel.shape[3] - 1) // 2
-                output = output[:, :, shift_x:input.shape[2] + shift_x,
-                                shift_y:input.shape[3] + shift_y]
+            output = conv2d(input, kernel, border_mode=border_mode)
             output = output[:, :, ::stride, ::stride]
             yield _convert(input, kernel, output, {'border_mode': border_mode,
                                                    'stride': stride
@@ -49,12 +47,7 @@ def conv2d_test_sets():
 
             input = np.random.random((3, 3, 16, 23))
             kernel = np.random.random((16, 3, 3, 3))
-            output = conv2d(input, kernel, border_mode=conv_mode)
-            if border_mode == 'same':
-                shift_x = (kernel.shape[2] - 1) // 2
-                shift_y = (kernel.shape[3] - 1) // 2
-                output = output[:, :, shift_x:input.shape[2] + shift_x,
-                                shift_y:input.shape[3] + shift_y]
+            output = conv2d(input, kernel, border_mode=border_mode)
             output = output[:, :, ::stride, ::stride]
             yield _convert(input, kernel, output, {'border_mode': border_mode,
                                                    'stride': stride
@@ -122,7 +115,6 @@ class TestConv1DLayer:
         input_layer = DummyInputLayer((b, c, w))
         try:
             from lasagne.layers.conv import Conv1DLayer
-            from lasagne.layers.helper import get_output
             layer = Conv1DLayer(
                 input_layer,
                 num_filters=kernel.shape[0],
@@ -130,7 +122,7 @@ class TestConv1DLayer:
                 W=kernel,
                 **kwargs
             )
-            actual = get_output(layer, input).eval()
+            actual = layer.get_output_for(input).eval()
             assert actual.shape == output.shape
             assert actual.shape == layer.output_shape
             assert np.allclose(actual, output)


### PR DESCRIPTION
This replaces the Theano-based conv2d test set with one using numpy.

The multiple calls to `conv2d(...).eval()` were a taking a lot of time, on my machine this change brings the test collection time from 33.59 to 0.51 seconds.