### PR TITLE
add dim arg to flatten

### DIFF
--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -21,17 +21,35 @@ __all__ = [
 
 class FlattenLayer(Layer):
     """
-    Flatten all but the first dimension.
+    A layer that flattens its input. The leading ``outdim-1`` dimensions of
+    the output will have the same shape as the input. The remaining dimensions
+    are collapsed into the last dimension.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape.
+    outdim : int
+        The number of dimensions in the output.
 
     See Also
     --------
     flatten  : Shortcut
     """
+    def __init__(self, incoming, outdim=2, **kwargs):
+        super(FlattenLayer, self).__init__(incoming, **kwargs)
+        self.outdim = outdim
+
+        if outdim < 1:
+            raise ValueError('Dim must be >0, was %i', outdim)
+
     def get_output_shape_for(self, input_shape):
-        return (input_shape[0], int(np.prod(input_shape[1:])))
+        shp = [input_shape[i] for i in range(self.outdim-1)]
+        shp += [int(np.prod(input_shape[(self.outdim-1):]))]
+        return tuple(shp)
 
     def get_output_for(self, input, **kwargs):
-        return input.flatten(2)
+        return input.flatten(self.outdim)
 
 flatten = FlattenLayer  # shortcut
 

--- a/lasagne/tests/layers/test_shape.py
+++ b/lasagne/tests/layers/test_shape.py
@@ -11,6 +11,16 @@ class TestFlattenLayer:
         from lasagne.layers.shape import FlattenLayer
         return FlattenLayer(Mock(output_shape=(None,)))
 
+    @pytest.fixture
+    def layer_outdim3(self):
+        from lasagne.layers.shape import FlattenLayer
+        return FlattenLayer(Mock(output_shape=(None,)), outdim=3)
+
+    @pytest.fixture
+    def layer_outdim1(self):
+        from lasagne.layers.shape import FlattenLayer
+        return FlattenLayer(Mock(output_shape=(None,)), outdim=1)
+
     def test_get_output_shape_for(self, layer):
         input_shape = (2, 3, 4, 5)
         assert layer.get_output_shape_for(input_shape) == (2, 3 * 4 * 5)
@@ -19,6 +29,31 @@ class TestFlattenLayer:
         input = np.random.random((2, 3, 4, 5))
         result = layer.get_output_for(theano.shared(input)).eval()
         assert (result == input.reshape((input.shape[0], -1))).all()
+
+    def test_get_output_shape_for_outdim3(self, layer_outdim3):
+        input_shape = (2, 3, 4, 5)
+        assert layer_outdim3.get_output_shape_for(input_shape) == (2, 3, 4 * 5)
+
+    def test_get_output_for_outdim3(self, layer_outdim3):
+        input = np.random.random((2, 3, 4, 5))
+        result = layer_outdim3.get_output_for(theano.shared(input)).eval()
+        assert (result == input.reshape(
+            (input.shape[0], input.shape[1], -1))).all()
+
+    def test_get_output_shape_for_outdim1(self, layer_outdim1):
+        input_shape = (2, 3, 4, 5)
+        assert layer_outdim1.get_output_shape_for(input_shape) == (
+            2 * 3 * 4 * 5, )
+
+    def test_get_output_for_outdim1(self, layer_outdim1):
+        input = np.random.random((2, 3, 4, 5))
+        result = layer_outdim1.get_output_for(theano.shared(input)).eval()
+        assert (result == input.reshape(-1)).all()
+
+    def test_dim0_raises(self):
+        from lasagne.layers.shape import FlattenLayer
+        with pytest.raises(ValueError):
+            FlattenLayer((2, 3, 4), outdim=0)
 
 
 class TestPadLayer:


### PR DESCRIPTION
adds a `dim` argument to flatten that lets the user decide from which dimension the input should be flattend, e.g. `dim=1`(default) has the same behavior as the current flatten layer.

This is usefull if you have recurrent layer that has convolutional output.  