### PR TITLE
Check that parameter shapes match value shapes when loading weights

### DIFF
--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -474,6 +474,7 @@ def set_all_param_values(layer, values, **tags):
     values : list of numpy.array
         A list of numpy arrays representing the parameter values, must match
         the number of parameters.
+        Every parameter's shape must match the shape of its new value.
 
     **tags (optional)
         tags can be specified to filter the list of parameters to be set.
@@ -486,7 +487,8 @@ def set_all_param_values(layer, values, **tags):
     Raises
     ------
     ValueError
-        If the number of values is not equal to the number of params.
+        If the number of values is not equal to the number of params, or
+        if a parameter's shape does not match the shape of its new value.
 
     Examples
     --------
@@ -503,5 +505,11 @@ def set_all_param_values(layer, values, **tags):
     if len(params) != len(values):
         raise ValueError("mismatch: got %d values to set %d parameters" %
                          (len(values), len(params)))
+
     for p, v in zip(params, values):
-        p.set_value(v)
+        if p.get_value().shape != v.shape:
+            raise ValueError("mismatch: parameter has shape %r but value to "
+                             "set has shape %r" %
+                             (p.get_value().shape, v.shape))
+        else:
+            p.set_value(v)

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -733,13 +733,19 @@ class TestSetAllParamValues:
         l2 = DenseLayer(l1, 30)
         l3 = DenseLayer(l2, 40)
 
-        a = floatX(numpy.random.normal(0, 1, (1, 1)))
-        b = floatX(numpy.random.normal(0, 1, (1,)))
-        set_all_param_values(l3, [a, b, a, b])
-        assert numpy.allclose(l3.W.get_value(), a)
-        assert numpy.allclose(l3.b.get_value(), b)
-        assert numpy.allclose(l2.W.get_value(), a)
-        assert numpy.allclose(l2.b.get_value(), b)
+        a2 = floatX(numpy.random.normal(0, 1, (20, 30)))
+        b2 = floatX(numpy.random.normal(0, 1, (30,)))
+        a3 = floatX(numpy.random.normal(0, 1, (30, 40)))
+        b3 = floatX(numpy.random.normal(0, 1, (40,)))
+        set_all_param_values(l3, [a2, b2, a3, b3])
+        assert numpy.allclose(l3.W.get_value(), a3)
+        assert numpy.allclose(l3.b.get_value(), b3)
+        assert numpy.allclose(l2.W.get_value(), a2)
+        assert numpy.allclose(l2.b.get_value(), b2)
 
         with pytest.raises(ValueError):
-            set_all_param_values(l3, [a, b, a])
+            set_all_param_values(l3, [a3, b3, a2])
+
+        with pytest.raises(ValueError):
+            a3_bad = floatX(numpy.random.normal(0, 1, (25, 40)))
+            set_all_param_values(l3, [a2, b2, a3_bad, b3])


### PR DESCRIPTION
Recently I accidentally tried to load saved network parameters from a model with different numbers of units in the dense layers.  This passed by silently and I could not figure out why my network was not improving with more hidden units.  I think an error should be raised when loading saved weights changes the network structure.  This is closely related to https://github.com/Lasagne/Lasagne/pull/177.