### PR TITLE
Bump to next development version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ copyright = u'2014–2015, Lasagne contributors'
 #
 import lasagne
 # The short X.Y version.
-version = '.'.join(lasagne.__version__.split('.', 3)[:2]).rstrip('dev')
+version = '.'.join(lasagne.__version__.split('.', 2)[:2])
 # The full version, including alpha/beta/rc tags.
 release = lasagne.__version__
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
-version = '0.1'
+version = '0.2.dev1'
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:


### PR DESCRIPTION
This should be merged before merging any code changes (at the very least because the documentation on readthedocs uses the `dev` suffix to check whether to link to the `v0.1` tag or the `master` branch on github for source code).

I'm not sure if `0.2.dev` is the right choice, though. We could also go for `0.1.1.dev`. And it seems that's not a valid version string anyway, I've previously seen some tool (pip?) complain and change it to `0.1.dev0`. So we could also go for `0.2.dev0` and slightly adapt `docs/conf.py` to cope with that.