### PR TITLE
Conv1d slow compilation fix

### DIFF
--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -249,7 +249,7 @@ class Conv1DLayer(Layer):
                                       filter_shape=self.get_W_shape(),
                                       border_mode='full')
             shift = (self.filter_size[0] - 1) // 2
-            conved = conved[:, :, shift:input.shape[2] + shift]
+            conved = conved[:, :, shift:-shift]
         else:
             # no padding needed, or explicit padding of input needed
             if self.pad == 'full':

--- a/lasagne/theano_extensions/conv.py
+++ b/lasagne/theano_extensions/conv.py
@@ -37,7 +37,11 @@ def conv1d_sc(input, filters, image_shape=None, filter_shape=None,
     conved = T.nnet.conv2d(input_sc, filters_sc, image_shape=image_shape_sc,
                            filter_shape=filter_shape_sc,
                            subsample=(1, subsample[0]))
-    return conved[:, :, 0, :]  # drop the unused dimension
+    try:
+        conved = conved.dimshuffle(0, 1, 3)  # drop the unused dimension
+    except ValueError:
+        conved = T.addbroadcast(conved, 2).dimshuffle(0, 1, 3)
+    return conved
 
 
 def conv1d_mc0(input, filters, image_shape=None, filter_shape=None,
@@ -64,7 +68,11 @@ def conv1d_mc0(input, filters, image_shape=None, filter_shape=None,
         input_mc0, filters_mc0, image_shape=image_shape_mc0,
         filter_shape=filter_shape_mc0, subsample=(1, subsample[0]),
         border_mode=border_mode)
-    return conved[:, :, 0, :]  # drop the unused dimension
+    try:
+        conved = conved.dimshuffle(0, 1, 3)  # drop the unused dimension
+    except ValueError:
+        conved = T.addbroadcast(conved, 2).dimshuffle(0, 1, 3)
+    return conved
 
 
 def conv1d_mc1(input, filters, image_shape=None, filter_shape=None,
@@ -91,7 +99,11 @@ def conv1d_mc1(input, filters, image_shape=None, filter_shape=None,
         input_mc1, filters_mc1, image_shape=image_shape_mc1,
         filter_shape=filter_shape_mc1, subsample=(subsample[0], 1),
         border_mode=border_mode)
-    return conved[:, :, :, 0]  # drop the unused dimension
+    try:
+        conved = conved.dimshuffle(0, 1, 2)  # drop the unused dimension
+    except ValueError:
+        conved = T.addbroadcast(conved, 3).dimshuffle(0, 1, 2)
+    return conved
 
 
 def conv1d_unstrided(input, filters, image_shape, filter_shape,


### PR DESCRIPTION
Attempts to address the bug discussed [here](https://groups.google.com/forum/#!topic/lasagne-users/XR-jmU1pMWc). 

The changes to `theano_extensions.conv` improved the optimization speed dramatically, but I think it's still triggering some underlying problem in Theano, as the compilation time increases nonlinearly with each additional layer.

The change to `Conv1DLayer` seems to be an effective workaround, but I need to profile and see how the execution speed compares.