### PR TITLE
Fix readthedocs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,13 +12,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-# import sys
+import sys
 import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))  # make lasagne available for import
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -231,9 +231,9 @@ Docker images
 =============
 
 Instead of manually installing Theano and Lasagne on your machines as described
-above, you may want to use a pre-made `Docker<https://www.docker.com/whatisdocker>`_
-image: `Lasagne Docker (CPU)<https://hub.docker.com/r/kaixhin/lasagne/>`_ or
-`Lasagne Docker (CUDA)<https://hub.docker.com/r/kaixhin/cuda-lasagne/>`_. These
+above, you may want to use a pre-made `Docker <https://www.docker.com/whatisdocker>`_
+image: `Lasagne Docker (CPU) <https://hub.docker.com/r/kaixhin/lasagne/>`_ or
+`Lasagne Docker (CUDA) <https://hub.docker.com/r/kaixhin/cuda-lasagne/>`_. These
 are updated on a weekly basis with bleeding-edge builds of Theano and Lasagne.
 Examples of running bash in a Docker container are as follows:
 
@@ -242,6 +242,6 @@ Examples of running bash in a Docker container are as follows:
   sudo docker run -it kaixhin/lasagne
   sudo docker run -it --device /dev/nvidiactl --device /dev/nvidia-uvm --device /dev/nvidia0 kaixhin/cuda-lasagne:7.0
 
-For a guide to Docker, see the `official docs<https://docs.docker.com/userguide/>`_.
+For a guide to Docker, see the `official docs <https://docs.docker.com/userguide/>`_.
 For more details on how to use the Lasagne Docker images, including requirements for
-CUDA support, consult the `source project<https://github.com/Kaixhin/dockerfiles>`_.
+CUDA support, consult the `source project <https://github.com/Kaixhin/dockerfiles>`_.


### PR DESCRIPTION
This hopefully fixes #417 (and it fixes markup errors introduced in #412, so we're down to zero Sphinx warnings again).