### PR TITLE
WIP: Give RecurrentLayer W params better names

### DIFF
--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -551,16 +551,30 @@ class RecurrentLayer(CustomRecurrentLayer):
             input_shape = incoming
         else:
             input_shape = incoming.output_shape
+        # Retrieve the supplied name, if it exists; otherwise use ''
+        if 'name' in kwargs:
+            basename = kwargs['name'] + '.'
+            # Create a separate version of kwargs for the contained layers
+            # which does not include 'name'
+            layer_kwargs = dict((key, arg) for key, arg in kwargs.items()
+                                if key != 'name')
+        else:
+            basename = ''
+            layer_kwargs = kwargs
         # We will be passing the input at each time step to the dense layer,
         # so we need to remove the second dimension (the time dimension)
         in_to_hid = DenseLayer(InputLayer((None,) + input_shape[2:]),
                                num_units, W=W_in_to_hid, b=b,
-                               nonlinearity=None, **kwargs)
+                               nonlinearity=None,
+                               name=basename + 'input_to_hidden',
+                               **layer_kwargs)
         # The hidden-to-hidden layer expects its inputs to have num_units
         # features because it recycles the previous hidden state
         hid_to_hid = DenseLayer(InputLayer((None, num_units)),
                                 num_units, W=W_hid_to_hid, b=None,
-                                nonlinearity=None, **kwargs)
+                                nonlinearity=None,
+                                name=basename + 'hidden_to_hidden',
+                                **layer_kwargs)
 
         # Make child layer parameters intuitively accessible
         self.W_in_to_hid = in_to_hid.W

--- a/lasagne/tests/layers/test_recurrent.py
+++ b/lasagne/tests/layers/test_recurrent.py
@@ -100,6 +100,15 @@ def test_recurrent_init_val_error():
         l_rec = RecurrentLayer(InputLayer((2, 2, 3)), 5, hid_init=hid_init)
 
 
+def test_recurrent_name():
+    l_in = lasagne.layers.InputLayer((2, 3, 4))
+    layer_name = 'l_rec'
+    l_rec = lasagne.layers.RecurrentLayer(l_in, 4, name=layer_name)
+    assert l_rec.b.name == layer_name + '.input_to_hidden.b'
+    assert l_rec.W_in_to_hid.name == layer_name + '.input_to_hidden.W'
+    assert l_rec.W_hid_to_hid.name == layer_name + '.hidden_to_hidden.W'
+
+
 def test_custom_recurrent_arbitrary_shape():
     # Check that the custom recurrent layer can handle more than 1 feature dim
     n_batch, n_steps, n_channels, width, height = (2, 3, 4, 5, 6)


### PR DESCRIPTION
Because of the way they are constructed, the weight matrices in a `RecurrentLayer` are both just called `layer_name.W` which is not terribly helpful.  This fixes that.  Are there any edge cases I'm not thinking of, e.g. would the `.name` attribute of the parameters ever not exist?