### PR TITLE
Fleshed out README and design goals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,23 +14,122 @@ Lasagne
 =======
 
 Lasagne is a lightweight library to build and train neural networks in Theano.
+Its main features are:
 
-For support, please refer to the lasagne-users mailing list: https://groups.google.com/forum/#!forum/lasagne-users
+* Supports feed-forward networks such as Convolutional Neural Networks (CNNs),
+  recurrent networks including Long Short-Term Memory (LSTM), and any
+  combination thereof
+* Allows architectures of multiple inputs and multiple outputs, including
+  auxiliary classifiers
+* Many optimization methods including Nesterov momentum, RMSprop and ADAM
+* Freely definable cost function and no need to derive gradients due to
+  Theano's symbolic differentiation
+* Transparent support of CPUs and GPUs due to Theano's expression compiler
 
-Documentation: http://lasagne.readthedocs.org/ (work in progress)
+Its design is governed by `six principles
+<http://lasagne.readthedocs.org/en/latest/user/development.html#philosophy>`_:
+
+* **Simplicity**: Be easy to use and easy to extend, with as few abstractions
+  as possible, to facilitate research
+* **Small interfaces**: Have as few classes and methods as possible
+* **Don't get in the way**: Do not obstruct users with features they decide not
+  to use, and allow all parts to be used independently
+* **Transparency**: Do not hide Theano behind abstractions, directly process and
+  return Theano expressions or Python / numpy data types
+* **Focus**: "Do one thing and do it well"
+* **Pragmatism**: Make common use cases easy, do not overrate uncommon cases
+
+
+Installation
+------------
+
+In short, you can install a known compatible version of Theano and the latest
+Lasagne development version via:
+
+.. code-block:: bash
+
+  pip install -r https://raw.githubusercontent.com/Lasagne/Lasagne/master/requirements.txt
+  pip install https://github.com/Lasagne/Lasagne/archive/master.zip
+
+For more details and alternatives, please see the `Installation instructions
+<http://lasagne.readthedocs.org/en/latest/user/installation.html>`_.
+
+
+Documentation
+-------------
+
+Documentation is available online: http://lasagne.readthedocs.org/
+
+For support, please refer to the `lasagne-users mailing list
+<https://groups.google.com/forum/#!forum/lasagne-users>`_.
+
+
+Example
+-------
+
+.. code-block:: python
+
+  import lasagne
+  import theano
+  import theano.tensor as T
+
+  # create Theano variables for input and target minibatch
+  input_var = T.tensor4('X')
+  target_var = T.ivector('y')
+
+  # create a small convolutional neural network
+  from lasagne.nonlinearities import leaky_rectify, softmax
+  network = lasagne.layers.InputLayer((None, 3, 32, 32), input_var)
+  network = lasagne.layers.Conv2DLayer(network, 64, (3, 3),
+                                       nonlinearity=leaky_rectify)
+  network = lasagne.layers.Conv2DLayer(network, 32, (3, 3),
+                                       nonlinearity=leaky_rectify)
+  network = lasagne.layers.Pool2DLayer(network, (3, 3), stride=2, mode='max')
+  network = lasagne.layers.DenseLayer(lasagne.layers.dropout(network, 0.5),
+                                      128, nonlinearity=leaky_rectify,
+                                      W=lasagne.init.Orthogonal())
+  network = lasagne.layers.DenseLayer(lasagne.layers.dropout(network, 0.5),
+                                      10, nonlinearity=softmax)
+
+  # create loss function
+  prediction = lasagne.layers.get_output(network)
+  loss = lasagne.objectives.categorical_crossentropy(prediction, target_var)
+  loss = loss.mean() + 1e-4 * lasagne.regularization.regularize_network_params(
+          network, lasagne.regularization.l2)
+
+  # create parameter update expressions
+  params = lasagne.layers.get_all_params(network, trainable=True)
+  updates = lasagne.updates.nesterov_momentum(loss, params, learning_rate=0.01,
+                                              momentum=0.9)
+
+  # compile training function that updates parameters and returns training loss
+  train_fn = theano.function([input_var, target_var], loss, updates=updates)
+
+  # train network (assuming you've got some training data in numpy arrays)
+  for epoch in range(100):
+      loss = 0
+      for input_batch, target_batch in training_data:
+          loss += train_fn(input_batch, target_batch)
+      print("Epoch %d: Loss %g" % (epoch + 1, loss / len(training_data)))
+
+  # use trained network for predictions
+  test_prediction = lasagne.layers.get_output(network, deterministic=True)
+  predict_fn = theano.function([input_var], T.argmax(test_prediction, axis=1))
+  print("Predicted class for first test input: %r" % predict_fn(test_data[0]))
+
+For a fully-functional example, see `examples/mnist.py <examples/mnist.py>`_,
+and check the `Tutorial
+<http://lasagne.readthedocs.org/en/latest/user/tutorial.html>`_ for in-depth
+explanations of the same. More examples, code snippets and reproductions of
+recent research papers are maintained in the separate `Lasagne Recipes
+<https://github.com/Lasagne/Recipes>`_ repository.
+
+
+Development
+-----------
 
 Lasagne is a work in progress, input is welcome.
 
-Design goals:
-
-* Simplicity: it should be easy to use and extend the library. Whenever a feature is added, the effect on both of these should be considered. Every added abstraction should be carefully scrutinized, to determine whether the added complexity is justified.
-
-* Small interfaces: as few classes and methods as possible. Try to rely on Theano's functionality and data types where possible, and follow Theano's conventions. Don't wrap things in classes if it is not strictly necessary. This should make it easier to both use the library and extend it (less cognitive overhead).
-
-* Don't get in the way: unused features should be invisible, the user should not have to take into account a feature that they do not use. It should be possible to use each component of the library in isolation from the others.
-
-* Transparency: don't try to hide Theano behind abstractions. Functions and methods should return Theano expressions and standard Python / numpy data types where possible.
-
-* Focus: follow the Unix philosophy of "do one thing and do it well", with a strong focus on feed-forward neural networks.
-
-* Pragmatism: making common use cases easy is more important than supporting every possible use case out of the box.
+Please see the `Contribution instructions
+<http://lasagne.readthedocs.org/en/latest/user/development.html>`_ for details
+on how you can contribute!

--- a/README.rst
+++ b/README.rst
@@ -29,15 +29,15 @@ Its main features are:
 Its design is governed by `six principles
 <http://lasagne.readthedocs.org/en/latest/user/development.html#philosophy>`_:
 
-* **Simplicity**: Be easy to use and easy to extend, with as few abstractions
-  as possible, to facilitate research
-* **Small interfaces**: Have as few classes and methods as possible
-* **Don't get in the way**: Do not obstruct users with features they decide not
-  to use, and allow all parts to be used independently
-* **Transparency**: Do not hide Theano behind abstractions, directly process and
+* Simplicity: Be easy to use, easy to understand and easy to extend, to
+  facilitate use in research
+* Transparency: Do not hide Theano behind abstractions, directly process and
   return Theano expressions or Python / numpy data types
-* **Focus**: "Do one thing and do it well"
-* **Pragmatism**: Make common use cases easy, do not overrate uncommon cases
+* Modularity: Allow all parts (layers, regularizers, optimizers, ...) to be
+  used independently of Lasagne
+* Pragmatism: Make common use cases easy, do not overrate uncommon cases
+* Restraint: Do not obstruct users with features they decide not to use
+* Focus: "Do one thing and do it well"
 
 
 Installation

--- a/docs/user/development.rst
+++ b/docs/user/development.rst
@@ -120,17 +120,30 @@ Philosophy
 
 Lasagne grew out of a need to combine the flexibility of Theano with the availability of the right building blocks for training neural networks. Its development is guided by a number of design goals:
 
-* **Simplicity**: it should be easy to use and extend the library. Whenever a feature is added, the effect on both of these should be considered. Every added abstraction should be carefully scrutinized, to determine whether the added complexity is justified.
+* **Simplicity**: Be easy to use, easy to understand and easy to extend, to
+  facilitate use in research. Interfaces should be kept small, with as few
+  classes and methods as possible. Every added abstraction and feature should
+  be carefully scrutinized, to determine whether the added complexity is
+  justified.
 
-* **Small interfaces**: as few classes and methods as possible. Try to rely on Theano's functionality and data types where possible, and follow Theano's conventions. Don't wrap things in classes if it is not strictly necessary. This should make it easier to both use the library and extend it (less cognitive overhead).
+* **Transparency**: Do not hide Theano behind abstractions, directly process
+  and return Theano expressions or Python / numpy data types. Try to rely on
+  Theano's functionality where possible, and follow Theano's conventions.
 
-* **Don't get in the way**: unused features should be invisible, the user should not have to take into account a feature that they do not use. It should be possible to use each component of the library in isolation from the others.
+* **Modularity**: Allow all parts (layers, regularizers, optimizers, ...) to be
+  used independently of Lasagne. Make it easy to use components in isolation or
+  in conjunction with other frameworks.
 
-* **Transparency**: don't try to hide Theano behind abstractions. Functions and methods should return Theano expressions and standard Python / numpy data types where possible.
+* **Pragmatism**: Make common use cases easy, do not overrate uncommon cases.
+  Ideally, everything should be possible, but common use cases shouldn't be
+  made more difficult just to cater for exotic ones.
 
-* **Focus**: follow the Unix philosophy of "do one thing and do it well", with a strong focus on feed-forward neural networks.
+* **Restraint**: Do not obstruct users with features they decide not to use.
+  Both in using and in extending components, it should be possible for users to
+  be fully oblivious to features they do not need.
 
-* **Pragmatism**: making common use cases easy is more important than supporting every possible use case out of the box.
+* **Focus**: "Do one thing and do it well". Do not try to provide a library for
+  everything to do with deep learning.
 
 
 


### PR DESCRIPTION
This fleshes out the README file to show an example upfront so you know what to expect, and to point to installation instructions, documentation and contribution guidelines (although the latter should probably be fleshed out in the documentation).

See https://github.com/f0k/Lasagne/tree/readme for how it would look.

Closes #86 in passing.