### PR TITLE
Add license badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@
 .. image:: https://img.shields.io/coveralls/Lasagne/Lasagne.svg
     :target: https://coveralls.io/r/Lasagne/Lasagne
 
+.. image:: https://img.shields.io/github/license/Lasagne/Lasagne.svg
+    :target: https://github.com/Lasagne/Lasagne/blob/master/LICENSE
+
 Lasagne
 =======
 


### PR DESCRIPTION
This adds a license badge to the README file, making it easier to see the license we're using.