### PR TITLE
MNIST example: Show how to save and load param values

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -330,7 +330,12 @@ def main(model='mlp', num_epochs=500):
         test_acc / test_batches * 100))
 
     # Optionally, you could now dump the network weights to a file like this:
-    # np.savez('model.npz', lasagne.layers.get_all_param_values(network))
+    # np.savez('model.npz', *lasagne.layers.get_all_param_values(network))
+    #
+    # And load them again later on like this:
+    # with np.load('model.npz') as f:
+    #     param_values = [f['arr_%d' % i] for i in range(len(f.files))]
+    # lasagne.layers.set_all_param_values(network, param_values)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I had a commented line in the MNIST example that shows how to save parameters. However, it inadvertently saved all the parameters as a single numpy array of dtype='O' that had all the other numpy arrays as its elements. Although it works, this was not what I meant to suggest to users.

This PR changes the commented line to save the parameters as separate arrays, and adds two more lines that show how to re-read them (in correct order).