### PR TITLE
"Informal" string representation for Layer Class

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -53,8 +53,12 @@ class Layer(object):
             Please do NOT override this method, or __repr__!
             To create a representation of the layer, override __layer_str.
             """
+        # TODO: this supports sequential networks, add support for networks with merge layer
         network = get_all_layers(self)
-        representation = ''
+        representation = 'input --> '
+        representation += ''.join(['[' + str(i) + '] --> ' for i in range(len(network))])
+        representation += 'output \n' \
+                          'Details:'
         for i in range(len(network)):
             try:
                 layer_repr = network[i].__layer_str()
@@ -62,7 +66,7 @@ class Layer(object):
                 layer_repr = type(network[i]).__name__
             except:
                 raise
-            representation += '\n[{0}]: {1}'.format(i, layer_repr)
+            representation += '\n\t[{0}]: {1}'.format(i, layer_repr)
         return representation
 
     def __layer_str(self):

--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from .. import utils
+from .helper import get_all_layers
 
 
 __all__ = [
@@ -46,6 +47,29 @@ class Layer(object):
                 "Cannot create Layer with a non-positive input_shape "
                 "dimension. input_shape=%r, self.name=%r") % (
                     self.input_shape, self.name))
+
+    def __str__(self):
+        """ Returns an `informal` string representation of the entire network contained under this layer.
+            Please do NOT override this method, or __repr__!
+            To create a representation of the layer, override __layer_str.
+            """
+        network = get_all_layers(self)
+        representation = ''
+        for i in range(len(network)):
+            try:
+                layer_repr = network[i].__layer_str()
+            except NotImplementedError:
+                layer_repr = type(network[i]).__name__
+            except:
+                raise
+            representation += '\n[{0}]: {1}'.format(i, layer_repr)
+        return representation
+
+    def __layer_str(self):
+        """ Returns an `informal` string representation of the layer alone and not all layers under this layer.
+            Override this method to return a custom representation of the Layer.
+            Please do NOT override __str__ or __repr__."""
+        raise NotImplementedError
 
     @property
     def output_shape(self):


### PR DESCRIPTION
Based on [this mailing list post](https://groups.google.com/forum/#!searchin/lasagne-users/__repr__/lasagne-users/CtDfEC3wVnk/ahS2TefZt0cJ), I wrote a simple __str__ method for the base class which should return an easy to understand "informal" representation of the entire network contained under the specific Layer, similar to what Torch does.

For example, if a model such as the one in mnist.py example is built using

    >>> network = build_model(100, 10)

then one could

    >>> print(network)

to get

    input --> [0] --> [1] --> [2] --> [3] --> [4] --> [5] --> output 
    Details:
            [0]: InputLayer
            [1]: DenseLayer
            [2]: DropoutLayer
            [3]: DenseLayer
            [4]: DropoutLayer
            [5]: DenseLayer

To return more details for each layer, the corresponding layer class (that inherits from Layer) must override a method called __layer_str()

Note that this currently supports only completely sequential networks, but should be simple enough to extend.