### PR TITLE
Merge border_mode with pad argument for convolutional layers

### DIFF
--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -30,7 +30,7 @@ class MMLayer(Layer):
 class Conv2DMMLayer(MMLayer):
     """
     lasagne.layers.Conv2DMMLayer(incoming, num_filters, filter_size,
-    stride=(1, 1), border_mode=None, untie_biases=False,
+    stride=(1, 1), pad=0, untie_biases=False,
     W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
     nonlinearity=lasagne.nonlinearities.rectify, pad=None, flip_filters=False,
     **kwargs)
@@ -58,23 +58,29 @@ class Conv2DMMLayer(MMLayer):
         An integer or a 2-element tuple specifying the stride of the
         convolution operation.
 
-    border_mode : str, one of 'valid', 'full', 'same'
-        A string indicating the convolution border mode.
+    pad : int, tuple of int, 'full' or 'same' (default: 0)
+        By default, the convolution is only computed where the input and the
+        filter fully overlap (a valid convolution). When ``stride=1``, this
+        yields an output that is smaller than the input by ``filter_size - 1``.
+        The `pad` argument allows to implicitly pad the input with zeros,
+        extending the output size.
 
-        If 'valid', the convolution is only computed where the input and the
-        filter fully overlap.
+        A single integer results in symmetric zero-padding of the given size on
+        all borders, a tuple of two integers allows different symmetric padding
+        per dimension.
 
-        If 'full', the convolution is computed wherever the input and the
+        ``'full'`` pads with one less than the filter size on both sides. This
+        is equivalent to computing the convolution wherever the input and the
         filter overlap by at least one position.
 
-        If 'same', the convolution is computed wherever the input and the
-        filter overlap by at least half the filter size, when the filter size
-        is odd. In practice, the input is zero-padded with half the filter size
-        at the beginning and half at the end (or one less than half in the case
-        of an even filter size). This results in an output length that is the
-        same as the input length (for both odd and even filter sizes).
+        ``'same'`` pads with half the filter size on both sides (one less on
+        the second side for an even filter size). When ``stride=1``, this
+        results in an output size equal to the input size.
 
-    untie_biases : bool, default False
+        Note that ``'full'`` and ``'same'`` can be faster than equivalent
+        integer values due to optimizations by Theano.
+
+    untie_biases : bool (default: False)
         If ``False``, the layer will have a bias parameter for each channel,
         which is shared across all positions in this channel. As a result, the
         `b` attribute will be a vector (1D).
@@ -101,12 +107,7 @@ class Conv2DMMLayer(MMLayer):
         The nonlinearity that is applied to the layer activations. If None
         is provided, the layer will be linear.
 
-    pad : int, iterable or None
-        An integer or a 2-element tuple specifying the amount of zero-padding
-        on each side. This may also be ``None``, in which case the correct
-        amount of padding will be inferred from the specified ``border_mode``.
-
-    flip_filters : bool, default False
+    flip_filters : bool (default: False)
         Whether to flip the filters and perform a convolution, or not to flip
         them and perform a correlation. Flipping adds a bit of overhead, so it
         is disabled by default. In most cases this does not make a difference
@@ -128,15 +129,13 @@ class Conv2DMMLayer(MMLayer):
     Notes
     -----
     Unlike :class:`lasagne.layers.Conv2DLayer`, this layer properly supports
-    the 'same' border mode. It is not emulated. This should result in better
+    the 'same' pad. It is not emulated. This should result in better
     performance.
-
-    Only one of ``pad`` and ``border_mode`` should be specified.
     """
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
-                 border_mode=None, untie_biases=False, W=init.GlorotUniform(),
+                 pad=0, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
-                 pad=None, flip_filters=False, **kwargs):
+                 flip_filters=False, **kwargs):
         super(Conv2DMMLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
@@ -149,25 +148,18 @@ class Conv2DMMLayer(MMLayer):
         self.untie_biases = untie_biases
         self.flip_filters = flip_filters
 
-        if border_mode is not None and pad is not None:
-            raise RuntimeError("You cannot specify both 'border_mode' and "
-                               "'pad'. To avoid ambiguity, please specify "
-                               "only one of them.")
-        elif border_mode is None and pad is None:
-            # no option specified, default to valid mode
-            self.pad = (0, 0)
-        elif border_mode is not None:
-            if border_mode == 'valid':
+        if isinstance(pad, basestring):
+            if pad == 'valid':
                 self.pad = (0, 0)
-            elif border_mode == 'full':
+            elif pad == 'full':
                 self.pad = (self.filter_size[0] - 1, self.filter_size[1] - 1)
-            elif border_mode == 'same':
+            elif pad == 'same':
                 # only works for odd filter size, but the even filter size case
                 # is probably not worth supporting.
                 self.pad = ((self.filter_size[0] - 1) // 2,
                             (self.filter_size[1] - 1) // 2)
             else:
-                raise RuntimeError("Invalid border mode: '%s'" % border_mode)
+                raise RuntimeError("Invalid pad: '%s'" % pad)
         else:
             self.pad = as_tuple(pad, 2)
 
@@ -196,12 +188,12 @@ class Conv2DMMLayer(MMLayer):
         output_rows = conv_output_length(input_shape[2],
                                          self.filter_size[0],
                                          self.stride[0],
-                                         'pad', self.pad[0])
+                                         self.pad[0])
 
         output_columns = conv_output_length(input_shape[3],
                                             self.filter_size[1],
                                             self.stride[1],
-                                            'pad', self.pad[1])
+                                            self.pad[1])
 
         return (batch_size, self.num_filters, output_rows, output_columns)
 

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -51,14 +51,14 @@ class Conv2DMMLayer(MMLayer):
     num_filters : int
         The number of learnable convolutional filters this layer has.
 
-    filter_size : int or iterable
+    filter_size : int or iterable of int
         An integer or a 2-element tuple specifying the size of the filters.
 
-    stride : int or iterable
+    stride : int or iterable of int
         An integer or a 2-element tuple specifying the stride of the
         convolution operation.
 
-    pad : int, tuple of int, 'full', 'same' or 'valid' (default: 0)
+    pad : int, iterable of int, 'full', 'same' or 'valid' (default: 0)
         By default, the convolution is only computed where the input and the
         filter fully overlap (a valid convolution). When ``stride=1``, this
         yields an output that is smaller than the input by ``filter_size - 1``.

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -62,16 +62,16 @@ class Conv2DCCLayer(CCLayer):
     num_filters : int
         The number of learnable convolutional filters this layer has.
 
-    filter_size : int or iterable
+    filter_size : int or iterable of int
         An integer or a 2-element tuple specifying the size of the filters.
         This layer does not support non-square filters.
 
-    stride : int or iterable
+    stride : int or iterable of int
         An integer or a 2-element tuple specifying the stride of the
         convolution operation. This layer does not support using different
         strides along both axes.
 
-    pad : int, tuple of int, 'full', 'same' or 'valid' (default: 0)
+    pad : int, iterable of int, 'full', 'same' or 'valid' (default: 0)
         By default, the convolution is only computed where the input and the
         filter fully overlap (a valid convolution). When ``stride=1``, this
         yields an output that is smaller than the input by ``filter_size - 1``.

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -38,7 +38,7 @@ class CCLayer(Layer):
 class Conv2DCCLayer(CCLayer):
     """
     lasagne.layers.Conv2DCCLayer(incoming, num_filters, filter_size,
-    stride=(1, 1), border_mode=None, untie_biases=False, W=None,
+    stride=(1, 1), pad=0, untie_biases=False, W=None,
     b=lasagne.init.Constant(0.), nonlinearity=lasagne.nonlinearities.rectify,
     pad=None, dimshuffle=True, flip_filters=False, partial_sum=1, **kwargs)
 
@@ -71,23 +71,30 @@ class Conv2DCCLayer(CCLayer):
         convolution operation. This layer does not support using different
         strides along both axes.
 
-    border_mode : str, one of 'valid', 'full', 'same'
-        A string indicating the convolution border mode.
+    pad : int, tuple of int, 'full' or 'same' (default: 0)
+        By default, the convolution is only computed where the input and the
+        filter fully overlap (a valid convolution). When ``stride=1``, this
+        yields an output that is smaller than the input by ``filter_size - 1``.
+        The `pad` argument allows to implicitly pad the input with zeros,
+        extending the output size.
 
-        If 'valid', the convolution is only computed where the input and the
-        filter fully overlap.
+        A single integer results in symmetric zero-padding of the given size on
+        all borders. This layer does not support using different amounts of
+        padding along both axes, but for compatibility to other layers you can
+        still specify the padding as a tuple of two same-valued integers.
 
-        If 'full', the convolution is computed wherever the input and the
+        ``'full'`` pads with one less than the filter size on both sides. This
+        is equivalent to computing the convolution wherever the input and the
         filter overlap by at least one position.
 
-        If 'same', the convolution is computed wherever the input and the
-        filter overlap by at least half the filter size, when the filter size
-        is odd. In practice, the input is zero-padded with half the filter size
-        at the beginning and half at the end (or one less than half in the case
-        of an even filter size). This results in an output length that is the
-        same as the input length (for both odd and even filter sizes).
+        ``'same'`` pads with half the filter size on both sides (one less on
+        the second side for an even filter size). When ``stride=1``, this
+        results in an output size equal to the input size.
 
-    untie_biases : bool, default False
+        Note that ``'full'`` and ``'same'`` can be faster than equivalent
+        integer values due to optimizations by Theano.
+
+    untie_biases : bool (default: False)
         If ``False``, the layer will have a bias parameter for each channel,
         which is shared across all positions in this channel. As a result, the
         `b` attribute will be a vector (1D).
@@ -117,13 +124,6 @@ class Conv2DCCLayer(CCLayer):
         The nonlinearity that is applied to the layer activations. If None
         is provided, the layer will be linear.
 
-    pad : int, iterable or None
-        An integer or a 2-element tuple specifying the amount of zero-padding
-        on each side. This may also be ``None``, in which case the correct
-        amount of padding will be inferred from the specified ``border_mode``.
-        This layer does not support using different amounts of padding along
-        both axes.
-
     dimshuffle : bool (default: True)
         If ``True``, the layer will automatically apply the necessary
         dimshuffle operations to deal with the fact that the cuda-convnet
@@ -137,7 +137,7 @@ class Conv2DCCLayer(CCLayer):
         :class:`ShuffleC01BToBC01Layer` can be used to convert between bc01 and
         c01b axis order.
 
-    flip_filters : bool, default False
+    flip_filters : bool (default: False)
         Whether to flip the filters and perform a convolution, or not to flip
         them and perform a correlation. Flipping adds a bit of overhead, so it
         is disabled by default. In most cases this does not make a difference
@@ -172,10 +172,8 @@ class Conv2DCCLayer(CCLayer):
     Notes
     -----
     Unlike :class:`lasagne.layers.Conv2DLayer`, this layer properly supports
-    the 'same' border mode. It is not emulated. This should result in better
+    the 'same' pad. It is not emulated. This should result in better
     performance.
-
-    Only one of ``pad`` and ``border_mode`` should be specified.
 
     The cuda-convnet convolution implementation has several limitations:
 
@@ -204,9 +202,9 @@ class Conv2DCCLayer(CCLayer):
     c01b axis order.
     """
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
-                 border_mode=None, untie_biases=False, W=None,
+                 pad=0, untie_biases=False, W=None,
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
-                 pad=None, dimshuffle=True, flip_filters=False, partial_sum=1,
+                 dimshuffle=True, flip_filters=False, partial_sum=1,
                  **kwargs):
         super(Conv2DCCLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
@@ -244,24 +242,17 @@ class Conv2DCCLayer(CCLayer):
                                "channels to be 1, 2, 3 or a multiple of 4, "
                                "but it is %d" % self.num_input_channels)
 
-        if border_mode is not None and pad is not None:
-            raise RuntimeError("You cannot specify both 'border_mode' and "
-                               "'pad'. To avoid ambiguity, please specify "
-                               "only one of them.")
-        elif border_mode is None and pad is None:
-            # no option specified, default to valid mode
-            self.pad = 0
-        elif border_mode is not None:
-            if border_mode == 'valid':
+        if isinstance(pad, basestring):
+            if pad == 'valid':
                 self.pad = 0
-            elif border_mode == 'full':
+            elif pad == 'full':
                 self.pad = self.filter_size - 1
-            elif border_mode == 'same':
+            elif pad == 'same':
                 # only works for odd filter size, but the even filter size case
                 # is probably not worth supporting.
                 self.pad = (self.filter_size - 1) // 2
             else:
-                raise RuntimeError("Invalid border mode: '%s'" % border_mode)
+                raise RuntimeError("Invalid pad: '%s'" % pad)
         else:
             pad = as_tuple(pad, 2)
             if pad[0] != pad[1]:
@@ -320,12 +311,12 @@ class Conv2DCCLayer(CCLayer):
         output_rows = conv_output_length(input_rows,
                                          self.filter_size,
                                          self.stride,
-                                         'pad', self.pad)
+                                         self.pad)
 
         output_columns = conv_output_length(input_columns,
                                             self.filter_size,
                                             self.stride,
-                                            'pad', self.pad)
+                                            self.pad)
 
         if self.dimshuffle:
             return (batch_size, self.num_filters, output_rows, output_columns)
@@ -352,11 +343,11 @@ class Conv2DCCLayer(CCLayer):
             true_rows = conv_output_length(input.shape[1],
                                            self.filter_size,
                                            self.stride,
-                                           'pad', self.pad)
+                                           self.pad)
             true_columns = conv_output_length(input.shape[2],
                                               self.filter_size,
                                               self.stride,
-                                              'pad', self.pad)
+                                              self.pad)
             conved = conved[:, :true_rows, :true_columns, :]
 
         if self.b is not None:

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -116,7 +116,7 @@ class Conv2DDNNLayer(DNNLayer):
     lasagne.layers.Conv2DDNNLayer(incoming, num_filters, filter_size,
     stride=(1, 1), pad=0, untie_biases=False,
     W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
-    nonlinearity=lasagne.nonlinearities.rectify, pad=None, flip_filters=False,
+    nonlinearity=lasagne.nonlinearities.rectify, flip_filters=False,
     **kwargs)
 
     2D convolutional layer
@@ -142,11 +142,11 @@ class Conv2DDNNLayer(DNNLayer):
         An integer or a 2-element tuple specifying the stride of the
         convolution operation.
 
-    pad : int, tuple of int, 'full' or 'same' (default: 0)
+    pad : int, tuple of int, 'full', 'same' or 'valid' (default: 0)
         By default, the convolution is only computed where the input and the
         filter fully overlap (a valid convolution). When ``stride=1``, this
         yields an output that is smaller than the input by ``filter_size - 1``.
-        The `pad` argument allows to implicitly pad the input with zeros,
+        The `pad` argument allows you to implicitly pad the input with zeros,
         extending the output size.
 
         A single integer results in symmetric zero-padding of the given size on
@@ -160,6 +160,8 @@ class Conv2DDNNLayer(DNNLayer):
         ``'same'`` pads with half the filter size on both sides (one less on
         the second side for an even filter size). When ``stride=1``, this
         results in an output size equal to the input size.
+
+        ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
 
         Note that ``'full'`` and ``'same'`` can be faster than equivalent
         integer values due to optimizations by Theano.
@@ -213,7 +215,7 @@ class Conv2DDNNLayer(DNNLayer):
     Notes
     -----
     Unlike :class:`lasagne.layers.Conv2DLayer`, this layer properly supports
-    the 'same' pad. It is not emulated. This should result in better
+    ``pad='same'``. It is not emulated. This should result in better
     performance.
     """
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
@@ -232,22 +234,19 @@ class Conv2DDNNLayer(DNNLayer):
         self.untie_biases = untie_biases
         self.flip_filters = flip_filters
 
-        if isinstance(pad, basestring):
-            if pad == 'valid':
-                self.pad = (0, 0)
-            elif pad == 'full':
-                self.pad = 'full'
-            elif pad == 'same':
-                # dnn_conv does not support same, so we just specify
-                # padding directly.
-                # only works for odd filter size, but the even filter size
-                # case is probably not worth supporting.
-                self.pad = ((self.filter_size[0] - 1) // 2,
-                            (self.filter_size[1] - 1) // 2)
-            else:
-                raise RuntimeError("Invalid pad: '%s'" % pad)
+        if pad == 'valid':
+            self.pad = (0, 0)
+        elif pad == 'full':
+            self.pad = 'full'
+        elif pad == 'same':
+            # dnn_conv does not support same, so we just specify
+            # padding directly.
+            # only works for odd filter size, but the even filter size
+            # case is probably not worth supporting.
+            self.pad = ((self.filter_size[0] - 1) // 2,
+                        (self.filter_size[1] - 1) // 2)
         else:
-            self.pad = as_tuple(pad, 2)
+            self.pad = as_tuple(pad, 2, int)
 
         self.W = self.add_param(W, self.get_W_shape(), name="W")
         if b is None:
@@ -268,16 +267,17 @@ class Conv2DDNNLayer(DNNLayer):
 
     def get_output_shape_for(self, input_shape):
         batch_size = input_shape[0]
+        pad = self.pad if isinstance(self.pad, tuple) else (self.pad,) * 2
 
         output_rows = conv_output_length(input_shape[2],
                                          self.filter_size[0],
                                          self.stride[0],
-                                         self.pad[0])
+                                         pad[0])
 
         output_columns = conv_output_length(input_shape[3],
                                             self.filter_size[1],
                                             self.stride[1],
-                                            self.pad[1])
+                                            pad[1])
 
         return (batch_size, self.num_filters, output_rows, output_columns)
 

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -135,14 +135,14 @@ class Conv2DDNNLayer(DNNLayer):
     num_filters : int
         The number of learnable convolutional filters this layer has.
 
-    filter_size : int or iterable
+    filter_size : int or iterable of int
         An integer or a 2-element tuple specifying the size of the filters.
 
-    stride : int or iterable
+    stride : int or iterable of int
         An integer or a 2-element tuple specifying the stride of the
         convolution operation.
 
-    pad : int, tuple of int, 'full', 'same' or 'valid' (default: 0)
+    pad : int, iterable of int, 'full', 'same' or 'valid' (default: 0)
         By default, the convolution is only computed where the input and the
         filter fully overlap (a valid convolution). When ``stride=1``, this
         yields an output that is smaller than the input by ``filter_size - 1``.

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -114,7 +114,7 @@ class MaxPool2DDNNLayer(Pool2DDNNLayer):  # for consistency
 class Conv2DDNNLayer(DNNLayer):
     """
     lasagne.layers.Conv2DDNNLayer(incoming, num_filters, filter_size,
-    stride=(1, 1), border_mode=None, untie_biases=False,
+    stride=(1, 1), pad=0, untie_biases=False,
     W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
     nonlinearity=lasagne.nonlinearities.rectify, pad=None, flip_filters=False,
     **kwargs)
@@ -142,23 +142,29 @@ class Conv2DDNNLayer(DNNLayer):
         An integer or a 2-element tuple specifying the stride of the
         convolution operation.
 
-    border_mode : str, one of 'valid', 'full', 'same'
-        A string indicating the convolution border mode.
+    pad : int, tuple of int, 'full' or 'same' (default: 0)
+        By default, the convolution is only computed where the input and the
+        filter fully overlap (a valid convolution). When ``stride=1``, this
+        yields an output that is smaller than the input by ``filter_size - 1``.
+        The `pad` argument allows to implicitly pad the input with zeros,
+        extending the output size.
 
-        If 'valid', the convolution is only computed where the input and the
-        filter fully overlap.
+        A single integer results in symmetric zero-padding of the given size on
+        all borders, a tuple of two integers allows different symmetric padding
+        per dimension.
 
-        If 'full', the convolution is computed wherever the input and the
+        ``'full'`` pads with one less than the filter size on both sides. This
+        is equivalent to computing the convolution wherever the input and the
         filter overlap by at least one position.
 
-        If 'same', the convolution is computed wherever the input and the
-        filter overlap by at least half the filter size, when the filter size
-        is odd. In practice, the input is zero-padded with half the filter size
-        at the beginning and half at the end (or one less than half in the case
-        of an even filter size). This results in an output length that is the
-        same as the input length (for both odd and even filter sizes).
+        ``'same'`` pads with half the filter size on both sides (one less on
+        the second side for an even filter size). When ``stride=1``, this
+        results in an output size equal to the input size.
 
-    untie_biases : bool, default False
+        Note that ``'full'`` and ``'same'`` can be faster than equivalent
+        integer values due to optimizations by Theano.
+
+    untie_biases : bool (default: False)
         If ``False``, the layer will have a bias parameter for each channel,
         which is shared across all positions in this channel. As a result, the
         `b` attribute will be a vector (1D).
@@ -185,12 +191,7 @@ class Conv2DDNNLayer(DNNLayer):
         The nonlinearity that is applied to the layer activations. If None
         is provided, the layer will be linear.
 
-    pad : int, iterable or None
-        An integer or a 2-element tuple specifying the amount of zero-padding
-        on each side. This may also be ``None``, in which case the correct
-        amount of padding will be inferred from the specified ``border_mode``.
-
-    flip_filters : bool, default False
+    flip_filters : bool (default: False)
         Whether to flip the filters and perform a convolution, or not to flip
         them and perform a correlation. Flipping adds a bit of overhead, so it
         is disabled by default. In most cases this does not make a difference
@@ -212,15 +213,13 @@ class Conv2DDNNLayer(DNNLayer):
     Notes
     -----
     Unlike :class:`lasagne.layers.Conv2DLayer`, this layer properly supports
-    the 'same' border mode. It is not emulated. This should result in better
+    the 'same' pad. It is not emulated. This should result in better
     performance.
-
-    Only one of ``pad`` and ``border_mode`` should be specified.
     """
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
-                 border_mode=None, untie_biases=False, W=init.GlorotUniform(),
+                 pad=0, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
-                 pad=None, flip_filters=False, **kwargs):
+                 flip_filters=False, **kwargs):
         super(Conv2DDNNLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
@@ -233,34 +232,22 @@ class Conv2DDNNLayer(DNNLayer):
         self.untie_biases = untie_biases
         self.flip_filters = flip_filters
 
-        if border_mode is not None and pad is not None:
-            raise RuntimeError("You cannot specify both 'border_mode' and "
-                               "'pad'. To avoid ambiguity, please specify "
-                               "only one of them.")
-        elif border_mode is None and pad is None:
-            # no option specified, default to valid mode
-            self.pad = (0, 0)
-            self.border_mode = 'valid'
-        elif border_mode is not None:
-            if border_mode == 'valid':
+        if isinstance(pad, basestring):
+            if pad == 'valid':
                 self.pad = (0, 0)
-                self.border_mode = 'valid'
-            elif border_mode == 'full':
-                self.pad = (self.filter_size[0] - 1, self.filter_size[1] - 1)
-                self.border_mode = 'full'
-            elif border_mode == 'same':
+            elif pad == 'full':
+                self.pad = 'full'
+            elif pad == 'same':
                 # dnn_conv does not support same, so we just specify
                 # padding directly.
                 # only works for odd filter size, but the even filter size
                 # case is probably not worth supporting.
                 self.pad = ((self.filter_size[0] - 1) // 2,
                             (self.filter_size[1] - 1) // 2)
-                self.border_mode = None
             else:
-                raise RuntimeError("Invalid border mode: '%s'" % border_mode)
+                raise RuntimeError("Invalid pad: '%s'" % pad)
         else:
             self.pad = as_tuple(pad, 2)
-            self.border_mode = None
 
         self.W = self.add_param(W, self.get_W_shape(), name="W")
         if b is None:
@@ -285,27 +272,23 @@ class Conv2DDNNLayer(DNNLayer):
         output_rows = conv_output_length(input_shape[2],
                                          self.filter_size[0],
                                          self.stride[0],
-                                         'pad', self.pad[0])
+                                         self.pad[0])
 
         output_columns = conv_output_length(input_shape[3],
                                             self.filter_size[1],
                                             self.stride[1],
-                                            'pad', self.pad[1])
+                                            self.pad[1])
 
         return (batch_size, self.num_filters, output_rows, output_columns)
 
     def get_output_for(self, input, **kwargs):
         # by default we assume 'cross', consistent with corrmm.
         conv_mode = 'conv' if self.flip_filters else 'cross'
-        # if 'border_mode' is one of 'valid' or 'full' use that.
-        # else use pad directly.
-        border_mode = (self.border_mode if (self.border_mode is not None)
-                       else self.pad)
 
         conved = dnn.dnn_conv(img=input,
                               kerns=self.W,
                               subsample=self.stride,
-                              border_mode=border_mode,
+                              border_mode=self.pad,
                               conv_mode=conv_mode
                               )
 

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -115,7 +115,7 @@ def test_conv_output_length():
 
     with pytest.raises(ValueError) as exc:
         conv_output_length(13, 5, 3, '_nonexistent_mode')
-    assert "Invalid pad" in exc.value.args[0]
+    assert "Invalid pad: " in exc.value.args[0]
 
 
 @pytest.fixture
@@ -167,10 +167,17 @@ class TestConv1DLayer:
     def test_invalid_pad(self, DummyInputLayer):
         from lasagne.layers.conv import Conv1DLayer
         input_layer = DummyInputLayer((1, 2, 3))
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(TypeError) as exc:
             layer = Conv1DLayer(input_layer, num_filters=16, filter_size=(3,),
                                 pad='_nonexistent_mode')
-        assert "Invalid pad" in exc.value.args[0]
+        assert "iterable of int" in exc.value.args[0]
+
+    def test_custom_pad(self, DummyInputLayer):
+        from lasagne.layers.conv import Conv1DLayer
+        input_layer = DummyInputLayer((1, 2, 3))
+        with pytest.raises(ValueError) as exc:
+            layer = Conv1DLayer(input_layer, 16, (3,), pad=(1,))
+        assert "Arbitrary padding" in exc.value.args[0]
 
 
 class TestConv2DLayerImplementations:
@@ -264,10 +271,10 @@ class TestConv2DLayerImplementations:
 
     def test_invalid_pad(self, Conv2DImpl, DummyInputLayer):
         input_layer = DummyInputLayer((1, 2, 3))
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(TypeError) as exc:
             layer = Conv2DImpl(input_layer, num_filters=16, filter_size=(3, 3),
                                pad='_nonexistent_mode')
-        assert "Invalid pad" in exc.value.args[0]
+        assert "iterable of int" in exc.value.args[0]
 
     def test_get_params(self, Conv2DImpl, DummyInputLayer):
         input_layer = DummyInputLayer((128, 3, 32, 32))
@@ -279,6 +286,14 @@ class TestConv2DLayerImplementations:
         assert layer.get_params(trainable=False) == []
         assert layer.get_params(_nonexistent_tag=True) == []
         assert layer.get_params(_nonexistent_tag=False) == [layer.W, layer.b]
+
+
+class TestConv2DLayer:
+    def test_custom_pad(self):
+        from lasagne.layers.conv import Conv2DLayer
+        with pytest.raises(ValueError) as exc:
+            layer = Conv2DLayer((None,) * 4, 16, (3, 3), pad=(1, 1))
+        assert "Arbitrary padding" in exc.value.args[0]
 
 
 class TestConv2DDNNLayer:

--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -31,6 +31,8 @@ def test_as_tuple_fails():
     from lasagne.utils import as_tuple
     with pytest.raises(ValueError):
         as_tuple([1, 2, 3], 4)
+    with pytest.raises(TypeError):
+        as_tuple('asdf', 4, int)
 
 
 def test_compute_norms():

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -137,29 +137,42 @@ def unique(l):
     return new_list
 
 
-def as_tuple(x, N):
+def as_tuple(x, N, t=None):
     """
-    Coerce a value to a tuple of length N.
+    Coerce a value to a tuple of given length (and possibly given type).
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     x : value or iterable
     N : integer
         length of the desired tuple
+    t : type, optional
+        required type for all elements
 
-    Returns:
-    --------
+    Returns
+    -------
     tuple
         ``tuple(x)`` if `x` is iterable, ``(x,) * N`` otherwise.
+
+    Raises
+    ------
+    TypeError
+        if `type` is given and `x` or any of its elements do not match it
+    ValueError
+        if `x` is iterable, but does not have exactly `N` elements
     """
     try:
         X = tuple(x)
     except TypeError:
         X = (x,) * N
 
+    if (t is not None) and not all(isinstance(v, t) for v in X):
+        raise TypeError("expected a single value or an iterable "
+                        "of {0}, got {1} instead".format(t.__name__, x))
+
     if len(X) != N:
-        raise ValueError("input must be a single value "
-                         "or an iterable with length {0}".format(N))
+        raise ValueError("expected a single value or an iterable "
+                         "with length {0}, got {1} instead".format(N, x))
 
     return X
 


### PR DESCRIPTION
Continuation of #311. Closes #311. (So github knows.)

I'm starting from the relevant changes done by Martin, dropping all unrelated docstring style changes (sorry, they don't really belong here and they caused a merge conflict).

I'll try fixing all Python3- and cuDNN-related bugs now.