### PR TITLE
Revert unsuccessful attempt at fixing readthedocs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,14 +12,13 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
+# import sys
 import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('..'))  # make lasagne available for import
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
Reverts attempt in #419 to fix #417. It turned out the problem was a readthedocs misconfiguration, and the fix does not remove the need to install lasagne before building the documentation (it just makes the error message more cryptic -- a failed `import lasagne` hints more clearly at installing lasagne than [some `pkg_resources` error](https://github.com/Lasagne/Lasagne/pull/419#issuecomment-141085130)).