### PR TITLE
Optimize TransformerLayer

### DIFF
--- a/lasagne/tests/layers/test_special.py
+++ b/lasagne/tests/layers/test_special.py
@@ -171,7 +171,7 @@ def test_transform_errors():
 
 def test_transform_downsample():
         import lasagne
-        downsample = 2.3
+        downsample = (0.7, 2.3)
         x = np.random.random((10, 3, 28, 28)).astype('float32')
         x_sym = theano.tensor.tensor4()
         l_in = lasagne.layers.InputLayer((None, 3, 28, 28))
@@ -179,8 +179,12 @@ def test_transform_downsample():
         l_trans = lasagne.layers.TransformerLayer(l_in, l_loc,
                                                   downsample_factor=downsample)
 
+        # check that shape propagation works
+        assert l_trans.output_shape[0] is None
+        assert l_trans.output_shape[1:] == (3, int(28 / .7), int(28 / 2.3))
+
+        # check that data propagation works
         output = lasagne.layers.get_output(l_trans, x_sym)
         x_out = output.eval({x_sym: x})
-        assert x_out.shape[1:] == l_trans.output_shape[1:]
-        assert l_trans.output_shape[0] is None
         assert x_out.shape[0] == x.shape[0]
+        assert x_out.shape[1:] == l_trans.output_shape[1:]

--- a/lasagne/tests/layers/test_special.py
+++ b/lasagne/tests/layers/test_special.py
@@ -174,6 +174,8 @@ def test_transform_downsample():
         downsample = (0.7, 2.3)
         x = np.random.random((10, 3, 28, 28)).astype('float32')
         x_sym = theano.tensor.tensor4()
+
+        # create transformer with fixed input size
         l_in = lasagne.layers.InputLayer((None, 3, 28, 28))
         l_loc = lasagne.layers.DenseLayer(l_in, num_units=6)
         l_trans = lasagne.layers.TransformerLayer(l_in, l_loc,
@@ -188,3 +190,23 @@ def test_transform_downsample():
         x_out = output.eval({x_sym: x})
         assert x_out.shape[0] == x.shape[0]
         assert x_out.shape[1:] == l_trans.output_shape[1:]
+
+        # create transformer with variable input size
+        l_in = lasagne.layers.InputLayer((None, 3, None, 28))
+        l_loc = lasagne.layers.DenseLayer(
+                lasagne.layers.ReshapeLayer(l_in, ([0], 3*28*28)),
+                num_units=6, W=l_loc.W, b=l_loc.b)
+        l_trans = lasagne.layers.TransformerLayer(l_in, l_loc,
+                                                  downsample_factor=downsample)
+
+        # check that shape propagation works
+        assert l_trans.output_shape[0] is None
+        assert l_trans.output_shape[1] == 3
+        assert l_trans.output_shape[2] is None
+        assert l_trans.output_shape[3] == int(28 / 2.3)
+
+        # check that data propagation works
+        output = lasagne.layers.get_output(l_trans, x_sym)
+        x_out2 = output.eval({x_sym: x})
+        assert x_out2.shape == x_out.shape
+        np.testing.assert_allclose(x_out2, x_out, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
This PR does a few things to the spatial transform layer:

* For consistency, it renames the `input` constructor argument to `incoming` and adapts the docstring accordingly
* Also for consistency, it changes the exception messages a little
* It drops the `deterministic=False` keyword argument from `get_output_for`, it was never used
* It allows `downscale_factor` to be a two-element tuple and adapts the docstring and tests accordingly
* ~~If the image size is known at compile time, it constructs the meshgrid offline instead of doing it symbolically~~
* Shape and coordinate casting is done in a better order to avoid needless device/host transfers
* The custom `_repeat` function is replaced by `T.repeat`

Unluckily, speed improvements were minuscule. I've got something between 1% and 4% both for the forward and backward pass, mostly because of reordering the casts. Offline computation of the meshgrid hardly changes anything (but it definitely didn't get slower). If the batch size is known at compile time, the `base` index array in `_interpolate` could be precomputed as well, but that seemed to be a less common case than a fixed image size, so I didn't try that. After all, a more promising approach would be turning this into a custom kernel, possibly using `tex2D`, but then we'd also need to do a gradient Op and CPU Ops and a graph optimizer.