### PR TITLE
Fix Read the Docs badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: http://img.shields.io/badge/docs-latest-brightgreen.svg
+.. image:: https://readthedocs.org/projects/lasagne/badge/
     :target: http://lasagne.readthedocs.org/en/latest/
 
 .. image:: https://travis-ci.org/Lasagne/Lasagne.svg?branch=master


### PR DESCRIPTION
Does what it says. Make detecting https://github.com/Lasagne/Lasagne/issues/417 a little easier.