### PR TITLE
fix slicing axis with size None

### DIFF
--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -375,9 +375,11 @@ class SliceLayer(Layer):
         output_shape = list(input_shape)
         if isinstance(self.slice, int):
             del output_shape[self.axis]
-        else:
+        elif input_shape[self.axis] is not None:
             output_shape[self.axis] = len(
                 range(*self.slice.indices(input_shape[self.axis])))
+        else:
+            output_shape[self.axis] = None
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):

--- a/lasagne/tests/layers/test_shape.py
+++ b/lasagne/tests/layers/test_shape.py
@@ -275,3 +275,10 @@ def test_slice_layer():
     aeq(get_output(l_slice_ax0, x).eval(), x1)
     aeq(get_output(l_slice_ax1, x).eval(), x2)
     aeq(get_output(l_slice_ax2, x).eval(), x3)
+
+    # test slicing None dimension
+    in_shp = (2, None, 2)
+    l_inp = InputLayer(in_shp)
+    l_slice_ax1 = SliceLayer(l_inp, axis=1, indices=slice(3, 5))
+    assert get_output_shape(l_slice_ax1) == (2, None, 2)
+    aeq(get_output(l_slice_ax1, x).eval(), x2)


### PR DESCRIPTION
Fix a but where the SliceLayer would fail if one tried to slice a dimension with size None.

This would fail:
```Python
import lasagne
import theano.tensor as T
from lasagne.layers import *
import numpy as np
sym_x = T.matrix()
l_in = InputLayer((None, 10), sym_x)
l_slice = SliceLayer(l_in, axis=0, indices=slice(0, 50))
l_out = ConcatLayer([l_slice, l_slice], axis=0)
output = lasagne.layers.get_output(l_out)
print output.eval({sym_x :np.ones((100, 10), dtype='float32')}).shape
```