### PR TITLE
Fix RecurrentLayer type(incoming) == tuple error

### DIFF
--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -546,7 +546,11 @@ class RecurrentLayer(CustomRecurrentLayer):
                  precompute_input=True,
                  mask_input=None,
                  **kwargs):
-        input_shape = incoming.output_shape
+
+        if isinstance(incoming, tuple):
+            input_shape = incoming
+        else:
+            input_shape = incoming.output_shape
         # We will be passing the input at each time step to the dense layer,
         # so we need to remove the second dimension (the time dimension)
         in_to_hid = DenseLayer(InputLayer((None,) + input_shape[2:]),

--- a/lasagne/tests/layers/test_recurrent.py
+++ b/lasagne/tests/layers/test_recurrent.py
@@ -87,6 +87,12 @@ def test_recurrent_tensor_init():
     assert isinstance(output_val, np.ndarray)
 
 
+def test_recurrent_incoming_tuple():
+    input_shape = (2, 3, 4)
+    l_rec = lasagne.layers.RecurrentLayer(input_shape, 5)
+    assert l_rec.input_shapes[0] == input_shape
+
+
 def test_recurrent_init_val_error():
     # check if errors are raised when init is non matrix tensor
     hid_init = T.vector()


### PR DESCRIPTION
RecurrentLayer would throw an error when incoming was a tuple because it was trying to access incoming.output_shape.  This adds an explicit check whether incoming is a tuple, and handles it appropriately. Also adds a test for this special case because all of the RecurrentLayer tests used a InputLayer as incoming.