### PR TITLE
Add coveralls.io

### DIFF
--- a/.coveragerc-nogpu
+++ b/.coveragerc-nogpu
@@ -1,0 +1,6 @@
+[run]
+omit =
+    lasagne/tests/*
+    lasagne/layers/corrmm.py
+    lasagne/layers/cuda_convnet.py
+    lasagne/layers/dnn.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
 install:
   - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy
   - travis_retry pip install -r requirements.txt
+  - travis_retry pip install python-coveralls
   - travis_retry python setup.py dev
 script: py.test --runslow
+after_success:
+  - coveralls
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install python-coveralls
   - travis_retry python setup.py dev
-script: py.test --runslow
+script: py.test --runslow --cov-config=.coveragerc-nogpu
 after_success:
   - coveralls
 cache: apt

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@
 .. image:: https://travis-ci.org/Lasagne/Lasagne.svg?branch=master
     :target: https://travis-ci.org/Lasagne/Lasagne
 
+.. image:: https://img.shields.io/coveralls/Lasagne/Lasagne.svg
+    :target: https://coveralls.io/r/Lasagne/Lasagne
+
 Lasagne
 =======
 


### PR DESCRIPTION
Apart from registering Lasagne on coveralls.io, this should be all that's needed for python-coveralls to do its work.

Related to #112: Improving test coverage.