### PR TITLE
Split layer docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 # serve to show the default.
 
 # import sys
-# import os
+import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -140,6 +140,13 @@ def linkcode_resolve(domain, info):
 #}
 
 ## Read the docs style:
+if os.environ.get('READTHEDOCS') != 'True':
+    try:
+        import sphinx_rtd_theme
+    except ImportError:
+        pass  # assume we have sphinx >= 1.3
+    else:
+        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_theme = 'sphinx_rtd_theme'
 def setup(app):
     app.add_stylesheet("fix_rtd.css")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,8 +36,8 @@ method, this part of the documentation is for you.
   modules/init
   modules/nonlinearities
   modules/objectives
-  modules/random
   modules/regularization
+  modules/random
   modules/utils
 
 Indices and tables

--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -3,171 +3,173 @@
 
 .. automodule:: lasagne.layers
 
+.. toctree::
+    :hidden:
 
-Helper functions
-----------------
+    layers/helper
+    layers/base
+    layers/input
+    layers/dense
+    layers/conv
+    layers/pool
+    layers/recurrent
+    layers/noise
+    layers/shape
+    layers/merge
+    layers/embedding
+    layers/corrmm
+    layers/cuda_convnet
+    layers/dnn
+   
 
-.. autofunction:: get_output
-.. autofunction:: get_output_shape
-.. autofunction:: get_all_layers
-.. autofunction:: get_all_params
-.. autofunction:: get_all_bias_params
-.. autofunction:: get_all_non_bias_params
-.. autofunction:: count_params
-.. autofunction:: get_all_param_values
-.. autofunction:: set_all_param_values
+.. rubric:: :doc:`layers/helper`
 
+.. autosummary::
+    :nosignatures:
 
-Layer base classes
-------------------
-
-.. autoclass:: Layer
-   :members:
-
-.. autoclass:: MergeLayer
-    :members:
-
-Layer classes: network input
-----------------------------
-
-.. autoclass:: InputLayer
-   :members:
-
-Layer classes: dense layers
----------------------------
-
-.. autoclass:: DenseLayer
-   :members:
-
-.. autoclass:: NonlinearityLayer
-   :members:
-
-.. autoclass:: NINLayer
-    :members:
-
-Layer classes: convolutional layers
------------------------------------
-
-.. autoclass:: Conv1DLayer
-    :members:
-
-.. autoclass:: Conv2DLayer
-    :members:
-
-Layer classes: pooling layers
------------------------------
-
-.. autoclass:: MaxPool1DLayer
-    :members:
-
-.. autoclass:: Pool2DLayer
-    :members:
-
-.. autoclass:: MaxPool2DLayer
-    :members:
-
-.. autoclass:: GlobalPoolLayer
-    :members:
-
-.. autoclass:: FeaturePoolLayer
-    :members:
-
-.. autoclass:: FeatureWTALayer
-    :members:
-
-Layer classes: noise layers
----------------------------
-
-.. autoclass:: DropoutLayer
-    :members:
-
-.. autoclass:: dropout
-
-.. autoclass:: GaussianNoiseLayer
-    :members:
-
-Layer classes: shape layers
----------------------------
-
-.. autoclass:: ReshapeLayer
-    :members:
-
-.. autoclass:: reshape
-
-.. autoclass:: FlattenLayer
-    :members:
-
-.. autoclass:: flatten
-
-.. autoclass:: DimshuffleLayer
-    :members:
-
-.. autoclass:: dimshuffle
-
-.. autoclass:: PadLayer
-    :members:
-
-.. autoclass:: pad
-
-.. autoclass:: SliceLayer
+    get_output
+    get_output_shape
+    get_all_layers
+    get_all_params
+    count_params
+    get_all_param_values
+    set_all_param_values
 
 
-Layer classes: merge layers
----------------------------
+.. rubric:: :doc:`layers/base`
 
-.. autoclass:: ConcatLayer
-    :members:
+.. autosummary::
+    :nosignatures:
 
-.. autoclass:: concat
-
-.. autoclass:: ElemwiseMergeLayer
-    :members:
-
-.. autoclass:: ElemwiseSumLayer
-    :members:
-
-Layer classes: embedding layers
--------------------------------
-
-.. autoclass:: EmbeddingLayer
-    :members:
-
-Layer classes: recurrent layers
--------------------------------
-
-.. automodule:: lasagne.layers.recurrent
-
-.. autoclass:: CustomRecurrentLayer
-    :members:
-
-.. autoclass:: RecurrentLayer
-    :members:
-
-.. autoclass:: LSTMLayer
-    :members:
-
-.. autoclass:: GRULayer
-    :members:
-
-.. autoclass:: Gate
-    :members:
-
-:mod:`lasagne.layers.corrmm`
-============================
-
-.. automodule:: lasagne.layers.corrmm
-    :members:
+    Layer
+    MergeLayer
 
 
-:mod:`lasagne.layers.cuda_convnet`
-==================================
+.. rubric:: :doc:`layers/input`
 
-.. automodule:: lasagne.layers.cuda_convnet
-    :members:
+.. autosummary::
+    :nosignatures:
+
+    InputLayer
 
 
-:mod:`lasagne.layers.dnn`
-=========================
+.. rubric:: :doc:`layers/dense`
 
-.. automodule:: lasagne.layers.dnn
-    :members:
+.. autosummary::
+    :nosignatures:
+
+    DenseLayer
+    NonlinearityLayer
+    NINLayer
+
+
+.. rubric:: :doc:`layers/conv`
+
+.. autosummary::
+    :nosignatures:
+
+    Conv1DLayer
+    Conv2DLayer
+
+
+.. rubric:: :doc:`layers/pool`
+
+.. autosummary::
+    :nosignatures:
+
+    MaxPool1DLayer
+    MaxPool2DLayer
+    Pool2DLayer
+    GlobalPoolLayer
+    FeaturePoolLayer
+    FeatureWTALayer
+
+
+.. rubric:: :doc:`layers/recurrent`
+
+.. autosummary::
+    :nosignatures:
+
+    CustomRecurrentLayer
+    RecurrentLayer
+    LSTMLayer
+    GRULayer
+    Gate
+
+
+.. rubric:: :doc:`layers/noise`
+
+.. autosummary::
+    :nosignatures:
+
+    DropoutLayer
+    dropout
+    GaussianNoiseLayer
+
+
+.. rubric:: :doc:`layers/shape`
+
+.. autosummary::
+    :nosignatures:
+
+    ReshapeLayer
+    reshape
+    FlattenLayer
+    flatten
+    DimshuffleLayer
+    dimshuffle
+    PadLayer
+    pad
+    SliceLayer
+
+
+.. rubric:: :doc:`layers/merge`
+
+.. autosummary::
+    :nosignatures:
+
+    ConcatLayer
+    concat
+    ElemwiseMergeLayer
+    ElemwiseSumLayer
+
+
+.. rubric:: :doc:`layers/embedding`
+
+.. autosummary::
+    :nosignatures:
+
+    EmbeddingLayer
+
+
+.. rubric:: :doc:`layers/corrmm`
+
+.. autosummary::
+    :nosignatures:
+
+    corrmm.Conv2DMMLayer
+
+
+.. rubric:: :doc:`layers/cuda_convnet`
+
+.. autosummary::
+    :nosignatures:
+
+    cuda_convnet.Conv2DCCLayer
+    cuda_convnet.MaxPool2DCCLayer
+    cuda_convnet.ShuffleBC01ToC01BLayer
+    cuda_convnet.bc01_to_c01b
+    cuda_convnet.ShuffleC01BToBC01Layer
+    cuda_convnet.c01b_to_bc01
+    cuda_convnet.NINLayer_c01b
+
+
+.. rubric:: :doc:`layers/dnn`
+
+.. autosummary::
+    :nosignatures:
+
+    dnn.Conv2DDNNLayer
+    dnn.MaxPool2DDNNLayer
+    dnn.Pool2DDNNLayer
+

--- a/docs/modules/layers/base.rst
+++ b/docs/modules/layers/base.rst
@@ -1,0 +1,13 @@
+Layer base classes
+------------------
+
+.. automodule:: lasagne.layers.base
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: Layer
+   :members:
+
+.. autoclass:: MergeLayer
+    :members:
+

--- a/docs/modules/layers/conv.rst
+++ b/docs/modules/layers/conv.rst
@@ -1,0 +1,29 @@
+Convolutional layers
+--------------------
+
+.. automodule:: lasagne.layers.conv
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: Conv1DLayer
+    :members:
+
+.. autoclass:: Conv2DLayer
+    :members:
+
+.. note::
+    For experts: ``Conv2DLayer`` will create a convolutional layer using
+    ``T.nnet.conv2d``, Theano's default convolution. On compilation for GPU,
+    Theano replaces this with a `cuDNN`_-based implementation if available,
+    otherwise falls back to a gemm-based implementation. For details on this,
+    please see the `Theano convolution documentation`_.
+
+    Lasagne also provides convolutional layers directly enforcing a specific
+    implementation: :class:`lasagne.layers.dnn.Conv2DDNNLayer` to enforce
+    cuDNN, :class:`lasagne.layers.corrmm.Conv2DMMLayer` to enforce the
+    gemm-based one, :class:`lasagne.layers.cuda_convnet.Conv2DCCLayer` for
+    Krizhevsky's `cuda-convnet`_.
+
+.. _cuda-convnet: https://code.google.com/p/cuda-convnet/
+.. _cuDNN: https://developer.nvidia.com/cudnn
+.. _Theano convolution documentation: http://deeplearning.net/software/theano/library/tensor/nnet/conv.html

--- a/docs/modules/layers/corrmm.rst
+++ b/docs/modules/layers/corrmm.rst
@@ -1,0 +1,6 @@
+:mod:`lasagne.layers.corrmm`
+----------------------------
+
+.. automodule:: lasagne.layers.corrmm
+    :members:
+

--- a/docs/modules/layers/cuda_convnet.rst
+++ b/docs/modules/layers/cuda_convnet.rst
@@ -1,0 +1,6 @@
+:mod:`lasagne.layers.cuda_convnet`
+----------------------------------
+
+.. automodule:: lasagne.layers.cuda_convnet
+    :members:
+

--- a/docs/modules/layers/dense.rst
+++ b/docs/modules/layers/dense.rst
@@ -1,0 +1,16 @@
+Dense layers
+------------
+
+.. automodule:: lasagne.layers.dense
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: DenseLayer
+   :members:
+
+.. autoclass:: NonlinearityLayer
+   :members:
+
+.. autoclass:: NINLayer
+    :members:
+

--- a/docs/modules/layers/dnn.rst
+++ b/docs/modules/layers/dnn.rst
@@ -1,0 +1,6 @@
+:mod:`lasagne.layers.dnn`
+-------------------------
+
+.. automodule:: lasagne.layers.dnn
+    :members:
+

--- a/docs/modules/layers/embedding.rst
+++ b/docs/modules/layers/embedding.rst
@@ -1,0 +1,10 @@
+Embedding layers
+----------------
+
+.. automodule:: lasagne.layers.embedding
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: EmbeddingLayer
+    :members:
+

--- a/docs/modules/layers/helper.rst
+++ b/docs/modules/layers/helper.rst
@@ -1,0 +1,17 @@
+Helper functions
+----------------
+
+.. automodule:: lasagne.layers.helper
+
+.. currentmodule:: lasagne.layers
+
+.. autofunction:: get_output
+.. autofunction:: get_output_shape
+.. autofunction:: get_all_layers
+.. autofunction:: get_all_params
+.. autofunction:: get_all_bias_params
+.. autofunction:: get_all_non_bias_params
+.. autofunction:: count_params
+.. autofunction:: get_all_param_values
+.. autofunction:: set_all_param_values
+

--- a/docs/modules/layers/input.rst
+++ b/docs/modules/layers/input.rst
@@ -1,0 +1,10 @@
+Network input
+-------------
+
+.. automodule:: lasagne.layers.input
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: InputLayer
+   :members:
+

--- a/docs/modules/layers/merge.rst
+++ b/docs/modules/layers/merge.rst
@@ -1,0 +1,18 @@
+Merge layers
+------------
+
+.. automodule:: lasagne.layers.merge
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: ConcatLayer
+    :members:
+
+.. autoclass:: concat
+
+.. autoclass:: ElemwiseMergeLayer
+    :members:
+
+.. autoclass:: ElemwiseSumLayer
+    :members:
+

--- a/docs/modules/layers/noise.rst
+++ b/docs/modules/layers/noise.rst
@@ -1,0 +1,15 @@
+Noise layers
+------------
+
+.. automodule:: lasagne.layers.noise
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: DropoutLayer
+    :members:
+
+.. autoclass:: dropout
+
+.. autoclass:: GaussianNoiseLayer
+    :members:
+

--- a/docs/modules/layers/pool.rst
+++ b/docs/modules/layers/pool.rst
@@ -1,0 +1,25 @@
+Pooling layers
+--------------
+
+.. automodule:: lasagne.layers.pool
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: MaxPool1DLayer
+    :members:
+
+.. autoclass:: MaxPool2DLayer
+    :members:
+
+.. autoclass:: Pool2DLayer
+    :members:
+
+.. autoclass:: GlobalPoolLayer
+    :members:
+
+.. autoclass:: FeaturePoolLayer
+    :members:
+
+.. autoclass:: FeatureWTALayer
+    :members:
+

--- a/docs/modules/layers/recurrent.rst
+++ b/docs/modules/layers/recurrent.rst
@@ -1,0 +1,22 @@
+Recurrent layers
+----------------
+
+.. automodule:: lasagne.layers.recurrent
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: CustomRecurrentLayer
+    :members:
+
+.. autoclass:: RecurrentLayer
+    :members:
+
+.. autoclass:: LSTMLayer
+    :members:
+
+.. autoclass:: GRULayer
+    :members:
+
+.. autoclass:: Gate
+    :members:
+

--- a/docs/modules/layers/shape.rst
+++ b/docs/modules/layers/shape.rst
@@ -1,0 +1,29 @@
+Shape layers
+------------
+
+.. automodule:: lasagne.layers.shape
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: ReshapeLayer
+    :members:
+
+.. autoclass:: reshape
+
+.. autoclass:: FlattenLayer
+    :members:
+
+.. autoclass:: flatten
+
+.. autoclass:: DimshuffleLayer
+    :members:
+
+.. autoclass:: dimshuffle
+
+.. autoclass:: PadLayer
+    :members:
+
+.. autoclass:: pad
+
+.. autoclass:: SliceLayer
+

--- a/docs/modules/random.rst
+++ b/docs/modules/random.rst
@@ -1,5 +1,5 @@
 :mod:`lasagne.random`
-====================
+=====================
 
 .. automodule:: lasagne.random
 

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -123,7 +123,7 @@ class NINLayer(Layer):
     W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
     nonlinearity=lasagne.nonlinearities.rectify, **kwargs)
 
-    Network-in-network layer [1]_.
+    Network-in-network layer.
     Like DenseLayer, but broadcasting across all trailing dimensions beyond the
     2nd.  This results in a convolution operation with filter size 1 on all
     trailing dimensions.  Any number of trailing dimensions is supported,

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -105,6 +105,12 @@ class Pool2DDNNLayer(DNNLayer):
 
 
 class MaxPool2DDNNLayer(Pool2DDNNLayer):  # for consistency
+    """
+    2D max-pooling layer
+
+    Subclass of :class:`Pool2DDNNLayer` fixing ``mode='max'``, provided for
+    compatibility to other ``MaxPool2DLayer`` classes.
+    """
     def __init__(self, incoming, pool_size, stride=None,
                  pad=(0, 0), **kwargs):
         super(MaxPool2DDNNLayer, self).__init__(incoming, pool_size, stride,

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -371,7 +371,7 @@ def get_all_non_bias_params(layer):  # pragma no cover
 
 def count_params(layer, **tags):
     """
-    This function counts all parameters (i.e. the number of scalar
+    This function counts all parameters (i.e., the number of scalar
     values) of all layers below one or more given :class:`Layer` instances,
     including the layer(s) itself.
 

--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -14,7 +14,7 @@ __all__ = [
 
 
 class DropoutLayer(Layer):
-    """Dropout layer [1]_, [2]_
+    """Dropout layer
 
     Sets values to zero with probability p. See notes for disabling dropout
     during testing.
@@ -32,7 +32,7 @@ class DropoutLayer(Layer):
     Notes
     -----
     The dropout layer is a regularizer that randomly sets input values to
-    zero, see references for why this might improve generalization.
+    zero; see [1]_, [2]_ for why this might improve generalization.
     During training you should set deterministic to false and during
     testing you should set deterministic to true.
 
@@ -86,16 +86,16 @@ dropout = DropoutLayer  # shortcut
 
 
 class GaussianNoiseLayer(Layer):
-    """Gaussian noise layer [1]_.
+    """Gaussian noise layer.
 
-    Add zero Gaussian noise with mean 0 and std sigma to the input
+    Add zero-mean Gaussian noise of given standard deviation to the input [1]_.
 
     Parameters
     ----------
     incoming : a :class:`Layer` instance or a tuple
             the layer feeding into this layer, or the expected input shape
     sigma : float or tensor scalar
-            Std of added Gaussian noise
+            Standard deviation of added Gaussian noise
 
     Notes
     -----

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -364,7 +364,7 @@ class FeaturePoolLayer(Layer):
 
 class FeatureWTALayer(Layer):
     """
-    'Winner Take' All layer
+    'Winner Take All' layer
 
     This layer performs 'Winner Take All' (WTA) across feature maps: zero out
     all but the maximal activation value within a region.

--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -8,6 +8,8 @@ dimension are flattened.
 
 The following recurrent layers are implemented:
 
+.. currentmodule:: lasagne.layers
+
 .. autosummary::
     :nosignatures:
 
@@ -114,7 +116,7 @@ class CustomRecurrentLayer(MergeLayer):
         Nonlinearity to apply when computing new state (:math:`\sigma`). If
         None is provided, no nonlinearity will be applied.
     hid_init : callable, np.ndarray, theano.shared or TensorVariable
-        Initializer for initial hidden state (:math:`h_0').  If a
+        Initializer for initial hidden state (:math:`h_0`).  If a
         TensorVariable (Theano expression) is supplied, it will not be learned
         regardless of the value of `learn_init`.
     backwards : bool
@@ -422,7 +424,7 @@ class RecurrentLayer(CustomRecurrentLayer):
         Nonlinearity to apply when computing new state (:math:`\sigma`). If
         None is provided, no nonlinearity will be applied.
     hid_init : callable, np.ndarray, theano.shared or TensorVariable
-        Initializer for initial hidden state (:math:`h_0').  If a
+        Initializer for initial hidden state (:math:`h_0`).  If a
         TensorVariable (Theano expression) is supplied, it will not be learned
         regardless of the value of `learn_init`.
     backwards : bool
@@ -613,11 +615,11 @@ class LSTMLayer(MergeLayer):
         The nonlinearity that is applied to the output (:math:`\sigma_h`). If
         None is provided, no nonlinearity will be applied.
     cell_init : callable, np.ndarray, theano.shared or TensorVariable
-        Initializer for initial cell state (:math:`c_0').  If a
+        Initializer for initial cell state (:math:`c_0`).  If a
         TensorVariable (Theano expression) is supplied, it will not be learned
         regardless of the value of `learn_init`.
     hid_init : callable, np.ndarray, theano.shared or TensorVariable
-        Initializer for initial hidden state (:math:`h_0').  If a
+        Initializer for initial hidden state (:math:`h_0`).  If a
         TensorVariable (Theano expression) is supplied, it will not be learned
         regardless of the value of `learn_init`.
     backwards : bool
@@ -1028,7 +1030,7 @@ class GRULayer(MergeLayer):
         Parameters for the hidden update (:math:`c_t`): :math:`W_{xc}`,
         :math:`W_{hc}`, :math:`b_c`, and :math:`\sigma_c`.
     hid_init : callable, np.ndarray, theano.shared or TensorVariable
-        Initializer for initial hidden state (:math:`h_0').  If a
+        Initializer for initial hidden state (:math:`h_0`).  If a
         TensorVariable (Theano expression) is supplied, it will not be learned
         regardless of the value of `learn_init`.
     backwards : bool

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-cov
 pytest-pep8
 Jinja2==2.7.3
 Sphinx==1.2.3
+sphinx_rtd_theme


### PR DESCRIPTION
This splits up the `lasagne.layers` Sphinx documentation across multiple pages; one per submodule (but taking care to present all classes as belonging to the `lasagne.layers` namespace if appropriate). It requires Sphinx 1.2.3 to build because of a regression in more recent versions (see https://github.com/Lasagne/Lasagne/issues/203#issuecomment-121310595), but we use that one on readthedocs anyway (just note that a more recent version will omit the autosummary tables, so make sure to use Sphinx version 1.2.3 or the latest git version if building locally).

I've tried a few different options for the TOC and layout, and this is the best I found. It has a bunch of autosummary tables for `lasagne.layers`, and the TOC is set up such that clicking `Convolutional layers` in the left-hand navbar takes you to the detail page for convolutional layers, not to the autosummary table within the `lasagne.layers` overview page (mainly because then we'd either have a second navbar entry for the detail page or have Sphinx whine about the detail page not being included in any TOC).

Finally, I did some minor docstring fixes that triggered Sphinx warnings or caught my eye in the overview page.