### PR TITLE
Add BiasLayer

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -148,6 +148,7 @@
     :nosignatures:
 
     NonlinearityLayer
+    BiasLayer
     InverseLayer
     TransformerLayer
 

--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -60,7 +60,6 @@
     :nosignatures:
 
     DenseLayer
-    NonlinearityLayer
     NINLayer
 
 
@@ -148,6 +147,7 @@
 .. autosummary::
     :nosignatures:
 
+    NonlinearityLayer
     InverseLayer
     TransformerLayer
 

--- a/docs/modules/layers/dense.rst
+++ b/docs/modules/layers/dense.rst
@@ -8,9 +8,6 @@ Dense layers
 .. autoclass:: DenseLayer
    :members:
 
-.. autoclass:: NonlinearityLayer
-   :members:
-
 .. autoclass:: NINLayer
     :members:
 

--- a/docs/modules/layers/special.rst
+++ b/docs/modules/layers/special.rst
@@ -5,6 +5,9 @@ Special-purpose layers
 
 .. currentmodule:: lasagne.layers
 
+.. autoclass:: NonlinearityLayer
+   :members:
+
 .. autoclass:: InverseLayer
     :members:
 

--- a/docs/modules/layers/special.rst
+++ b/docs/modules/layers/special.rst
@@ -8,6 +8,9 @@ Special-purpose layers
 .. autoclass:: NonlinearityLayer
    :members:
 
+.. autoclass:: BiasLayer
+   :members:
+
 .. autoclass:: InverseLayer
     :members:
 

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -10,7 +10,6 @@ from .base import Layer
 __all__ = [
     "DenseLayer",
     "NINLayer",
-    "NonlinearityLayer"
 ]
 
 
@@ -89,32 +88,6 @@ class DenseLayer(Layer):
         if self.b is not None:
             activation = activation + self.b.dimshuffle('x', 0)
         return self.nonlinearity(activation)
-
-
-class NonlinearityLayer(Layer):
-    """
-    lasagne.layers.NonlinearityLayer(incoming,
-    nonlinearity=lasagne.nonlinearities.rectify, **kwargs)
-
-    A layer that just applies a nonlinearity.
-
-    Parameters
-    ----------
-    incoming : a :class:`Layer` instance or a tuple
-        The layer feeding into this layer, or the expected input shape
-
-    nonlinearity : callable or None
-        The nonlinearity that is applied to the layer activations. If None
-        is provided, the layer will be linear.
-    """
-    def __init__(self, incoming, nonlinearity=nonlinearities.rectify,
-                 **kwargs):
-        super(NonlinearityLayer, self).__init__(incoming, **kwargs)
-        self.nonlinearity = (nonlinearities.identity if nonlinearity is None
-                             else nonlinearity)
-
-    def get_output_for(self, input, **kwargs):
-        return self.nonlinearity(input)
 
 
 class NINLayer(Layer):

--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -1,12 +1,14 @@
 import theano
 import theano.tensor as T
 
+from .. import init
 from .. import nonlinearities
 from .base import Layer, MergeLayer
 
 
 __all__ = [
     "NonlinearityLayer",
+    "BiasLayer",
     "InverseLayer",
     "TransformerLayer",
 ]
@@ -36,6 +38,75 @@ class NonlinearityLayer(Layer):
 
     def get_output_for(self, input, **kwargs):
         return self.nonlinearity(input)
+
+
+class BiasLayer(Layer):
+    """
+    lasagne.layers.BiasLayer(incoming, b=lasagne.init.Constant(0),
+    shared_axes='auto', **kwargs)
+
+    A layer that just adds a (trainable) bias term.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape
+
+    b : Theano shared variable, numpy array, callable or None
+        An initializer for the biases. If a shared variable or a numpy array
+        is provided, the shape must match the incoming shape, skipping those
+        axes the biases are shared over (see below for an example). If set to
+        ``None``, the layer will have no biases and pass through its input
+        unchanged.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    shared_axes : 'auto', int or tuple of int
+        The axis or axes to share biases over. If ``'auto'`` (the default),
+        share over all axes except for the second: this will share biases over
+        the minibatch dimension for dense layers, and additionally over all
+        spatial dimensions for convolutional layers.
+
+    Notes
+    -----
+    The bias parameter dimensionality is the input dimensionality minus the
+    number of axes the biases are shared over, which matches the bias parameter
+    conventions of :class:`DenseLayer` or :class:`Conv2DLayer`. For example:
+
+    >>> layer = BiasLayer((20, 30, 40, 50), shared_axes=(0, 2))
+    >>> layer.b.get_value().shape
+    (30, 50)
+    """
+    def __init__(self, incoming, b=init.Constant(0), shared_axes='auto',
+                 **kwargs):
+        super(BiasLayer, self).__init__(incoming, **kwargs)
+
+        if shared_axes == 'auto':
+            # default: share biases over all but the second axis
+            shared_axes = (0,) + tuple(range(2, len(self.input_shape)))
+        elif isinstance(shared_axes, int):
+            shared_axes = (shared_axes,)
+        self.shared_axes = shared_axes
+
+        if b is None:
+            self.b = None
+        else:
+            # create bias parameter, ignoring all dimensions in shared_axes
+            shape = [size for axis, size in enumerate(self.input_shape)
+                     if axis not in self.shared_axes]
+            if any(size is None for size in shape):
+                raise ValueError("BiasLayer needs specified input sizes for "
+                                 "all axes that biases are not shared over.")
+            self.b = self.add_param(b, shape, 'b', regularizable=False)
+
+    def get_output_for(self, input, **kwargs):
+        if self.b is not None:
+            bias_axes = iter(range(self.b.ndim))
+            pattern = ['x' if input_axis in self.shared_axes
+                       else next(bias_axes)
+                       for input_axis in range(input.ndim)]
+            return input + self.b.dimshuffle(*pattern)
+        else:
+            return input
 
 
 class InverseLayer(MergeLayer):

--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -1,13 +1,41 @@
 import theano
 import theano.tensor as T
 
-from .base import MergeLayer
+from .. import nonlinearities
+from .base import Layer, MergeLayer
 
 
 __all__ = [
+    "NonlinearityLayer",
     "InverseLayer",
     "TransformerLayer",
 ]
+
+
+class NonlinearityLayer(Layer):
+    """
+    lasagne.layers.NonlinearityLayer(incoming,
+    nonlinearity=lasagne.nonlinearities.rectify, **kwargs)
+
+    A layer that just applies a nonlinearity.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape
+
+    nonlinearity : callable or None
+        The nonlinearity that is applied to the layer activations. If None
+        is provided, the layer will be linear.
+    """
+    def __init__(self, incoming, nonlinearity=nonlinearities.rectify,
+                 **kwargs):
+        super(NonlinearityLayer, self).__init__(incoming, **kwargs)
+        self.nonlinearity = (nonlinearities.identity if nonlinearity is None
+                             else nonlinearity)
+
+    def get_output_for(self, input, **kwargs):
+        return self.nonlinearity(input)
 
 
 class InverseLayer(MergeLayer):

--- a/lasagne/tests/layers/test_dense.py
+++ b/lasagne/tests/layers/test_dense.py
@@ -117,48 +117,6 @@ class TestDenseLayer:
         assert layer.b.name == "foo.b"
 
 
-class TestNonlinearityLayer:
-    @pytest.fixture
-    def NonlinearityLayer(self):
-        from lasagne.layers.dense import NonlinearityLayer
-        return NonlinearityLayer
-
-    @pytest.fixture
-    def layer_vars(self, NonlinearityLayer, dummy_input_layer):
-        nonlinearity = Mock()
-
-        layer = NonlinearityLayer(
-            dummy_input_layer,
-            nonlinearity=nonlinearity,
-            )
-
-        return {
-            'nonlinearity': nonlinearity,
-            'layer': layer,
-            }
-
-    @pytest.fixture
-    def layer(self, layer_vars):
-        return layer_vars['layer']
-
-    def test_init_none_nonlinearity(self, NonlinearityLayer,
-                                    dummy_input_layer):
-        layer = NonlinearityLayer(
-            dummy_input_layer,
-            nonlinearity=None,
-            )
-        assert layer.nonlinearity == lasagne.nonlinearities.identity
-
-    def test_get_output_for(self, layer_vars):
-        layer = layer_vars['layer']
-        nonlinearity = layer_vars['nonlinearity']
-
-        input = theano.tensor.matrix()
-        result = layer.get_output_for(input)
-        nonlinearity.assert_called_with(input)
-        assert result is nonlinearity.return_value
-
-
 class TestNINLayer:
     @pytest.fixture
     def dummy_input_layer(self):

--- a/lasagne/tests/layers/test_special.py
+++ b/lasagne/tests/layers/test_special.py
@@ -1,6 +1,50 @@
+from mock import Mock
 import numpy
 import pytest
 import theano
+
+
+class TestNonlinearityLayer:
+    @pytest.fixture
+    def NonlinearityLayer(self):
+        from lasagne.layers.special import NonlinearityLayer
+        return NonlinearityLayer
+
+    @pytest.fixture
+    def layer_vars(self, NonlinearityLayer, dummy_input_layer):
+        nonlinearity = Mock()
+
+        layer = NonlinearityLayer(
+            dummy_input_layer,
+            nonlinearity=nonlinearity,
+            )
+
+        return {
+            'nonlinearity': nonlinearity,
+            'layer': layer,
+            }
+
+    @pytest.fixture
+    def layer(self, layer_vars):
+        return layer_vars['layer']
+
+    def test_init_none_nonlinearity(self, NonlinearityLayer,
+                                    dummy_input_layer):
+        import lasagne.nonlinearities
+        layer = NonlinearityLayer(
+            dummy_input_layer,
+            nonlinearity=None,
+            )
+        assert layer.nonlinearity == lasagne.nonlinearities.identity
+
+    def test_get_output_for(self, layer_vars):
+        layer = layer_vars['layer']
+        nonlinearity = layer_vars['nonlinearity']
+
+        input = theano.tensor.matrix()
+        result = layer.get_output_for(input)
+        nonlinearity.assert_called_with(input)
+        assert result is nonlinearity.return_value
 
 
 class TestInverseLayer:


### PR DESCRIPTION
This moves `NonlinearityLayer` from `dense.py` to `special.py`, and adds a `BiasLayer`.

The implementation allows to specify which dimensions to share biases over. By default, it matches what the dense and convolutional layers do, so you can use the `BiasLayer` and `NonlinearityLayer` to pull out the bias and nonlinearity from a convolution layer over the following pooling layer for efficiency. I've also taken care to not create a fully-dimensional, broadcastable bias tensor, but to match the implementation of the dense and convolutional layers, which create a lower-dimensional tensor and dimshuffle it to the correct shape afterwards (i.e., in `get_output_for()`). This makes it even easier to steal an existing layer's bias and put it into a `BiasLayer`.

Resolves #378.