### PR TITLE
Implemented 2D upscaling layer

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -80,6 +80,7 @@
     MaxPool1DLayer
     MaxPool2DLayer
     Pool2DLayer
+    Upscale2DLayer
     GlobalPoolLayer
     FeaturePoolLayer
     FeatureWTALayer

--- a/docs/modules/layers/pool.rst
+++ b/docs/modules/layers/pool.rst
@@ -14,6 +14,9 @@ Pooling layers
 .. autoclass:: Pool2DLayer
     :members:
 
+.. autoclass:: Upscale2DLayer
+    :members:
+
 .. autoclass:: GlobalPoolLayer
     :members:
 

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -10,6 +10,7 @@ __all__ = [
     "MaxPool1DLayer",
     "MaxPool2DLayer",
     "Pool2DLayer",
+    "Upscale2DLayer",
     "FeaturePoolLayer",
     "FeatureWTALayer",
     "GlobalPoolLayer",
@@ -289,6 +290,54 @@ class MaxPool2DLayer(Pool2DLayer):
 
 # TODO: add reshape-based implementation to MaxPool*DLayer
 # TODO: add MaxPool3DLayer
+
+
+class Upscale2DLayer(Layer):
+    """
+    2D upscaling layer layer
+
+    Performs 2D upscaling over the two trailing axes of a 4D input tensor.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or tuple
+        The layer feeding into this layer, or the expected input shape.
+
+    scale_factor : integer or iterable
+        The scale factor in each dimension. If an integer, it is promoted to
+        a square scale factor region. If an iterable, it should have two
+        elements.
+
+    **kwargs
+        Any additional keyword arguments are passed to the :class:`Layer`
+        superclass.
+    """
+
+    def __init__(self, incoming, scale_factor, **kwargs):
+        super(Upscale2DLayer, self).__init__(incoming, **kwargs)
+
+        self.scale_factor = as_tuple(scale_factor, 2)
+
+        if self.scale_factor[0] < 1 or self.scale_factor[1] < 1:
+            raise ValueError('Scale factor must be >= 1, not {0}'.format(
+                self.scale_factor))
+
+    def get_output_shape_for(self, input_shape):
+        output_shape = list(input_shape)  # copy / convert to mutable list
+        if output_shape[2] is not None:
+            output_shape[2] *= self.scale_factor[0]
+        if output_shape[3] is not None:
+            output_shape[3] *= self.scale_factor[1]
+        return tuple(output_shape)
+
+    def get_output_for(self, input, **kwargs):
+        a, b = self.scale_factor
+        upscaled = input
+        if b > 1:
+            upscaled = T.extra_ops.repeat(upscaled, b, 3)
+        if a > 1:
+            upscaled = T.extra_ops.repeat(upscaled, a, 2)
+        return upscaled
 
 
 class FeaturePoolLayer(Layer):

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -70,6 +70,19 @@ def max_pool_2d_ignoreborder(data, pool_size, stride, pad):
     return data_pooled
 
 
+def upscale_2d_shape(shape, scale_factor):
+    return (shape[0], shape[1],
+            shape[2] * scale_factor[0], shape[3] * scale_factor[1])
+
+
+def upscale_2d(data, scale_factor):
+    upscaled = np.zeros(upscale_2d_shape(data.shape, scale_factor))
+    for j in range(scale_factor[0]):
+        for i in range(scale_factor[1]):
+            upscaled[:, :, j::scale_factor[0], i::scale_factor[1]] = data
+    return upscaled
+
+
 class TestFeaturePoolLayer:
     def pool_test_sets():
         for pool_size in [2, 3]:
@@ -467,6 +480,67 @@ class TestMaxPool2DNNLayer:
         except NotImplementedError:
             raise
         #    pytest.skip()
+
+
+class TestUpscale2DLayer:
+    def scale_factor_test_sets():
+        for scale_factor in [2, 3]:
+                yield scale_factor
+
+    def input_layer(self, output_shape):
+        return Mock(output_shape=output_shape)
+
+    def layer(self, input_layer, scale_factor):
+        from lasagne.layers.pool import Upscale2DLayer
+        return Upscale2DLayer(
+            input_layer,
+            scale_factor=scale_factor,
+        )
+
+    def test_invalid_scale_factor(self):
+        from lasagne.layers.pool import Upscale2DLayer
+        inlayer = self.input_layer((128, 3, 32, 32))
+        with pytest.raises(ValueError):
+            Upscale2DLayer(inlayer, scale_factor=0)
+        with pytest.raises(ValueError):
+            Upscale2DLayer(inlayer, scale_factor=-1)
+        with pytest.raises(ValueError):
+            Upscale2DLayer(inlayer, scale_factor=(0, 2))
+        with pytest.raises(ValueError):
+            Upscale2DLayer(inlayer, scale_factor=(2, 0))
+
+    @pytest.mark.parametrize(
+        "scale_factor", list(scale_factor_test_sets()))
+    def test_get_output_for(self, scale_factor):
+        input = floatX(np.random.randn(8, 16, 17, 13))
+        input_layer = self.input_layer(input.shape)
+        input_theano = theano.shared(input)
+        result = self.layer(
+            input_layer,
+            (scale_factor, scale_factor),
+        ).get_output_for(input_theano)
+
+        result_eval = result.eval()
+        numpy_result = upscale_2d(input, (scale_factor, scale_factor))
+
+        assert np.all(numpy_result.shape == result_eval.shape)
+        assert np.allclose(result_eval, numpy_result)
+
+    @pytest.mark.parametrize(
+        "input_shape,output_shape",
+        [((32, 64, 24, 24), (32, 64, 48, 48)),
+         ((None, 64, 24, 24), (None, 64, 48, 48)),
+         ((32, None, 24, 24), (32, None, 48, 48)),
+         ((32, 64, None, 24), (32, 64, None, 48)),
+         ((32, 64, 24, None), (32, 64, 48, None)),
+         ((32, 64, None, None), (32, 64, None, None))],
+    )
+    def test_get_output_shape_for(self, input_shape, output_shape):
+        input_layer = self.input_layer(input_shape)
+        layer = self.layer(input_layer,
+                           scale_factor=(2, 2))
+        assert layer.get_output_shape_for(
+            input_shape) == output_shape
 
 
 class TestFeatureWTALayer(object):


### PR DESCRIPTION
Implemented Upscale2DLayer, a layer that performs in inverse operation of pooling layers.
Useful in segmentation approaches such as [1], [2] and [3].

The layer was added to pool.py. Tests are included.

[1] U-Net: Convolutional Networks for Biomedical Image Segmentation, http://arxiv.org/abs/1505.04597
[2] Hypercolumns for Object Segmentation and Fine-grained Localization, http://arxiv.org/abs/1411.5752
[3] Image Segmentation with Cascaded Hierarchical Models and Logistic
Disjunctive Normal Networks, http://www.cv-foundation.org/openaccess/content_iccv_2013/papers/Seyedhosseini_Image_Segmentation_with_2013_ICCV_paper.pdf

