### PR TITLE
Add Docker images to docs

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -226,3 +226,22 @@ To check whether it is found by Theano, run the following command:
 
 It will print ``True`` if everything is fine, or an error message otherwise.
 There are no additional steps required for Theano to make use of cuDNN.
+
+Docker images
+=============
+
+Instead of manually installing Theano and Lasagne on your machines as described
+above, you may want to use a pre-made `Docker<https://www.docker.com/whatisdocker>`_
+image: `Lasagne Docker (CPU)<https://hub.docker.com/r/kaixhin/lasagne/>`_ or
+`Lasagne Docker (CUDA)<https://hub.docker.com/r/kaixhin/cuda-lasagne/>`_. These
+are updated on a weekly basis with bleeding-edge builds of Theano and Lasagne.
+Examples of running bash in a Docker container are as follows:
+
+.. code-block:: bash
+
+  sudo docker run -it kaixhin/lasagne
+  sudo docker run -it --device /dev/nvidiactl --device /dev/nvidia-uvm --device /dev/nvidia0 kaixhin/cuda-lasagne:7.0
+
+For a guide to Docker, see the `official docs<https://docs.docker.com/userguide/>`_.
+For more details on how to use the Lasagne Docker images, including requirements for
+CUDA support, consult the `source project<https://github.com/Kaixhin/dockerfiles>`_.


### PR DESCRIPTION
I've added information on the Docker images to the docs, which closes https://github.com/Lasagne/Lasagne/issues/411.

I have also successfully run the test suite on both CPU and CUDA containers without errors.