### PR TITLE
added Upscale1DLayer implementation

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -81,6 +81,7 @@
     MaxPool2DLayer
     Pool1DLayer
     Pool2DLayer
+    Upscale1DLayer
     Upscale2DLayer
     GlobalPoolLayer
     FeaturePoolLayer

--- a/docs/modules/layers/pool.rst
+++ b/docs/modules/layers/pool.rst
@@ -17,6 +17,9 @@ Pooling layers
 .. autoclass:: Pool2DLayer
     :members:
 
+.. autoclass:: Upscale1DLayer
+    :members:
+
 .. autoclass:: Upscale2DLayer
     :members:
 

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -11,6 +11,7 @@ __all__ = [
     "MaxPool2DLayer",
     "Pool1DLayer",
     "Pool2DLayer",
+    "Upscale1DLayer",
     "Upscale2DLayer",
     "FeaturePoolLayer",
     "FeatureWTALayer",
@@ -364,9 +365,51 @@ class MaxPool2DLayer(Pool2DLayer):
 # TODO: add MaxPool3DLayer
 
 
+class Upscale1DLayer(Layer):
+    """
+    1D upscaling layer
+
+    Performs 1D upscaling over the trailing axis of a 3D input tensor.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or tuple
+        The layer feeding into this layer, or the expected input shape.
+
+    scale_factor : integer or iterable
+        The scale factor. If an iterable, it should have one element.
+
+    **kwargs
+        Any additional keyword arguments are passed to the :class:`Layer`
+        superclass.
+    """
+
+    def __init__(self, incoming, scale_factor, **kwargs):
+        super(Upscale1DLayer, self).__init__(incoming, **kwargs)
+
+        self.scale_factor = as_tuple(scale_factor, 1)
+
+        if self.scale_factor[0] < 1:
+            raise ValueError('Scale factor must be >= 1, not {0}'.format(
+                self.scale_factor))
+
+    def get_output_shape_for(self, input_shape):
+        output_shape = list(input_shape)  # copy / convert to mutable list
+        if output_shape[2] is not None:
+            output_shape[2] *= self.scale_factor[0]
+        return tuple(output_shape)
+
+    def get_output_for(self, input, **kwargs):
+        a, = self.scale_factor
+        upscaled = input
+        if a > 1:
+            upscaled = T.extra_ops.repeat(upscaled, a, 2)
+        return upscaled
+
+
 class Upscale2DLayer(Layer):
     """
-    2D upscaling layer layer
+    2D upscaling layer
 
     Performs 2D upscaling over the two trailing axes of a 4D input tensor.
 

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -48,6 +48,18 @@ def max_pool_1d_ignoreborder(data, pool_size, stride=None, pad=0):
     return data_pooled
 
 
+def upscale_1d_shape(shape, scale_factor):
+    return (shape[0], shape[1],
+            shape[2] * scale_factor[0])
+
+
+def upscale_1d(data, scale_factor):
+    upscaled = np.zeros(upscale_1d_shape(data.shape, scale_factor))
+    for i in range(scale_factor[0]):
+        upscaled[:, :, i::scale_factor[0]] = data
+    return upscaled
+
+
 def max_pool_2d(data, pool_size, stride):
     data_pooled = max_pool_1d(data, pool_size[1], stride[1])
 
@@ -488,6 +500,63 @@ class TestMaxPool2DNNLayer:
                                       ignore_border=False)
         assert ("Pool2DDNNLayer does not support ignore_border=False" in
                 exc.value.args[0])
+
+
+class TestUpscale1DLayer:
+    def scale_factor_test_sets():
+        for scale_factor in [2, 3]:
+            yield scale_factor
+
+    def input_layer(self, output_shape):
+        return Mock(output_shape=output_shape)
+
+    def layer(self, input_layer, scale_factor):
+        from lasagne.layers.pool import Upscale1DLayer
+        return Upscale1DLayer(
+            input_layer,
+            scale_factor=scale_factor,
+        )
+
+    def test_invalid_scale_factor(self):
+        from lasagne.layers.pool import Upscale1DLayer
+        inlayer = self.input_layer((128, 3, 32))
+        with pytest.raises(ValueError):
+            Upscale1DLayer(inlayer, scale_factor=0)
+        with pytest.raises(ValueError):
+            Upscale1DLayer(inlayer, scale_factor=-1)
+        with pytest.raises(ValueError):
+            Upscale1DLayer(inlayer, scale_factor=(0))
+
+    @pytest.mark.parametrize(
+        "scale_factor", list(scale_factor_test_sets()))
+    def test_get_output_for(self, scale_factor):
+        input = floatX(np.random.randn(8, 16, 17))
+        input_layer = self.input_layer(input.shape)
+        input_theano = theano.shared(input)
+        result = self.layer(
+            input_layer,
+            (scale_factor),
+        ).get_output_for(input_theano)
+
+        result_eval = result.eval()
+        numpy_result = upscale_1d(input, (scale_factor, scale_factor))
+
+        assert np.all(numpy_result.shape == result_eval.shape)
+        assert np.allclose(result_eval, numpy_result)
+
+    @pytest.mark.parametrize(
+        "input_shape,output_shape",
+        [((32, 64, 24), (32, 64, 48)),
+         ((None, 64, 24), (None, 64, 48)),
+         ((32, None, 24), (32, None, 48)),
+         ((32, 64, None), (32, 64, None))],
+    )
+    def test_get_output_shape_for(self, input_shape, output_shape):
+        input_layer = self.input_layer(input_shape)
+        layer = self.layer(input_layer,
+                           scale_factor=(2))
+        assert layer.get_output_shape_for(
+            input_shape) == output_shape
 
 
 class TestUpscale2DLayer:


### PR DESCRIPTION
This adds Upscale1DLayer, based on the Upscale2DLayer implementation. I've trained with it and it seems to work correctly.

It would be nice to have something like UpscaleNDLayer with a mode parameter that could be 'nearest' (current behavior), 'bilinear', or something else, similar to Pool1DLayer or Pool2DLayer. Though I'm not sure if there is any literature supporting the possibility of other kinds of upscaling.