### PR TITLE
Make regularization docs show up

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ method, this part of the documentation is for you.
   modules/init
   modules/nonlinearities
   modules/objectives
+  modules/regularization
   modules/utils
 
 Indices and tables

--- a/docs/modules/regularization.rst
+++ b/docs/modules/regularization.rst
@@ -1,0 +1,20 @@
+:mod:`lasagne.regularization`
+======================
+
+.. automodule:: lasagne.regularization
+
+Helper functions
+----------------
+
+.. autofunction:: apply_penalty
+.. autofunction:: regularize_layer_params
+.. autofunction:: regularize_layer_params_weighted
+.. autofunction:: regularize_network_params
+
+
+Penalty functions
+-----------------
+
+.. autofunction:: l1
+.. autofunction:: l2
+


### PR DESCRIPTION
The PR with the reworked regularization code (#285) did not include the necessary files to make the module show up in the docs. This PR adds rudimentary versions of those. It's probably useful to flesh this out a bit, but let's do that at a later date.