### PR TITLE
Fix documentation build after changes on readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,7 +147,7 @@ if os.environ.get('READTHEDOCS') != 'True':
         pass  # assume we have sphinx >= 1.3
     else:
         html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_theme = 'sphinx_rtd_theme'
+    html_theme = 'sphinx_rtd_theme'
 def setup(app):
     app.add_stylesheet("fix_rtd.css")
 


### PR DESCRIPTION
Fixes #434. https://github.com/rtfd/readthedocs.org/pull/1693 restores compatibility with Sphinx 1.2 on readthedocs (we need to use 1.2 due to https://github.com/sphinx-doc/sphinx/issues/1822 which will only be fixed in 1.4), but only if `html_theme` is not set in `conf.py` when running on readthedocs. So we comply. (It doesn't make a difference when building the docs locally.)

Will merge this right away as I don't expect a fruitful discussion over four inserted blanks ;)