### PR TITLE
Prepare for first release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,35 @@
+Changelog
+---------
+
+0.1 (2015-08-13)
+~~~~~~~~~~~~~~~~
+
+First release.
+
+* core contributors, in alphabetical order:
+
+  * Eric Battenberg (@ebattenberg)
+  * Sander Dieleman (@benanne)
+  * Daniel Nouri (@dnouri)
+  * Eben Olson (@ebenolson)
+  * Aäron van den Oord (@avdnoord)
+  * Colin Raffel (@craffel)
+  * Jan Schlüter (@f0k)
+  * Søren Kaae Sønderby (@skaae)
+
+* extra contributors, in chronological order:
+
+  * Daniel Maturana (@dimatura): documentation, cuDNN layers, LRN
+  * Jonas Degrave (@317070): get_all_param_values() fix
+  * Jack Kelly (@JackKelly): help with recurrent layers
+  * Gábor Takács (@takacsg84): support broadcastable parameters in lasagne.updates
+  * Diogo Moitinho de Almeida (@diogo149): MNIST example fixes
+  * Brian McFee (@bmcfee): MaxPool2DLayer fix
+  * Martin Thoma (@MartinThoma): documentation
+  * Jeffrey De Fauw (@JeffreyDF): documentation, ADAM fix
+  * Michael Heilman (@mheilman): NonlinearityLayer, lasagne.random
+  * Gregory Sanders (@instagibbs): documentation fix
+  * Jon Crall (@erotemic): check for non-positive input shapes
+  * Hendrik Weideman (@hjweide): set_all_param_values() test, MaxPool2DCCLayer fix
+  * Kashif Rasul (@kashif): ADAM simplification
+  * Peter de Rivaz (@peterderivaz): documentation fix

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include *.rst
+include *.txt
+include LICENSE
+
+recursive-include lasagne/tests *.py
+include .coveragerc
+recursive-include examples *.py
+recursive-include docs *.rst conf.py *.css Makefile
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -70,15 +70,12 @@ be handled below.
 Stable Lasagne release
 ======================
 
-.. note:: Lasagne hasn't been released yet. Please see the next section for
-    how to install the bleeding-edge version instead.
-
 Lasagne 0.1 requires a more recent version of Theano than the one available
 on PyPI. To install a version that is known to work, run the following command:
 
 .. code-block:: bash
 
-  pip install -r https://raw.githubusercontent.com/Lasagne/Lasagne/0.1/requirements.txt
+  pip install -r https://raw.githubusercontent.com/Lasagne/Lasagne/v0.1/requirements.txt
 
 .. warning::
   An even more recent version of Theano will often work as well, but at the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Theano/Theano.git@36d1eca8#egg=Theano==0.8.git
+git+https://github.com/Theano/Theano.git@15c90dd3#egg=Theano==0.8.git

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@ version = '0.1.dev'
 here = os.path.abspath(os.path.dirname(__file__))
 try:
     README = open(os.path.join(here, 'README.rst')).read()
-    CHANGES = ''
-    # CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
+    CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 except IOError:
     README = CHANGES = ''
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
-version = '0.1.dev'
+version = '0.1'
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     url="https://github.com/Lasagne/Lasagne",
     license="MIT",
     packages=find_packages(),
-    include_package_data=True,
+    include_package_data=False,
     zip_safe=False,
     install_requires=install_requires,
     extras_require={


### PR DESCRIPTION
This adds a changelog as suggested in https://github.com/Lasagne/Lasagne/issues/74#issuecomment-130331059, updates `requirements.txt` to a Theano version supporting cuDNN v3 as suggested in https://github.com/Lasagne/Lasagne/issues/74#issuecomment-130390810, and changes the version number from `0.1.dev` to `0.1`.

It assumes we're going to tag the release as `v0.1` (that's how numpy and blocks do it, for example), not as `0.1` (that's how, hmm... some projects do it like this). I'm fine with either way. @dnouri might have a preference?

It would be nice to have a DOI badge in the README of the first release, but I'm not sure if it's possible to add the DOI badge before we tag the release, which we need to do in order to get a DOI. I'll investigate.