### PR TITLE
Check that Theano is recent enough

### DIFF
--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -3,16 +3,21 @@ Tools to train neural nets in Theano
 """
 
 try:
+    install_instr = """
+
+Please make sure you install a recent enough version of Theano. Note that a
+simple 'pip install theano' will usually give you a version that is too old
+for Lasagne. See the installation docs for more details:
+http://lasagne.readthedocs.org/en/latest/user/installation.html#theano"""
     import theano
 except ImportError:  # pragma: no cover
-    raise ImportError("""Could not import Theano.
-
-Please make sure you install a recent enough version of Theano.  See
-section 'Install from PyPI' in the installation docs for more details:
-http://lasagne.readthedocs.org/en/latest/user/installation.html#install-from-pypi
-""")
+    raise ImportError("Could not import Theano." + install_instr)
 else:
+    if not hasattr(theano.tensor.nnet, 'relu'):  # pragma: no cover
+        raise ImportError("Your Theano version is too old." + install_instr)
+    del install_instr
     del theano
+
 
 from . import nonlinearities
 from . import init


### PR DESCRIPTION
This adds an additional check to `__init__.py` to not only test whether Theano is importable, but also test whether it is recent enough to support what's needed by Lasagne. The most recent feature we actually use is `theano.tensor.nnet.relu`. There are some commits between the addition of that feature to Theano and the commit we've got in our `requirements.txt`, but it's unlikely that anybody uses this and even if so, it wouldn't cause any problems -- the main goal is to catch users who merely installed the latest Theano release.
Corrects the link to the installation instructions, and clarifies that `pip install theano` is not the solution.
This closes #454.