### PR TITLE
Ensure that tests calling set_rng() switch back to the default RNG

### DIFF
--- a/lasagne/tests/layers/test_noise.py
+++ b/lasagne/tests/layers/test_noise.py
@@ -4,7 +4,7 @@ from numpy.random import RandomState
 import theano
 import pytest
 
-from lasagne.random import set_rng
+from lasagne.random import get_rng, set_rng
 
 
 class TestDropoutLayer:
@@ -59,6 +59,7 @@ class TestDropoutLayer:
         from lasagne.layers.noise import DropoutLayer
         input = theano.shared(numpy.ones((100, 100)))
         seed = 123456789
+        rng = get_rng()
 
         set_rng(RandomState(seed))
         result = DropoutLayer(input_layer).get_output_for(input)
@@ -67,6 +68,8 @@ class TestDropoutLayer:
         set_rng(RandomState(seed))
         result = DropoutLayer(input_layer).get_output_for(input)
         result_eval2 = result.eval()
+
+        set_rng(rng)  # reset to original RNG for other tests
         assert numpy.allclose(result_eval1, result_eval2)
 
 
@@ -99,6 +102,7 @@ class TestGaussianNoiseLayer:
         from lasagne.layers.noise import GaussianNoiseLayer
         input = theano.shared(numpy.ones((100, 100)))
         seed = 123456789
+        rng = get_rng()
 
         set_rng(RandomState(seed))
         result = GaussianNoiseLayer(input_layer).get_output_for(input)
@@ -107,4 +111,6 @@ class TestGaussianNoiseLayer:
         set_rng(RandomState(seed))
         result = GaussianNoiseLayer(input_layer).get_output_for(input)
         result_eval2 = result.eval()
+
+        set_rng(rng)  # reset to original RNG for other tests
         assert numpy.allclose(result_eval1, result_eval2)

--- a/lasagne/tests/test_init.py
+++ b/lasagne/tests/test_init.py
@@ -23,7 +23,7 @@ def test_shape():
 
 
 def test_specified_rng():
-    from lasagne.random import set_rng
+    from lasagne.random import get_rng, set_rng
     from lasagne.init import (Normal, Uniform, GlorotNormal,
                               GlorotUniform, Sparse, Orthogonal)
 
@@ -31,6 +31,7 @@ def test_specified_rng():
     from numpy import allclose
 
     seed = 123456789
+    rng = get_rng()
 
     for init_class in [Normal, Uniform, GlorotNormal,
                        GlorotUniform, Sparse, Orthogonal]:
@@ -38,6 +39,7 @@ def test_specified_rng():
         sample1 = init_class().sample((100, 100))
         set_rng(RandomState(seed))
         sample2 = init_class().sample((100, 100))
+        set_rng(rng)  # reset to original RNG for other tests
         assert allclose(sample1, sample2),\
             ("random initialization was inconsistent for {}"
              .format(init_class.__name__))


### PR DESCRIPTION
Fixes `test_noise.py` and `test_init.py` to restore the original RNG in `lasagne.random` after calling `lasagne.random.set_rng()` for some tests. This ensures that tests called afterwards can still use `np.random.seed(...)` as expected, and don't start with a fixed seed.

(Note: We could also do `get_rng().seed(...)` instead of `set_rng(RandomState(...))`, but I think a side intention was to test whether `set_rng()` works.)