### PR TITLE
Allow arbitrary parameter expressions

### DIFF
--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -138,15 +138,15 @@ class Conv1DLayer(Layer):
         position in each channel. As a result, the `b` attribute will be a
         matrix (2D).
 
-    W : Theano shared variable, numpy array or callable
-        An initializer for the weights of the layer. This should initialize the
-        layer weights to a 3D array with shape
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a 3D tensor with shape
         ``(num_filters, num_input_channels, filter_length)``.
         See :func:`lasagne.utils.create_param` for more information.
 
-    b : Theano shared variable, numpy array, callable or None
-        An initializer for the biases of the layer. If None is provided, the
-        layer will have no biases. This should initialize the layer biases to
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
         ``(num_filters, input_length)`` instead.
@@ -168,11 +168,11 @@ class Conv1DLayer(Layer):
 
     Attributes
     ----------
-    W : Theano shared variable
-        Variable representing the filter weights.
+    W : Theano shared variable or expression
+        Variable or expression representing the filter weights.
 
-    b : Theano shared variable
-        Variable representing the biases.
+    b : Theano shared variable or expression
+        Variable or expression representing the biases.
 
     Notes
     -----
@@ -349,18 +349,18 @@ class Conv2DLayer(Layer):
         position in each channel. As a result, the `b` attribute will be a
         3D tensor.
 
-    W : Theano shared variable, numpy array or callable
-        An initializer for the weights of the layer. This should initialize the
-        layer weights to a 4D array with shape
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a 4D tensor with shape
         ``(num_filters, num_input_channels, filter_rows, filter_columns)``.
         See :func:`lasagne.utils.create_param` for more information.
 
-    b : Theano shared variable, numpy array, callable or None
-        An initializer for the biases of the layer. If None is provided, the
-        layer will have no biases. This should initialize the layer biases to
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
-        ``(num_filters, input_rows, input_columns)`` instead.
+        ``(num_filters, output_rows, output_columns)`` instead.
         See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
@@ -376,11 +376,11 @@ class Conv2DLayer(Layer):
 
     Attributes
     ----------
-    W : Theano shared variable
-        Variable representing the filter weights.
+    W : Theano shared variable or expression
+        Variable or expression representing the filter weights.
 
-    b : Theano shared variable
-        Variable representing the biases.
+    b : Theano shared variable or expression
+        Variable or expression representing the biases.
 
     Notes
     -----

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -91,18 +91,18 @@ class Conv2DMMLayer(MMLayer):
         position in each channel. As a result, the `b` attribute will be a
         3D tensor.
 
-    W : Theano shared variable, numpy array or callable
-        An initializer for the weights of the layer. This should initialize the
-        layer weights to a 4D array with shape
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a 4D tensor with shape
         ``(num_filters, num_input_channels, filter_rows, filter_columns)``.
         See :func:`lasagne.utils.create_param` for more information.
 
-    b : Theano shared variable, numpy array, callable or None
-        An initializer for the biases of the layer. If None is provided, the
-        layer will have no biases. This should initialize the layer biases to
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
-        ``(num_filters, input_rows, input_columns)`` instead.
+        ``(num_filters, output_rows, output_columns)`` instead.
         See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -105,21 +105,21 @@ class Conv2DCCLayer(CCLayer):
         position in each channel. As a result, the `b` attribute will be a
         3D tensor.
 
-    W : Theano shared variable, numpy array or callable
-        An initializer for the weights of the layer. This should initialize the
-        layer weights to a 4D array with shape
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a 4D tensor with shape
         ``(num_filters, num_input_channels, filter_rows, filter_columns)``.
         If automatic dimshuffling is disabled (see notes), the shape should be
         ``(num_input_channels, input_rows, input_columns, num_filters)``
-        instead (c01b axis order). See :func:`lasagne.utils.create_param` for
-        more information.
+        instead (c01b axis order).
+        See :func:`lasagne.utils.create_param` for more information.
 
-    b : Theano shared variable, numpy array, callable or None
-        An initializer for the biases of the layer. If None is provided, the
-        layer will have no biases. This should initialize the layer biases to
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
-        ``(num_filters, input_rows, input_columns)`` instead.
+        ``(num_filters, output_rows, output_columns)`` instead.
         See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
@@ -165,11 +165,11 @@ class Conv2DCCLayer(CCLayer):
 
     Attributes
     ----------
-    W : Theano shared variable
-        Variable representing the filter weights.
+    W : Theano shared variable or expression
+        Variable or expression representing the filter weights.
 
-    b : Theano shared variable
-        Variable representing the biases.
+    b : Theano shared variable or expression
+        Variable or expression representing the biases.
 
     Notes
     -----

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -29,16 +29,16 @@ class DenseLayer(Layer):
     num_units : int
         The number of units of the layer
 
-    W : Theano shared variable, numpy array or callable
-        An initializer for the weights of the layer. If a shared variable or a
-        numpy array is provided the shape should  be (num_inputs, num_units).
-        See :meth:`Layer.create_param` for more information.
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a matrix with shape ``(num_inputs, num_units)``.
+        See :func:`lasagne.utils.create_param` for more information.
 
-    b : Theano shared variable, numpy array, callable or None
-        An initializer for the biases of the layer. If a shared variable or a
-        numpy array is provided the shape should be (num_units,).
-        If None is provided the layer will have no biases.
-        See :meth:`Layer.create_param` for more information.
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
+        a 1D array with shape ``(num_units,)``.
+        See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
         The nonlinearity that is applied to the layer activations. If None
@@ -115,19 +115,18 @@ class NINLayer(Layer):
         layer. If true a separate bias vector is used for each trailing
         dimension beyond the 2nd.
 
-    W : Theano shared variable, numpy array or callable
-        An initializer for the weights of the layer. If a shared variable or a
-        numpy array is provided the shape should be (num_inputs, num_units),
-        where num_units is the size of the 2nd. dimension of the input.
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a matrix with shape ``(num_inputs, num_units)``,
+        where ``num_inputs`` is the size of the second dimension of the input.
         See :func:`lasagne.utils.create_param` for more information.
 
-    b : Theano shared variable, numpy array, callable or None
-        An initializer for the biases of the layer. If a shared variable or a
-        numpy array is provided the correct shape is determined by the
-        untie_biases setting. If untie_biases is False, then the shape should
-        be (num_units, ). If untie_biases is True then the shape should be
-        (num_units, input_dim[2], ..., input_dim[-1]). If None is provided the
-        layer will have no biases.
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
+        a 1D array with shape ``(num_units,)`` for ``untie_biases=False``, and
+        a tensor of shape ``(num_units, input_shape[2], ..., input_shape[-1])``
+        for ``untie_biases=True``.
         See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -192,18 +192,18 @@ class Conv2DDNNLayer(DNNLayer):
         position in each channel. As a result, the `b` attribute will be a
         3D tensor.
 
-    W : Theano shared variable, numpy array or callable
-        An initializer for the weights of the layer. This should initialize the
-        layer weights to a 4D array with shape
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a 4D tensor with shape
         ``(num_filters, num_input_channels, filter_rows, filter_columns)``.
         See :func:`lasagne.utils.create_param` for more information.
 
-    b : Theano shared variable, numpy array, callable or None
-        An initializer for the biases of the layer. If None is provided, the
-        layer will have no biases. This should initialize the layer biases to
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
         a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
         ``False``. If it is set to ``True``, its shape should be
-        ``(num_filters, input_rows, input_columns)`` instead.
+        ``(num_filters, output_rows, output_columns)`` instead.
         See :func:`lasagne.utils.create_param` for more information.
 
     nonlinearity : callable or None
@@ -223,11 +223,11 @@ class Conv2DDNNLayer(DNNLayer):
 
     Attributes
     ----------
-    W : Theano shared variable
-        Variable representing the filter weights.
+    W : Theano shared variable or expression
+        Variable or expression representing the filter weights.
 
-    b : Theano shared variable
-        Variable representing the biases.
+    b : Theano shared variable or expression
+        Variable or expression representing the biases.
 
     Notes
     -----

--- a/lasagne/layers/embedding.py
+++ b/lasagne/layers/embedding.py
@@ -30,8 +30,10 @@ class EmbeddingLayer(Layer):
     output_size : int
         The size of each embedding.
 
-    W : Theano shared variable, numpy array or callable
-        The embedding matrix.
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the embedding matrix.
+        This should be a matrix with shape ``(input_size, output_size)``.
+        See :func:`lasagne.utils.create_param` for more information.
 
     Examples
     --------

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -265,16 +265,18 @@ def get_output_shape(layer_or_layers, input_shapes=None):
 
 def get_all_params(layer, **tags):
     """
-    This function gathers all parameters of all layers below one or
+    Returns a list of Theano shared variables that parameterize the layer.
+
+    This function gathers all parameter variables of all layers below one or
     more given :class:`Layer` instances, including the layer(s) itself. Its
     main use is to collect all parameters of a network just given the output
     layer(s).
 
-    By default, all parameters that participate in the forward pass will be
-    returned. The list can optionally be filtered by specifying tags as keyword
-    arguments. For example, ``trainable=True`` will only return trainable
-    parameters, and ``regularizable=True`` will only return parameters that can
-    be regularized (e.g., by L2 decay).
+    By default, all shared variables that participate in the forward pass will
+    be returned. The list can optionally be filtered by specifying tags as
+    keyword  arguments. For example, ``trainable=True`` will only return
+    trainable parameters, and ``regularizable=True`` will only return
+    parameters that can be regularized (e.g., by L2 decay).
 
     Parameters
     ----------
@@ -301,6 +303,22 @@ def get_all_params(layer, **tags):
     >>> l1 = DenseLayer(l_in, num_units=50)
     >>> all_params = get_all_params(l1)
     >>> all_params == [l1.W, l1.b]
+    True
+
+    Notes
+    -----
+    If any layer's parameter was set to a Theano expression instead of a shared
+    variable, the shared variables involved in that expression will be returned
+    rather than the expression itself. Tag filtering considers all variables
+    within an expression to be tagged the same.
+    >>> import theano
+    >>> import numpy as np
+    >>> from lasagne.utils import floatX
+    >>> w1 = theano.shared(floatX(.01 * np.random.randn(50, 30)))
+    >>> w2 = theano.shared(floatX(1))
+    >>> l2 = DenseLayer(l1, num_units=30, W=theano.tensor.exp(w1) - w2, b=None)
+    >>> all_params = get_all_params(l2, regularizable=True)
+    >>> all_params == [l1.W, w1, w2]
     True
     """
     layers = get_all_layers(layer)

--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -53,12 +53,11 @@ class BiasLayer(Layer):
     incoming : a :class:`Layer` instance or a tuple
         The layer feeding into this layer, or the expected input shape
 
-    b : Theano shared variable, numpy array, callable or None
-        An initializer for the biases. If a shared variable or a numpy array
-        is provided, the shape must match the incoming shape, skipping those
-        axes the biases are shared over (see below for an example). If set to
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
         ``None``, the layer will have no biases and pass through its input
-        unchanged.
+        unchanged. Otherwise, the bias shape must match the incoming shape,
+        skipping those axes the biases are shared over (see the example below).
         See :func:`lasagne.utils.create_param` for more information.
 
     shared_axes : 'auto', int or tuple of int

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -58,6 +58,19 @@ class TestLayer:
         assert layer.get_params(tag2=False) == [A]
         assert layer.get_params(tag1=True, tag2=True) == [B]
 
+    def test_get_params_expressions(self, layer):
+        x, y, z = (theano.shared(0, name=n) for n in 'xyz')
+        W1 = layer.add_param(x**2 + theano.tensor.log(y), (), tag1=True)
+        W2 = layer.add_param(theano.tensor.matrix(), (10, 10), tag1=True)
+        W3 = layer.add_param(z.T, (), tag2=True)
+        # layer.params stores the parameter expressions:
+        assert list(layer.params.keys()) == [W1, W2, W3]
+        # layer.get_params() returns the underlying shared variables:
+        assert layer.get_params() == [x, y, z]
+        # filtering acts on the parameter expressions:
+        assert layer.get_params(tag1=True) == [x, y]
+        assert layer.get_params(tag2=True) == [z]
+
     def test_add_param_tags(self, layer):
         a_shape = (20, 50)
         a = numpy.random.normal(0, 1, a_shape)

--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -62,12 +62,12 @@ class TestUpdateFunctions(object):
         assert np.allclose(A.get_value(), self.torch_values[method])
 
 
-def test_get_or_compute_grads_raises():
+def test_get_or_compute_grads():
 
     from lasagne.updates import get_or_compute_grads
 
-    A = T.scalar()
-    B = T.scalar()
+    A = theano.shared(1)
+    B = theano.shared(1)
     loss = A + B
     grads = get_or_compute_grads(loss, [A, B])
 
@@ -75,6 +75,10 @@ def test_get_or_compute_grads_raises():
 
     with pytest.raises(ValueError):
         get_or_compute_grads(grads, [A])
+
+    C = T.scalar()
+    with pytest.raises(ValueError):
+        get_or_compute_grads(A + C, [A, C])
 
 
 @pytest.mark.parametrize('ndim', [2, 3])

--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -18,6 +18,22 @@ def test_as_theano_expression_fails():
         as_theano_expression({})
 
 
+def test_collect_shared_vars():
+    from lasagne.utils import collect_shared_vars as collect
+    x, y, z = (theano.shared(0, name=n) for n in 'xyz')
+    # collecting must not change the order
+    assert collect([x, y, z]) == [x, y, z]
+    # duplicates should be eliminated
+    assert collect([x, y, x, y, y, z]) == [x, y, z]
+    # ensure we have left-recursive depth-first search
+    assert collect((x + y) + z) == [x, y, z]
+    assert collect(x + (y + z)) == [x, y, z]
+    # complex expressions and constants should not be included
+    assert collect([x**2, y * z * np.ones(10), x + T.matrix()]) == [x, y, z]
+    # the result can even be empty
+    assert collect([T.matrix() + T.matrix(), T.log(T.matrix())]) == []
+
+
 def test_one_hot():
     from lasagne.utils import one_hot
     a = np.random.randint(0, 10, 20)

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -100,7 +100,18 @@ def get_or_compute_grads(loss_or_grads, params):
         of `params`, in which case a `ValueError` is raised.
         Otherwise, `loss_or_grads` is assumed to be a cost expression and
         the function returns `theano.grad(loss_or_grads, params)`.
+
+    Raises
+    ------
+    ValueError
+        If `loss_or_grads` is a list of a different length than `params`, or if
+        any element of `params` is not a shared variable (while we could still
+        compute its gradient, we can never update it and want to fail early).
     """
+    if any(not isinstance(p, theano.compile.SharedVariable) for p in params):
+        raise ValueError("params must contain shared variables only. If it "
+                         "contains arbitrary parameter expressions, then "
+                         "lasagne.utils.collect_shared_vars() may help you.")
     if isinstance(loss_or_grads, list):
         if not len(loss_or_grads) == len(params):
             raise ValueError("Got %d gradient expressions for %d parameters" %


### PR DESCRIPTION
First stab at #11, to continue the discussion based on actual code.

This gets the basic case working:
```
In [3]: l1 = lasagne.layers.DenseLayer((100, 10), 20)

In [4]: l2 = lasagne.layers.DenseLayer(l1, 10, W=l1.W.T)

In [5]: lasagne.layers.get_all_params(l2)
Out[5]: [b, W, b]

In [6]: l1.params

Out[6]: OrderedDict([(W, set(['trainable', 'regularizable'])), (b, set(['trainable']))])

In [7]: l2.params
Out[7]: OrderedDict([(W.T, set(['trainable', 'regularizable'])), (b, set(['trainable']))])
```
It will work just as fine with `T.exp(l1.W)`, something adding up two shared variables, or something involving no shared variables at all (e.g., a constant weight matrix).

If there are no objections to the way it's implemented, I can go ahead and update the documentation and tests, as well as the recurrent layers that now have a specific switch for supporting arbitrary expressions for `hid_init`.


Todo:
* [x] update documentation and tests
* [x] add helpful error message to `lasagne.updates.*` in case you're not passing shared variables only
* ~~update the recurrent layer to not distinguish between parameter expressions and parameter variables in the constructor, because the base class supports both now~~
* [x] update all the docstrings of all the layers because the parameters can be expressions now