### PR TITLE
Remove conv same pad for even filter_size

### DIFF
--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -253,8 +253,8 @@ class Conv1DLayer(Layer):
                                       image_shape=input_shape,
                                       filter_shape=self.get_W_shape(),
                                       border_mode='full')
-            shift = (self.filter_size[0] - 1) // 2
-            conved = conved[:, :, shift:input.shape[2] + shift]
+            crop = self.filter_size[0] // 2
+            conved = conved[:, :, crop:-crop or None]
         else:
             # no padding needed, or explicit padding of input needed
             if self.pad == 'full':
@@ -468,10 +468,10 @@ class Conv2DLayer(Layer):
                                       image_shape=input_shape,
                                       filter_shape=self.get_W_shape(),
                                       border_mode='full')
-            shift_x = (self.filter_size[0] - 1) // 2
-            shift_y = (self.filter_size[1] - 1) // 2
-            conved = conved[:, :, shift_x:input.shape[2] + shift_x,
-                            shift_y:input.shape[3] + shift_y]
+            crop_x = self.filter_size[0] // 2
+            crop_y = self.filter_size[1] // 2
+            conved = conved[:, :, crop_x:-crop_x or None,
+                            crop_y:-crop_y or None]
         else:
             # no padding needed, or explicit padding of input needed
             if self.pad == 'full':

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -123,9 +123,9 @@ class Conv1DLayer(Layer):
         is equivalent to computing the convolution wherever the input and the
         filter overlap by at least one position.
 
-        ``'same'`` pads with half the filter size on both sides (one less on
-        the second side for an even filter size). When ``stride=1``, this
-        results in an output size equal to the input size.
+        ``'same'`` pads with half the filter size (rounded down) on both sides.
+        When ``stride=1`` this results in an output size equal to the input
+        size. Even filter size is not supported.
 
         ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
 
@@ -196,6 +196,11 @@ class Conv1DLayer(Layer):
         self.stride = as_tuple(stride, 1)
         self.untie_biases = untie_biases
         self.convolution = convolution
+
+        if pad == 'same':
+            if self.filter_size[0] % 2 == 0:
+                raise NotImplementedError(
+                    '`same` padding requires odd filter size.')
 
         if pad == 'valid':
             self.pad = (0,)
@@ -326,9 +331,9 @@ class Conv2DLayer(Layer):
         is equivalent to computing the convolution wherever the input and the
         filter overlap by at least one position.
 
-        ``'same'`` pads with half the filter size on both sides (one less on
-        the second side for an even filter size). When ``stride=1``, this
-        results in an output size equal to the input size.
+        ``'same'`` pads with half the filter size (rounded down) on both sides.
+        When ``stride=1`` this results in an output size equal to the input
+        size. Even filter size is not supported.
 
         ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
 
@@ -400,6 +405,11 @@ class Conv2DLayer(Layer):
         self.untie_biases = untie_biases
         self.convolution = convolution
 
+        if pad == 'same':
+            if any(s % 2 == 0 for s in self.filter_size):
+                raise NotImplementedError(
+                    '`same` padding requires odd filter size.')
+
         if pad == 'valid':
             self.pad = (0, 0)
         elif pad in ('full', 'same'):
@@ -470,9 +480,9 @@ class Conv2DLayer(Layer):
             elif self.pad == 'same':
                 border_mode = 'valid'
                 pad = [(self.filter_size[0] // 2,
-                        (self.filter_size[0] - 1) // 2),
+                        self.filter_size[0] // 2),
                        (self.filter_size[1] // 2,
-                        (self.filter_size[1] - 1) // 2)]
+                        self.filter_size[1] // 2)]
             else:
                 border_mode = 'valid'
                 pad = [(self.pad[0], self.pad[0]), (self.pad[1], self.pad[1])]

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -73,9 +73,9 @@ class Conv2DMMLayer(MMLayer):
         is equivalent to computing the convolution wherever the input and the
         filter overlap by at least one position.
 
-        ``'same'`` pads with half the filter size on both sides (one less on
-        the second side for an even filter size). When ``stride=1``, this
-        results in an output size equal to the input size.
+        ``'same'`` pads with half the filter size (rounded down) on both sides.
+        When ``stride=1`` this results in an output size equal to the input
+        size. Even filter size is not supported.
 
         ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
 
@@ -155,10 +155,10 @@ class Conv2DMMLayer(MMLayer):
         elif pad == 'full':
             self.pad = (self.filter_size[0] - 1, self.filter_size[1] - 1)
         elif pad == 'same':
-            # only works for odd filter size, but the even filter size case
-            # is probably not worth supporting.
-            self.pad = ((self.filter_size[0] - 1) // 2,
-                        (self.filter_size[1] - 1) // 2)
+            if any(s % 2 == 0 for s in self.filter_size):
+                raise NotImplementedError(
+                    '`same` padding requires odd filter size.')
+            self.pad = (self.filter_size[0] // 2, self.filter_size[1] // 2)
         else:
             self.pad = as_tuple(pad, 2, int)
 

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -87,9 +87,9 @@ class Conv2DCCLayer(CCLayer):
         is equivalent to computing the convolution wherever the input and the
         filter overlap by at least one position.
 
-        ``'same'`` pads with half the filter size on both sides (one less on
-        the second side for an even filter size). When ``stride=1``, this
-        results in an output size equal to the input size.
+        ``'same'`` pads with half the filter size (rounded down) on both sides.
+        When ``stride=1`` this results in an output size equal to the input
+        size. Even filter size is not supported.
 
         ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
 
@@ -249,9 +249,10 @@ class Conv2DCCLayer(CCLayer):
         elif pad == 'full':
             self.pad = self.filter_size - 1
         elif pad == 'same':
-            # only works for odd filter size, but the even filter size case
-            # is probably not worth supporting.
-            self.pad = (self.filter_size - 1) // 2
+            if self.filter_size % 2 == 0:
+                raise NotImplementedError(
+                    '`same` padding requires odd filter size.')
+            self.pad = self.filter_size // 2
         else:
             pad = as_tuple(pad, 2, int)
             if pad[0] != pad[1]:

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -90,7 +90,6 @@ class Pool2DDNNLayer(DNNLayer):
             raise NotImplementedError("Pool2DDNNLayer does not support "
                                       "ignore_border=False.")
 
-
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)  # copy / convert to mutable list
 
@@ -175,9 +174,9 @@ class Conv2DDNNLayer(DNNLayer):
         is equivalent to computing the convolution wherever the input and the
         filter overlap by at least one position.
 
-        ``'same'`` pads with half the filter size on both sides (one less on
-        the second side for an even filter size). When ``stride=1``, this
-        results in an output size equal to the input size.
+        ``'same'`` pads with half the filter size (rounded down) on both sides.
+        When ``stride=1`` this results in an output size equal to the input
+        size. Even filter size is not supported.
 
         ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
 
@@ -257,12 +256,10 @@ class Conv2DDNNLayer(DNNLayer):
         elif pad == 'full':
             self.pad = 'full'
         elif pad == 'same':
-            # dnn_conv does not support same, so we just specify
-            # padding directly.
-            # only works for odd filter size, but the even filter size
-            # case is probably not worth supporting.
-            self.pad = ((self.filter_size[0] - 1) // 2,
-                        (self.filter_size[1] - 1) // 2)
+            if any(s % 2 == 0 for s in self.filter_size):
+                raise NotImplementedError(
+                    '`same` padding requires odd filter size.')
+            self.pad = (self.filter_size[0] // 2, self.filter_size[1] // 2)
         else:
             self.pad = as_tuple(pad, 2, int)
 


### PR DESCRIPTION
Currently the docs say that `pad='same'` will work for both odd and even `filter_size`, but this is not tested and fails on all implementation except `Conv2DLayer`.

I don't think this case is worth supporting:

1. It's not possible to avoid asymmetric edge effects
2. I think it's uncommon in practice
3. It requires ugly and inefficient code to support

Therefore, this PR raises `NotImplementedError` in all conv layers for this case. 

It also changes how `Conv1DLayer` implements same padding to avoid the slow compilation bug. 
This supersedes and will close https://github.com/Lasagne/Lasagne/pull/415 if merged.

