### PR TITLE
Pool1DLayer

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -79,6 +79,7 @@
 
     MaxPool1DLayer
     MaxPool2DLayer
+    Pool1DLayer
     Pool2DLayer
     Upscale2DLayer
     GlobalPoolLayer

--- a/docs/modules/layers/pool.rst
+++ b/docs/modules/layers/pool.rst
@@ -11,6 +11,9 @@ Pooling layers
 .. autoclass:: MaxPool2DLayer
     :members:
 
+.. autoclass:: Pool1DLayer
+    :members:
+
 .. autoclass:: Pool2DLayer
     :members:
 

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -9,6 +9,7 @@ from theano.tensor.signal import downsample
 __all__ = [
     "MaxPool1DLayer",
     "MaxPool2DLayer",
+    "Pool1DLayer",
     "Pool2DLayer",
     "Upscale2DLayer",
     "FeaturePoolLayer",
@@ -72,11 +73,12 @@ def pool_output_length(input_length, pool_size, stride, pad, ignore_border):
     return output_length
 
 
-class MaxPool1DLayer(Layer):
+class Pool1DLayer(Layer):
     """
-    1D max-pooling layer
+    1D pooling layer
 
-    Performs 1D max-pooling over the trailing axis of a 3D input tensor.
+    Performs 1D mean or max-pooling over the trailing axis
+    of a 3D input tensor.
 
     Parameters
     ----------
@@ -99,9 +101,17 @@ class MaxPool1DLayer(Layer):
         If ``True``, partial pooling regions will be ignored.
         Must be ``True`` if ``pad != 0``.
 
+    mode : {'max', 'average_inc_pad', 'average_exc_pad'}
+        Pooling mode: max-pooling or mean-pooling including/excluding zeros
+        from partially padded pooling regions. Default is 'max'.
+
     **kwargs
         Any additional keyword arguments are passed to the :class:`Layer`
         superclass.
+
+    See Also
+    --------
+    MaxPool1DLayer : Shortcut for max pooling layer.
 
     Notes
     -----
@@ -112,14 +122,15 @@ class MaxPool1DLayer(Layer):
     Using ``ignore_border=False`` prevents Theano from using cuDNN for the
     operation, so it will fall back to a slower implementation.
     """
-
     def __init__(self, incoming, pool_size, stride=None, pad=0,
-                 ignore_border=True, **kwargs):
-        super(MaxPool1DLayer, self).__init__(incoming, **kwargs)
+                 ignore_border=True, mode='max', **kwargs):
+        super(Pool1DLayer, self).__init__(incoming, **kwargs)
+
         self.pool_size = as_tuple(pool_size, 1)
         self.stride = self.pool_size if stride is None else as_tuple(stride, 1)
         self.pad = as_tuple(pad, 1)
         self.ignore_border = ignore_border
+        self.mode = mode
 
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)  # copy / convert to mutable list
@@ -141,6 +152,7 @@ class MaxPool1DLayer(Layer):
                                         st=(self.stride[0], 1),
                                         ignore_border=self.ignore_border,
                                         padding=(self.pad[0], 0),
+                                        mode=self.mode,
                                         )
         return pooled[:, :, :, 0]
 
@@ -241,6 +253,58 @@ class Pool2DLayer(Layer):
                                         mode=self.mode,
                                         )
         return pooled
+
+
+class MaxPool1DLayer(Pool1DLayer):
+    """
+    1D max-pooling layer
+
+    Performs 1D max-pooling over the trailing axis of a 3D input tensor.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or tuple
+        The layer feeding into this layer, or the expected input shape.
+
+    pool_size : integer or iterable
+        The length of the pooling region. If an iterable, it should have a
+        single element.
+
+    stride : integer, iterable or ``None``
+        The stride between sucessive pooling regions.
+        If ``None`` then ``stride == pool_size``.
+
+    pad : integer or iterable
+        The number of elements to be added to the input on each side.
+        Must be less than stride.
+
+    ignore_border : bool
+        If ``True``, partial pooling regions will be ignored.
+        Must be ``True`` if ``pad != 0``.
+
+    **kwargs
+        Any additional keyword arguments are passed to the :class:`Layer`
+        superclass.
+
+    Notes
+    -----
+    The value used to pad the input is chosen to be less than
+    the minimum of the input, so that the output of each pooling region
+    always corresponds to some element in the unpadded input region.
+
+    Using ``ignore_border=False`` prevents Theano from using cuDNN for the
+    operation, so it will fall back to a slower implementation.
+    """
+
+    def __init__(self, incoming, pool_size, stride=None, pad=0,
+                 ignore_border=True, **kwargs):
+        super(MaxPool1DLayer, self).__init__(incoming,
+                                             pool_size,
+                                             stride,
+                                             pad,
+                                             ignore_border,
+                                             mode='max',
+                                             **kwargs)
 
 
 class MaxPool2DLayer(Pool2DLayer):


### PR DESCRIPTION
I recently wanted to do mean pooling in one dimension.  I saw #320, but could not find something similar for only one dimension.  So I moved the functionality from MaxPool1DLayer to Pool1DLayer, and let MaxPool1DLayer inherit from Pool1DLayer in a similar way to how MaxPool2DLayer works.  Using `mode='average_exc_pad'` seems to be much slower than `mode='max'`, but this is probably to be expected.

If this is useful and correct, I'll go ahead and squash the commits.