### PR TITLE
Add recently added objectives to docs; remove unnecessary restrictions

### DIFF
--- a/docs/modules/objectives.rst
+++ b/docs/modules/objectives.rst
@@ -10,6 +10,8 @@ Loss functions
 .. autofunction:: binary_crossentropy
 .. autofunction:: categorical_crossentropy
 .. autofunction:: squared_error
+.. autofunction:: binary_hinge_loss
+.. autofunction:: multiclass_hinge_loss
 
 
 Aggregation functions
@@ -17,3 +19,9 @@ Aggregation functions
 
 .. autofunction:: aggregate
 
+
+Evaluation functions
+--------------------
+
+.. autofunction:: binary_accuracy
+.. autofunction:: categorical_accuracy

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -143,14 +143,6 @@ def test_binary_hinge_loss_not_binary_targets():
     assert np.allclose(hinge, c.eval({p: predictions, t: targets}))
 
 
-def test_binary_hinge_loss_invalid():
-    from lasagne.objectives import binary_hinge_loss
-    with pytest.raises(TypeError) as exc:
-        binary_hinge_loss(theano.tensor.matrix(),
-                          theano.tensor.vector())
-    assert 'rank mismatch' in exc.value.args[0]
-
-
 def test_multiclass_hinge_loss():
     from lasagne.objectives import multiclass_hinge_loss
     from lasagne.nonlinearities import rectify
@@ -191,14 +183,6 @@ def test_binary_accuracy():
     accuracy = predictions == targets
     # compare
     assert np.allclose(accuracy, c.eval({p: predictions, t: targets}))
-
-
-def test_binary_accuracy_invalid():
-    from lasagne.objectives import binary_accuracy
-    with pytest.raises(TypeError) as exc:
-        binary_accuracy(theano.tensor.matrix(),
-                        theano.tensor.vector())
-    assert 'rank mismatch' in exc.value.args[0]
 
 
 def test_categorical_accuracy():


### PR DESCRIPTION
We overlooked in #428 that it didn't add the new functions to the Sphinx docs. I'm doing this here, changing some bits and pieces for better consistency (including removal of the restrictions for the binary hinge loss and accuracy, to be consistent with the binary cross-entropy).