### PR TITLE
Circumvent Travis badge bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://readthedocs.org/projects/lasagne/badge/
     :target: http://lasagne.readthedocs.org/en/latest/
 
-.. image:: https://travis-ci.org/Lasagne/Lasagne.svg?branch=master
+.. image:: https://travis-ci.org/Lasagne/Lasagne.svg
     :target: https://travis-ci.org/Lasagne/Lasagne
 
 .. image:: https://img.shields.io/coveralls/Lasagne/Lasagne.svg


### PR DESCRIPTION
Due to unsolved problems at Travis (https://github.com/travis-ci/travis-ci/issues/4024#issuecomment-146899985), the Travis badge displays "build: failing" while in fact it's fine. Removing `branch=master` from the badge link circumvents this. Fixes #458.