### PR TITLE
Add requirements-dev.txt for testing requirements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - conda update --yes conda
 install:
   - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy
-  - travis_retry pip install -r requirements.txt
+  - travis_retry pip install -r requirements-dev.txt
   - travis_retry pip install python-coveralls
   - travis_retry python setup.py dev
 script: py.test --runslow --cov-config=.coveragerc-nogpu

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-Jinja2==2.7.3
-Sphinx==1.2.3
-#sphinx-bootstrap-theme
-numpydoc
-mock

--- a/docs/user/development.rst
+++ b/docs/user/development.rst
@@ -41,7 +41,8 @@ Tools
 
 * `pytest <http://pytest.org/>`_ for unit testing
 
-* Install testing dependencies with: ``pip install -r requirements-dev.txt``
+* Install dependencies for testing and documentation with: ``pip
+  install -r requirements-dev.txt``
 
 * GitHub for hosting the source code
 
@@ -80,12 +81,6 @@ Documentation
 -------------
 
 The documentation is generated with `Sphinx <http://sphinx-doc.org/latest/index.html>`_.
-On Debian derivates it can be installed with
-
-.. code:: bash
-
-    $ sudo apt-get install python-sphinx
-    $ sudo -H pip install numpydoc
 
 Sphinx makes use of `reStructured Text <http://openalea.gforge.inria.fr/doc/openalea/doc/_build/html/source/sphinx/rest_syntax.html>`_
 

--- a/docs/user/development.rst
+++ b/docs/user/development.rst
@@ -39,11 +39,12 @@ contribute.
 Tools
 -----
 
-* ``pytests`` for unit testing
+* `pytest <http://pytest.org/>`_ for unit testing
 
-  * Install with: ``pip install pytest pytest-cov pytest-pep8``
+* Install testing dependencies with: ``pip install -r requirements-dev.txt``
 
 * GitHub for hosting the source code
+
 * http://lasagne.readthedocs.org/ for hosting the documentation
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,9 @@
 -r requirements.txt
 mock
+numpydoc
 pep8==1.6.2
 pytest
 pytest-cov
 pytest-pep8
+Jinja2==2.7.3
+Sphinx==1.2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+mock
+pep8==1.6.2
+pytest
+pytest-cov
+pytest-pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [aliases]
 dev = develop easy_install lasagne[testing]
-docs = develop easy_install lasagne[docs]
 
 [pytest]
 addopts =

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,6 @@ tests_require = [
     'pytest-pep8',
     ]
 
-docs_require = [
-    'Sphinx',
-    ]
-
 setup(
     name="Lasagne",
     version=version,
@@ -54,6 +50,5 @@ setup(
     install_requires=install_requires,
     extras_require={
         'testing': tests_require,
-        'docs': docs_require,
         },
     )


### PR DESCRIPTION
Necessary because different versions of pep8 will give different results.  See #271.