### PR TITLE
Unify *PoolLayer interfaces, new default ignore_border=True

### DIFF
--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -477,11 +477,11 @@ class MaxPool2DCCLayer(CCLayer):
             raise NotImplementedError("MaxPool2DCCLayer only supports "
                                       "stride <= pool_size.")
 
-        # ignore_border argument is for compatibility with MaxPool2DLayer.
-        # it is not supported. Borders are never ignored.
-        if ignore_border is not False:
+        # The ignore_border argument is for compatibility with MaxPool2DLayer.
+        # ignore_border=True is not supported. Borders are never ignored.
+        if ignore_border:
             raise NotImplementedError("MaxPool2DCCLayer does not support "
-                                      "ignore_border.")
+                                      "ignore_border=True.")
 
         self.dimshuffle = dimshuffle
 
@@ -500,14 +500,14 @@ class MaxPool2DCCLayer(CCLayer):
         output_rows = pool_output_length(input_rows,
                                          pool_size=self.pool_size,
                                          stride=self.stride,
-                                         ignore_border=False,
                                          pad=0,
+                                         ignore_border=False,
                                          )
         output_columns = pool_output_length(input_columns,
                                             pool_size=self.pool_size,
                                             stride=self.stride,
-                                            ignore_border=False,
                                             pad=0,
+                                            ignore_border=False,
                                             )
 
         if self.dimshuffle:

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -16,8 +16,7 @@ __all__ = [
 ]
 
 
-def pool_output_length(input_length, pool_size, stride,
-                       ignore_border, pad):
+def pool_output_length(input_length, pool_size, stride, pad, ignore_border):
     """
     Compute the output length of a pooling operator
     along a single dimension.
@@ -108,10 +107,13 @@ class MaxPool1DLayer(Layer):
     The value used to pad the input is chosen to be less than
     the minimum of the input, so that the output of each pooling region
     always corresponds to some element in the unpadded input region.
+
+    Using ``ignore_border=False`` prevents Theano from using cuDNN for the
+    operation, so it will fall back to a slower implementation.
     """
 
     def __init__(self, incoming, pool_size, stride=None, pad=0,
-                 ignore_border=False, **kwargs):
+                 ignore_border=True, **kwargs):
         super(MaxPool1DLayer, self).__init__(incoming, **kwargs)
         self.pool_size = as_tuple(pool_size, 1)
         self.stride = self.pool_size if stride is None else as_tuple(stride, 1)
@@ -124,8 +126,8 @@ class MaxPool1DLayer(Layer):
         output_shape[-1] = pool_output_length(input_shape[-1],
                                               pool_size=self.pool_size[0],
                                               stride=self.stride[0],
-                                              ignore_border=self.ignore_border,
                                               pad=self.pad[0],
+                                              ignore_border=self.ignore_border,
                                               )
 
         return tuple(output_shape)
@@ -163,14 +165,14 @@ class Pool2DLayer(Layer):
         The strides between sucessive pooling regions in each dimension.
         If ``None`` then ``stride = pool_size``.
 
-    ignore_border : bool
-        If ``True``, partial pooling regions will be ignored.
-        Must be ``True`` if ``pad != (0, 0)``.
-
     pad : integer or iterable
         Number of elements to be added on each side of the input
         in each dimension. Each value must be less than
         the corresponding stride.
+
+    ignore_border : bool
+        If ``True``, partial pooling regions will be ignored.
+        Must be ``True`` if ``pad != (0, 0)``.
 
     mode : {'max', 'average_inc_pad', 'average_exc_pad'}
         Pooling mode: max-pooling or mean-pooling including/excluding zeros
@@ -189,10 +191,13 @@ class Pool2DLayer(Layer):
     The value used to pad the input is chosen to be less than
     the minimum of the input, so that the output of each pooling region
     always corresponds to some element in the unpadded input region.
+
+    Using ``ignore_border=False`` prevents Theano from using cuDNN for the
+    operation, so it will fall back to a slower implementation.
     """
 
-    def __init__(self, incoming, pool_size, stride=None,
-                 ignore_border=False, pad=(0, 0), mode='max', **kwargs):
+    def __init__(self, incoming, pool_size, stride=None, pad=(0, 0),
+                 ignore_border=True, mode='max', **kwargs):
         super(Pool2DLayer, self).__init__(incoming, **kwargs)
 
         self.pool_size = as_tuple(pool_size, 2)
@@ -213,15 +218,15 @@ class Pool2DLayer(Layer):
         output_shape[2] = pool_output_length(input_shape[2],
                                              pool_size=self.pool_size[0],
                                              stride=self.stride[0],
-                                             ignore_border=self.ignore_border,
                                              pad=self.pad[0],
+                                             ignore_border=self.ignore_border,
                                              )
 
         output_shape[3] = pool_output_length(input_shape[3],
                                              pool_size=self.pool_size[1],
                                              stride=self.stride[1],
-                                             ignore_border=self.ignore_border,
                                              pad=self.pad[1],
+                                             ignore_border=self.ignore_border,
                                              )
 
         return tuple(output_shape)
@@ -275,15 +280,18 @@ class MaxPool2DLayer(Pool2DLayer):
     The value used to pad the input is chosen to be less than
     the minimum of the input, so that the output of each pooling region
     always corresponds to some element in the unpadded input region.
+
+    Using ``ignore_border=False`` prevents Theano from using cuDNN for the
+    operation, so it will fall back to a slower implementation.
     """
 
-    def __init__(self, incoming, pool_size, stride=None,
-                 ignore_border=False, pad=(0, 0), **kwargs):
+    def __init__(self, incoming, pool_size, stride=None, pad=(0, 0),
+                 ignore_border=True, **kwargs):
         super(MaxPool2DLayer, self).__init__(incoming,
                                              pool_size,
                                              stride,
-                                             ignore_border,
                                              pad,
+                                             ignore_border,
                                              mode='max',
                                              **kwargs)
 

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -354,29 +354,29 @@ class TestMaxPool2DCCLayer:
 
         input_layer = self.input_layer((128, 4, 12, 12))
 
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(NotImplementedError) as exc:
             layer = MaxPool2DCCLayer(input_layer, pool_size=2, pad=2)
         assert "MaxPool2DCCLayer does not support padding" in exc.value.args[0]
 
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(NotImplementedError) as exc:
             layer = MaxPool2DCCLayer(input_layer, pool_size=(2, 3))
         assert ("MaxPool2DCCLayer only supports square pooling regions" in
                 exc.value.args[0])
 
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(NotImplementedError) as exc:
             layer = MaxPool2DCCLayer(input_layer, pool_size=2, stride=(1, 2))
         assert (("MaxPool2DCCLayer only supports using the same stride in "
                  "both directions") in exc.value.args[0])
 
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(NotImplementedError) as exc:
             layer = MaxPool2DCCLayer(input_layer, pool_size=2, stride=3)
         assert ("MaxPool2DCCLayer only supports stride <= pool_size" in
                 exc.value.args[0])
 
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(NotImplementedError) as exc:
             layer = MaxPool2DCCLayer(input_layer, pool_size=2,
                                      ignore_border=True)
-        assert ("MaxPool2DCCLayer does not support ignore_border" in
+        assert ("MaxPool2DCCLayer does not support ignore_border=True" in
                 exc.value.args[0])
 
     def test_dimshuffle_false(self):
@@ -464,6 +464,17 @@ class TestMaxPool2DNNLayer:
         except NotImplementedError:
             raise
         #    pytest.skip()
+
+    def test_not_implemented(self):
+        try:
+            from lasagne.layers.dnn import MaxPool2DDNNLayer
+        except ImportError:
+            pytest.skip("cuDNN not available")
+        with pytest.raises(NotImplementedError) as exc:
+            layer = MaxPool2DDNNLayer((1, 2, 3, 4), pool_size=2,
+                                      ignore_border=False)
+        assert ("Pool2DDNNLayer does not support ignore_border=False" in
+                exc.value.args[0])
 
 
 class TestFeatureWTALayer(object):

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -203,8 +203,7 @@ class TestMaxPool2DLayer:
                     yield (pool_size, stride, pad)
 
     def input_layer(self, output_shape):
-        return Mock(get_output_shape=lambda: output_shape,
-                    output_shape=output_shape)
+        return Mock(output_shape=output_shape)
 
     def layer(self, input_layer, pool_size, stride=None,
               pad=(0, 0), ignore_border=False):
@@ -293,8 +292,7 @@ class TestMaxPool2DCCLayer:
                 yield (pool_size, stride)
 
     def input_layer(self, output_shape):
-        return Mock(get_output_shape=lambda: output_shape,
-                    output_shape=output_shape)
+        return Mock(output_shape=output_shape)
 
     def layer(self, input_layer, pool_size, stride):
         try:
@@ -407,8 +405,7 @@ class TestMaxPool2DNNLayer:
                     yield (pool_size, stride, pad)
 
     def input_layer(self, output_shape):
-        return Mock(get_output_shape=lambda: output_shape,
-                    output_shape=output_shape)
+        return Mock(output_shape=output_shape)
 
     def layer(self, input_layer, pool_size, stride, pad):
         try:


### PR DESCRIPTION
Resolves #371 (users would get slow pooling layers by default because `ignore_border=False` prevents cuDNN from being used). Adds a note about `ignore_border=True` slowing down computations. Unifies `*PoolLayer` interfaces to follow the same order of `pool_size, stride, pad, ignore_border, (mode)`, they were inconsistent before and sometimes not even matching the order in their own docstrings. Adapts the tests.