### PR TITLE
Attribute code to "Lasagne contributors"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,13 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Sander Dieleman
+Copyright (c) 2014-2015 Lasagne contributors
+
+Lasagne uses a shared copyright model: each contributor holds copyright over
+their contributions to Lasagne. The project versioning records all such
+contribution and copyright details.
+By contributing to the Lasagne repository through pull-request, comment,
+or otherwise, the contributor releases their content to the license and
+copyright terms herein.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Lasagne'
-copyright = u'2014–2015, Sander Dieleman and contributors'
+copyright = u'2014–2015, Lasagne contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -251,7 +251,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     ('index', 'lasagne.tex', u'lasagne Documentation',
-     u'Sander Dieleman and contributors', 'manual'),
+     u'Lasagne contributors', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -281,7 +281,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'lasagne', u'Lasagne Documentation',
-     [u'Sander Dieleman and contributors'], 1)
+     [u'Lasagne contributors'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -295,7 +295,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     ('index', 'lasagne', u'Lasagne Documentation',
-     u'Sander Dieleman and contributors', 'Lasagne',
+     u'Lasagne contributors', 'Lasagne',
      'One line description of project.', 'Miscellaneous'),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ tests_require = [
 setup(
     name="Lasagne",
     version=version,
-    description="neural network tools for Theano",
+    description="A lightweight library to build and train neural networks "
+                "in Theano",
     long_description="\n\n".join([README, CHANGES]),
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -40,8 +41,8 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         ],
     keywords="",
-    author="Sander Dieleman",
-    author_email="sanderdieleman@gmail.com",
+    author="Lasagne contributors",
+    author_email="lasagne-users@googlegroups.com",
     url="https://github.com/Lasagne/Lasagne",
     license="MIT",
     packages=find_packages(),


### PR DESCRIPTION
Changes attributions in code, documentation and license to include all Lasagne contributors, not only (or not primarily) Sander. He's still explicitly named as the one who started the project, though!

Copied some sections about copyright and contribution agreement from Caffe's license file. Not sure if we need to include Caffe's license file now because Caffe's license text is covered by Caffe's license text? %-)

I've chosen our google group as the email address to contact the authors under. Seemed like the most reasonable option. (Theano has its *theano-dev* group there, but we don't have nor need one. Blocks and Fuel don't give an email address at all, which would also be an option.)