### PR TITLE
Fix github source code links generated by Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,26 +108,27 @@ pygments_style = 'sphinx'
 
 # Resolve function for the linkcode extension.
 def linkcode_resolve(domain, info):
-    def find_line():
-        # try to find the correct line number, based on code from numpy:
+    def find_source():
+        # try to find the file and line number, based on code from numpy:
         # https://github.com/numpy/numpy/blob/master/doc/source/conf.py#L286
         obj = sys.modules[info['module']]
         for part in info['fullname'].split('.'):
             obj = getattr(obj, part)
         import inspect
+        import os
         fn = inspect.getsourcefile(obj)
-        source, lineno = inspect.findsource(obj)
-        return lineno + 1
+        fn = os.path.relpath(fn, start=os.path.dirname(lasagne.__file__))
+        source, lineno = inspect.getsourcelines(obj)
+        return fn, lineno, lineno + len(source) - 1
 
     if domain != 'py' or not info['module']:
         return None
-    filename = info['module'].replace('.', '/')
-    tag = 'master' if 'dev' in release else ('v' + release)
-    url = "https://github.com/Lasagne/Lasagne/blob/%s/%s.py" % (tag, filename)
     try:
-        return url + '#L%d' % find_line()
+        filename = 'lasagne/%s#L%d-L%d' % find_source()
     except Exception:
-        return url
+        filename = info['module'].replace('.', '/') + '.py'
+    tag = 'master' if 'dev' in release else ('v' + release)
+    return "https://github.com/Lasagne/Lasagne/blob/%s/%s" % (tag, filename)
 
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
Fixes the issue noted in https://github.com/Lasagne/Lasagne/pull/262#issuecomment-109764518: The source code file was not inferred correctly for `lasagne.layers.*` members. In addition, changes the github links to highlight the full range of the entity rather than just the first line. (This is something I should add to numpy as well... after my vacation.)