### PR TITLE
Require Git version of Theano.  For #320.  See #323.

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -20,16 +20,13 @@ Install from PyPI
 .. note:: Lasagne hasn't been released as of now.  The only way to
           install it for now is from source.
 
-Simply run:
+To install release 0.1 of Lasagne from PyPI, run the following
+commands:
 
 .. code-block:: bash
 
-  pip install Lasagne
-
-It's also a good practice to install dependencies with exactly the
-same version numbers that the release was made with.  You can find the
-``requirements.txt`` that defines those version numbers in the top
-level directory of the Lasagne source tree.
+  pip install -r https://raw.githubusercontent.com/Lasagne/Lasagne/0.1/requirements.txt
+  pip install Lasagne==0.1
 
 Install from source
 ===================
@@ -42,10 +39,11 @@ copy is by cloning the git repository, for example:
   git clone https://github.com/Lasagne/Lasagne.git
 
 Once you have obtained a copy of the source, run the following command to
-install its dependencies:
+install Lasagne's dependencies:
 
 .. code-block:: bash
 
+  cd Lasagne
   pip install -r requirements.txt
 
 To install the Lasagne package itself, run:

--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -2,6 +2,18 @@
 Tools to train neural nets in Theano
 """
 
+try:
+    import theano
+except ImportError:  # pragma: no cover
+    raise ImportError("""Could not import Theano.
+
+Please make sure you install a recent enough version of Theano.  See
+section 'Install from PyPI' in the installation docs for more details:
+http://lasagne.readthedocs.org/en/latest/user/installation.html#install-from-pypi
+""")
+else:
+    del theano
+
 from . import nonlinearities
 from . import init
 from . import layers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Theano==0.7
+git+https://github.com/Theano/Theano.git@36d1eca8#egg=Theano==0.8.git

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except IOError:
 
 install_requires = [
     'numpy',
-    'Theano',
+    # 'Theano',  # we require a development version, see requirements.txt
     ]
 
 tests_require = [


### PR DESCRIPTION
For discussion, see #323.

`requirements.txt` has been changed to point to a recent Git version of Theano as per our discussion.  Install docs were updated, though necessary changes were minimal.  (Installation has become slightly more complicated though.)

I also did what @ebenolson suggested and removed `Theano` from dependencies in `setup.py`.  I've added a friendly error message for people who ignore the updated installation docs, run `pip install Lasagne` alone, and now get `ImportError theano`.  The point here is to avoid accidentally installing a too old version of Theano, which would then be hard to detect for us at runtime, and would lead to obscure errors as pointed out by @ebenolson.