### PR TITLE
Fix license badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 .. image:: https://img.shields.io/coveralls/Lasagne/Lasagne.svg
     :target: https://coveralls.io/r/Lasagne/Lasagne
 
-.. image:: https://img.shields.io/github/license/Lasagne/Lasagne.svg
+.. image:: https://img.shields.io/badge/license-MIT-blue.svg
     :target: https://github.com/Lasagne/Lasagne/blob/master/LICENSE
 
 Lasagne


### PR DESCRIPTION
With the additions in #366, github doesn't recognize the license file as being MIT any more. This PR just hard-codes the license type (as done by Blocks).