### PR TITLE
Update MaxPool2DCCLayer to use pool_output_length

### DIFF
--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -8,6 +8,7 @@ from .. import nonlinearities
 from .base import Layer
 
 from .conv import conv_output_length
+from .pool import pool_output_length
 from ..utils import as_tuple
 
 from theano.sandbox.cuda.basic_ops import gpu_contiguous
@@ -506,10 +507,18 @@ class MaxPool2DCCLayer(CCLayer):
             num_input_channels = input_shape[0]
             input_rows, input_columns = input_shape[1:3]
 
-        output_rows = int(np.ceil(float(input_rows - self.pool_size +
-                                        self.stride) / self.stride))
-        output_columns = int(np.ceil(float(input_columns - self.pool_size +
-                                           self.stride) / self.stride))
+        output_rows = pool_output_length(input_rows,
+                                         pool_size=self.pool_size,
+                                         stride=self.stride,
+                                         ignore_border=False,
+                                         pad=0,
+                                         )
+        output_columns = pool_output_length(input_columns,
+                                            pool_size=self.pool_size,
+                                            stride=self.stride,
+                                            ignore_border=False,
+                                            pad=0,
+                                            )
 
         if self.dimshuffle:
             return (batch_size, num_input_channels, output_rows,

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -180,7 +180,8 @@ class TestMaxPool1DLayer:
         assert np.allclose(numpy_result, layer_result)
 
     @pytest.mark.parametrize(
-        "input_shape", [(32, 64, 128), (None, 64, 128), (32, None, 128)])
+        "input_shape", [(32, 64, 128), (None, 64, 128), (32, None, 128),
+                        (32, 64, None)])
     def test_get_output_shape_for(self, input_shape):
         input_layer = self.input_layer(input_shape)
         layer = self.layer_ignoreborder(input_layer, pool_size=2)
@@ -266,18 +267,21 @@ class TestMaxPool2DLayer:
             pytest.skip()
 
     @pytest.mark.parametrize(
-        "input_shape",
-        [(32, 64, 24, 24), (None, 64, 24, 24), (32, None, 24, 24)],
+        "input_shape,output_shape",
+        [((32, 64, 24, 24), (32, 64, 12, 12)),
+         ((None, 64, 24, 24), (None, 64, 12, 12)),
+         ((32, None, 24, 24), (32, None, 12, 12)),
+         ((32, 64, None, 24), (32, 64, None, 12)),
+         ((32, 64, 24, None), (32, 64, 12, None)),
+         ((32, 64, None, None), (32, 64, None, None))],
     )
-    def test_get_output_shape_for(self, input_shape):
+    def test_get_output_shape_for(self, input_shape, output_shape):
         try:
             input_layer = self.input_layer(input_shape)
             layer = self.layer(input_layer,
                                pool_size=(2, 2), stride=None)
             assert layer.get_output_shape_for(
-                (None, 64, 24, 24)) == (None, 64, 12, 12)
-            assert layer.get_output_shape_for(
-                (32, 64, 24, 24)) == (32, 64, 12, 12)
+                input_shape) == output_shape
         except NotImplementedError:
             pytest.skip()
 
@@ -326,18 +330,21 @@ class TestMaxPool2DCCLayer:
             pytest.skip()
 
     @pytest.mark.parametrize(
-        "input_shape",
-        [(32, 64, 24, 24), (None, 64, 24, 24), (32, None, 24, 24)],
+        "input_shape,output_shape",
+        [((32, 64, 24, 24), (32, 64, 12, 12)),
+         ((None, 64, 24, 24), (None, 64, 12, 12)),
+         ((32, None, 24, 24), (32, None, 12, 12)),
+         ((32, 64, None, 24), (32, 64, None, 12)),
+         ((32, 64, 24, None), (32, 64, 12, None)),
+         ((32, 64, None, None), (32, 64, None, None))],
     )
-    def test_get_output_shape_for(self, input_shape):
+    def test_get_output_shape_for(self, input_shape, output_shape):
         try:
             input_layer = self.input_layer(input_shape)
             layer = self.layer(input_layer,
                                pool_size=(2, 2), stride=None)
             assert layer.get_output_shape_for(
-                (None, 64, 24, 24)) == (None, 64, 12, 12)
-            assert layer.get_output_shape_for(
-                (32, 64, 24, 24)) == (32, 64, 12, 12)
+                input_shape) == output_shape
         except NotImplementedError:
             pytest.skip()
 
@@ -442,18 +449,21 @@ class TestMaxPool2DNNLayer:
             pytest.skip()
 
     @pytest.mark.parametrize(
-        "input_shape",
-        [(32, 64, 24, 24), (None, 64, 24, 24), (32, None, 24, 24)],
+        "input_shape,output_shape",
+        [((32, 64, 24, 24), (32, 64, 12, 12)),
+         ((None, 64, 24, 24), (None, 64, 12, 12)),
+         ((32, None, 24, 24), (32, None, 12, 12)),
+         ((32, 64, None, 24), (32, 64, None, 12)),
+         ((32, 64, 24, None), (32, 64, 12, None)),
+         ((32, 64, None, None), (32, 64, None, None))],
     )
-    def test_get_output_shape_for(self, input_shape):
+    def test_get_output_shape_for(self, input_shape, output_shape):
         try:
             input_layer = self.input_layer(input_shape)
             layer = self.layer(input_layer,
                                pool_size=(2, 2), stride=None, pad=(0, 0))
             assert layer.get_output_shape_for(
-                (None, 64, 24, 24)) == (None, 64, 12, 12)
-            assert layer.get_output_shape_for(
-                (32, 64, 24, 24)) == (32, 64, 12, 12)
+                input_shape) == output_shape
         except NotImplementedError:
             raise
         #    pytest.skip()


### PR DESCRIPTION
MaxPoolConv2DCCLayer should allow inputs whose dimensions are not known at compile-time to be specified with None.  I updated MaxPoolConv2DCCLayer to use pool_output_length in a similar manner to how Conv2DCCLayer uses conv_output_length.

I set ignore_border=False and pad=0 because MaxPool2DCCLayer does not support ignore_border or padding.

This was inspired by the discussion on [lasagne-users](https://groups.google.com/forum/#!topic/lasagne-users/72e1-EEAZGM).