### PR TITLE
Remove deprecates

### DIFF
--- a/lasagne/init.py
+++ b/lasagne/init.py
@@ -83,13 +83,6 @@ class Uniform(Initializer):
         see std for description.
     """
     def __init__(self, range=0.01, std=None, mean=0.0):
-        import warnings
-        warnings.warn("The uniform initializer no longer uses Glorot et al.'s "
-                      "approach to determine the bounds, but defaults to the "
-                      "range (-0.01, 0.01) instead. Please use the new "
-                      "GlorotUniform initializer to get the old behavior. "
-                      "GlorotUniform is now the default for all layers.")
-
         if std is not None:
             a = mean - np.sqrt(3) * std
             b = mean + np.sqrt(3) * std

--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -218,14 +218,6 @@ class Layer(object):
 
         return param
 
-    def get_bias_params(self):  # pragma: no cover
-        import warnings
-        warnings.warn("layer.get_bias_params() is deprecated and will be "
-                      "removed for the first release of Lasagne. Please use "
-                      "layer.get_params(regularizable=False) instead.",
-                      stacklevel=2)
-        return self.get_params(regularizable=False)
-
 
 class MergeLayer(Layer):
     """

--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -97,28 +97,6 @@ class Layer(object):
 
         return result
 
-    def get_output_shape(self):  # pragma: no cover
-        """
-        Deprecated. Use `layer.output_shape`.
-        """
-        import warnings
-        warnings.warn("layer.get_output_shape() is deprecated and will be "
-                      "removed for the first release of Lasagne. Please use "
-                      "layer.output_shape instead.", stacklevel=2)
-        return self.output_shape
-
-    def get_output(self, input=None, **kwargs):  # pragma: no cover
-        """
-        Deprecated. Use `lasagne.layers.get_output(layer, input, **kwargs)`.
-        """
-        import warnings
-        warnings.warn("layer.get_output(...) is deprecated and will be "
-                      "removed for the first release of Lasagne. Please use "
-                      "lasagne.layers.get_output(layer, ...) instead.",
-                      stacklevel=2)
-        from .helper import get_output
-        return get_output(self, input, **kwargs)
-
     def get_output_shape_for(self, input_shape):
         """
         Computes the output shape of this layer, given an input shape.

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -8,7 +8,6 @@ from .. import utils
 
 __all__ = [
     "get_all_layers",
-    "get_all_layers_old",
     "get_output",
     "get_output_shape",
     "get_all_params",
@@ -65,14 +64,6 @@ def get_all_layers(layer, treat_as_input=None):
     >>> get_all_layers(l3, treat_as_input=[l2]) == [l2, l3]
     True
     """
-    import warnings
-    warnings.warn("get_all_layers() has been changed to return layers in "
-                  "topological order. The former implementation is still "
-                  "available as get_all_layers_old(), but will be removed "
-                  "before the first release of Lasagne. To ignore this "
-                  "warning, use `warnings.filterwarnings('ignore', "
-                  "'.*topo.*')`.")
-
     # We perform a depth-first search. We add a layer to the result list only
     # after adding all its incoming layers (if any) or when detecting a cycle.
     # We use a LIFO stack to avoid ever running into recursion depth limits.
@@ -114,38 +105,6 @@ def get_all_layers(layer, treat_as_input=None):
                 done.add(layer)
 
     return result
-
-
-def get_all_layers_old(layer):  # pragma no cover
-    """
-    Earlier implementation of `get_all_layers()` that does a breadth-first
-    search. Kept here to ease converting old models that rely on the order of
-    get_all_layers() or get_all_params(). Will be removed before the first
-    release of Lasagne.
-    """
-    if isinstance(layer, (list, tuple)):
-        layers = list(layer)
-    else:
-        layers = [layer]
-    layers_to_expand = list(layers)
-    while len(layers_to_expand) > 0:
-        current_layer = layers_to_expand.pop(0)
-        children = []
-
-        if hasattr(current_layer, 'input_layers'):
-            children = current_layer.input_layers
-        elif hasattr(current_layer, 'input_layer'):
-            children = [current_layer.input_layer]
-
-        # filter the layers that have already been visited, and remove None
-        # elements (for layers without incoming layers)
-        children = [child for child in children
-                    if child not in layers and
-                    child is not None]
-        layers_to_expand.extend(children)
-        layers.extend(children)
-
-    return layers
 
 
 def get_output(layer_or_layers, inputs=None, **kwargs):

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -14,8 +14,6 @@ __all__ = [
     "count_params",
     "get_all_param_values",
     "set_all_param_values",
-    "get_all_bias_params",
-    "get_all_non_bias_params",
 ]
 
 
@@ -308,24 +306,6 @@ def get_all_params(layer, **tags):
     layers = get_all_layers(layer)
     params = sum([l.get_params(**tags) for l in layers], [])
     return utils.unique(params)
-
-
-def get_all_bias_params(layer):  # pragma no cover
-    import warnings
-    warnings.warn("get_all_bias_params(layer) is deprecated and will be "
-                  "removed for the first release of Lasagne. Please use "
-                  "get_all_params(layer, regularizable=False) instead.",
-                  stacklevel=2)
-    return get_all_params(layer, regularizable=False)
-
-
-def get_all_non_bias_params(layer):  # pragma no cover
-    import warnings
-    warnings.warn("get_all_non_bias_params(layer) is deprecated and will be "
-                  "removed for the first release of Lasagne. Please use "
-                  "get_all_params(layer, regularizable=True) instead.",
-                  stacklevel=2)
-    return get_all_params(layer, regularizable=True)
 
 
 def count_params(layer, **tags):

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -71,7 +71,6 @@ __all__ = [
     "categorical_crossentropy",
     "squared_error",
     "aggregate",
-    "mse", "Objective", "MaskedObjective",  # deprecated
 ]
 
 
@@ -199,81 +198,3 @@ def aggregate(loss, weights=None, mode='mean'):
     else:
         raise ValueError("mode must be 'mean', 'sum' or 'normalized_sum', "
                          "got %r" % mode)
-
-
-def mse(x, t):  # pragma no cover
-    """Deprecated. Use :func:`squared_error()` instead."""
-    import warnings
-    warnings.warn("lasagne.objectives.mse() is deprecated and will be removed "
-                  "for the first release of Lasagne. Use "
-                  "lasagne.objectives.squared_error() instead.", stacklevel=2)
-    return squared_error(x, t)
-
-
-class Objective(object):  # pragma no cover
-    """
-    Deprecated. See docstring of :mod:`lasagne.objectives` for alternatives.
-    """
-
-    def __init__(self, input_layer, loss_function=squared_error,
-                 aggregation='mean'):
-        import warnings
-        warnings.warn("lasagne.objectives.Objective is deprecated and "
-                      "will be removed for the first release of Lasagne. For "
-                      "alternatives, please see: "
-                      "http://lasagne.readthedocs.org/en/latest/"
-                      "modules/objectives.html", stacklevel=2)
-        import theano.tensor as T
-        self.input_layer = input_layer
-        self.loss_function = loss_function
-        self.target_var = T.matrix("target")
-        self.aggregation = aggregation
-
-    def get_loss(self, input=None, target=None, aggregation=None, **kwargs):
-        from lasagne.layers import get_output
-        network_output = get_output(self.input_layer, input, **kwargs)
-
-        if target is None:
-            target = self.target_var
-        if aggregation is None:
-            aggregation = self.aggregation
-
-        losses = self.loss_function(network_output, target)
-
-        return aggregate(losses, mode=aggregation)
-
-
-class MaskedObjective(object):  # pragma no cover
-    """
-    Deprecated. See docstring of :mod:`lasagne.objectives` for alternatives.
-    """
-
-    def __init__(self, input_layer, loss_function=mse, aggregation='mean'):
-        import warnings
-        warnings.warn("lasagne.objectives.MaskedObjective is deprecated and "
-                      "will be removed for the first release of Lasagne. For "
-                      "alternatives, please see: "
-                      "http://lasagne.readthedocs.org/en/latest/"
-                      "modules/objectives.html", stacklevel=2)
-        import theano.tensor as T
-        self.input_layer = input_layer
-        self.loss_function = loss_function
-        self.target_var = T.matrix("target")
-        self.mask_var = T.matrix("mask")
-        self.aggregation = aggregation
-
-    def get_loss(self, input=None, target=None, mask=None,
-                 aggregation=None, **kwargs):
-        from lasagne.layers import get_output
-        network_output = get_output(self.input_layer, input, **kwargs)
-
-        if target is None:
-            target = self.target_var
-        if mask is None:
-            mask = self.mask_var
-        if aggregation is None:
-            aggregation = self.aggregation
-
-        losses = self.loss_function(network_output, target)
-
-        return aggregate(losses, mask, mode=aggregation)

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -108,7 +108,7 @@ class TestFeaturePoolLayer:
         numpy_result = max_pool_1d(numpy_result, pool_size)
         numpy_result = np.swapaxes(numpy_result, -1, axis)
 
-        assert np.all(numpy_result.shape == layer.get_output_shape())
+        assert np.all(numpy_result.shape == layer.output_shape)
         assert np.all(numpy_result.shape == layer_result.shape)
         assert np.allclose(numpy_result, layer_result)
 


### PR DESCRIPTION
Resolves #345.

There's no instance of `warning`, `deprec` or `no cover` left (except for GPU-related `pragma: no cover` markers), and all the tests pass (actually had to fix one of them, though).