### PR TITLE
Fix vertical alignment mismatch in sphinx documentation

### DIFF
--- a/docs/_static/fix_rtd.css
+++ b/docs/_static/fix_rtd.css
@@ -1,0 +1,4 @@
+/* work around https://github.com/snide/sphinx_rtd_theme/issues/149 */
+.rst-content table.field-list .field-body {
+    padding-top: 8px;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,8 @@ pygments_style = 'sphinx'
 
 ## Read the docs style:
 html_theme = 'sphinx_rtd_theme'
+def setup(app):
+    app.add_stylesheet("fix_rtd.css")
 
 ## Bootstrap style:
 #import sphinx_bootstrap_theme


### PR DESCRIPTION
This provides a workaround for https://github.com/snide/sphinx_rtd_theme/issues/149, the first point on the list of documentation layout issues that bothered me: https://github.com/Lasagne/Lasagne/issues/203#issuecomment-103983492. See "Parameters: leakiness" on the following page if you're unsure what I'm talking about: http://lasagne.readthedocs.org/en/latest/modules/nonlinearities.html#lasagne.nonlinearities.LeakyRectify