### PR TITLE
Add BatchNormLayer

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -16,6 +16,7 @@
     layers/noise
     layers/shape
     layers/merge
+    layers/normalization
     layers/embedding
     layers/special
     layers/corrmm
@@ -135,6 +136,16 @@
     concat
     ElemwiseMergeLayer
     ElemwiseSumLayer
+
+
+.. rubric:: :doc:`layers/normalization`
+
+.. autosummary::
+    :nosignatures:
+
+    LocalResponseNormalization2DLayer
+    BatchNormLayer
+    batch_norm
 
 
 .. rubric:: :doc:`layers/embedding`

--- a/docs/modules/layers/normalization.rst
+++ b/docs/modules/layers/normalization.rst
@@ -1,0 +1,15 @@
+Normalization layers
+--------------------
+
+.. automodule:: lasagne.layers.normalization
+
+.. currentmodule:: lasagne.layers
+
+.. autoclass:: LocalResponseNormalization2DLayer
+    :members:
+
+.. autoclass:: BatchNormLayer
+    :members:
+
+.. autofunction:: batch_norm
+

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -59,30 +59,35 @@ class LocalResponseNormalization2DLayer(Layer):
     Aggregation is purely across channels, not within channels,
     and performed "pixelwise".
 
-    Input order is assumed to be `BC01`.
-
-    If the value of the ith channel is :math:`x_i`, the output is
+    If the value of the :math:`i` th channel is :math:`x_i`, the output is
 
     .. math::
-
-        x_i = \frac{x_i}{ (k + ( \alpha \sum_j x_j^2 ))^\beta }
+        x_i = \\frac{x_i}{ (k + ( \\alpha \\sum_j x_j^2 ))^\\beta }
 
     where the summation is performed over this position on :math:`n`
     neighboring channels.
 
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape. Must
+        follow *BC01* layout, i.e., ``(batchsize, channels, rows, columns)``.
+    alpha : float scalar
+        coefficient, see equation above
+    k : float scalar
+        offset, see equation above
+    beta : float scalar
+        exponent, see equation above
+    n : int
+        number of adjacent channels to normalize over, must be odd
+
+    Notes
+    -----
     This code is adapted from pylearn2. See the module docstring for license
     information.
     """
 
     def __init__(self, incoming, alpha=1e-4, k=2, beta=0.75, n=5, **kwargs):
-        """
-        :parameters:
-            - incoming: input layer or shape
-            - alpha: see equation above
-            - k: see equation above
-            - beta: see equation above
-            - n: number of adjacent channels to normalize over.
-        """
         super(LocalResponseNormalization2DLayer, self).__init__(incoming,
                                                                 **kwargs)
         self.alpha = alpha

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 """
-
-This file contains code from pylearn2, which is covered by the following
-license:
+The :class:`LocalResponseNormalization2DLayer
+<lasagne.layers.LocalResponseNormalization2DLayer>` implementation contains
+code from `pylearn2 <http://github.com/lisa-lab/pylearn2>`_, which is covered
+by the following license:
 
 
 Copyright (c) 2011--2014, Université de Montréal
@@ -35,12 +36,19 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+import theano
 import theano.tensor as T
+
+from .. import init
+from .. import nonlinearities
 
 from .base import Layer
 
+
 __all__ = [
     "LocalResponseNormalization2DLayer",
+    "BatchNormLayer",
+    "batch_norm",
 ]
 
 
@@ -62,7 +70,8 @@ class LocalResponseNormalization2DLayer(Layer):
     where the summation is performed over this position on :math:`n`
     neighboring channels.
 
-    This code is adapted from pylearn2.
+    This code is adapted from pylearn2. See the module docstring for license
+    information.
     """
 
     def __init__(self, incoming, alpha=1e-4, k=2, beta=0.75, n=5, **kwargs):
@@ -101,3 +110,259 @@ class LocalResponseNormalization2DLayer(Layer):
             scale += self.alpha * input_sqr[:, i:i+ch, :, :]
         scale = scale ** self.beta
         return input / scale
+
+
+class BatchNormLayer(Layer):
+    """
+    lasagne.layers.BatchNormLayer(incoming, axes='auto', epsilon=1e-4,
+    alpha=0.1, mode='low_mem',
+    beta=lasagne.init.Constant(0), gamma=lasagne.init.Constant(1),
+    mean=lasagne.init.Constant(0), var=lasagne.init.Constant(1), **kwargs)
+
+    Batch Normalization
+
+    This layer implements batch normalization of its inputs, following [1]_:
+
+    .. math::
+        y = \\frac{x - \\mu}{\\sqrt{\\sigma^2 + \\epsilon}} \\gamma + \\beta
+
+    That is, the input is normalized to zero mean and unit variance, and then
+    linearly transformed. The crucial part is that the mean and variance are
+    computed across the batch dimension, i.e., over examples, not per example.
+
+    During training, :math:`\\mu` and :math:`\\sigma^2` are defined to be the
+    mean and variance of the current input mini-batch :math:`x`, and during
+    testing, they are replaced with average statistics over the training
+    data. Consequently, this layer has four stored parameters: :math:`\\beta`,
+    :math:`\\gamma`, and the averages :math:`\\mu` and :math:`\\sigma^2`.
+    By default, this layer learns the average statistics as exponential moving
+    averages computed during training, so it can be plugged into an existing
+    network without any changes of the training procedure (see Notes).
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape
+    axes : 'auto', int or tuple of int
+        The axis or axes to normalize over. If ``'auto'`` (the default),
+        normalize over all axes except for the second: this will normalize over
+        the minibatch dimension for dense layers, and additionally over all
+        spatial dimensions for convolutional layers.
+    epsilon : scalar
+        Small constant :math:`\\epsilon` added to the variance before taking
+        the square root and dividing by it, to avoid numerical problems
+    alpha : scalar
+        Coefficient for the exponential moving average of batch-wise means and
+        standard deviations computed during training; the closer to one, the
+        more it will depend on the last batches seen
+    mode : {'low_mem', 'high_mem'}
+        Specify which batch normalization implementation to use: ``'low_mem'``
+        avoids storing intermediate representations and thus requires less
+        memory, while ``'high_mem'`` can reuse representations for the backward
+        pass and is thus 5-10% faster.
+    beta : Theano shared variable, expression, numpy array, callable or None
+        Initial value, expression or initializer for :math:`\\beta`. Must match
+        the incoming shape, skipping all axes in `axes`. Set to ``None`` to fix
+        it to 0.0 instead of learning it.
+        See :func:`lasagne.utils.create_param` for more information.
+    gamma : Theano shared variable, expression, numpy array, callable or None
+        Initial value, expression or initializer for :math:`\\gamma`. Must
+        match the incoming shape, skipping all axes in `axes`. Set to ``None``
+        to fix it to 1.0 instead of learning it.
+        See :func:`lasagne.utils.create_param` for more information.
+    mean : Theano shared variable, expression, numpy array, or callable
+        Initial value, expression or initializer for :math:`\\mu`. Must match
+        the incoming shape, skipping all axes in `axes`.
+        See :func:`lasagne.utils.create_param` for more information.
+    var : Theano shared variable, expression, numpy array, or callable
+        Initial value, expression or initializer for :math:`\\sigma^2`. Must
+        match the incoming shape, skipping all axes in `axes`.
+        See :func:`lasagne.utils.create_param` for more information.
+    **kwargs
+        Any additional keyword arguments are passed to the :class:`Layer`
+        superclass.
+
+    Notes
+    -----
+    This layer should be inserted between a linear transformation (such as a
+    :class:`DenseLayer`, or :class:`Conv2DLayer`) and its nonlinearity. The
+    convenience function :func:`batch_norm` modifies an existing layer to
+    insert batch normalization in front of its nonlinearity.
+
+    The behavior can be controlled by passing keyword arguments to
+    :func:`lasagne.layers.get_output()` when building the output expression
+    of any network containing this layer.
+
+    During training, [1]_ normalize each input mini-batch by its statistics
+    and update an exponential moving average of the statistics to be used for
+    validation. This can be achieved by passing ``deterministic=False``.
+    For validation, [1]_ normalize each input mini-batch by the stored
+    statistics. This can be achieved by passing ``deterministic=True``.
+
+    For more fine-grained control, ``batch_norm_update_averages`` can be passed
+    to update the exponential moving averages (``True``) or not (``False``),
+    and ``batch_norm_use_averages`` can be passed to use the exponential moving
+    averages for normalization (``True``) or normalize each mini-batch by its
+    own statistics (``False``). These settings override ``deterministic``.
+
+    Note that for testing a model after training, [1]_ replace the stored
+    exponential moving average statistics by fixing all network weights and
+    re-computing average statistics over the training data in a layerwise
+    fashion. This is not part of the layer implementation.
+
+    In case you set `axes` to not include the batch dimension (the first axis,
+    usually), normalization is done per example, not across examples. This does
+    not require any averages, so you can pass ``batch_norm_update_averages``
+    and ``batch_norm_use_averages`` as ``False`` in this case.
+
+    See also
+    --------
+    batch_norm : Convenience function to apply batch normalization to a layer
+
+    References
+    ----------
+    .. [1] Ioffe, Sergey and Szegedy, Christian (2015):
+           Batch Normalization: Accelerating Deep Network Training by Reducing
+           Internal Covariate Shift. http://arxiv.org/abs/1502.03167.
+    """
+    def __init__(self, incoming, axes='auto', epsilon=1e-4, alpha=0.1,
+                 mode='low_mem', beta=init.Constant(0), gamma=init.Constant(1),
+                 mean=init.Constant(0), var=init.Constant(1), **kwargs):
+        super(BatchNormLayer, self).__init__(incoming, **kwargs)
+
+        if axes == 'auto':
+            # default: normalize over all but the second axis
+            axes = (0,) + tuple(range(2, len(self.input_shape)))
+        elif isinstance(axes, int):
+            axes = (axes,)
+        self.axes = axes
+
+        self.epsilon = epsilon
+        self.alpha = alpha
+        self.mode = mode
+
+        # create parameters, ignoring all dimensions in axes
+        shape = [size for axis, size in enumerate(self.input_shape)
+                 if axis not in self.axes]
+        if any(size is None for size in shape):
+            raise ValueError("BatchNormLayer needs specified input sizes for "
+                             "all axes not normalized over.")
+        if beta is None:
+            self.beta = None
+        else:
+            self.beta = self.add_param(beta, shape, 'beta',
+                                       trainable=True, regularizable=False)
+        if gamma is None:
+            self.gamma = None
+        else:
+            self.gamma = self.add_param(gamma, shape, 'gamma',
+                                        trainable=True, regularizable=True)
+        self.mean = self.add_param(mean, shape, 'mean',
+                                   trainable=False, regularizable=False)
+        self.var = self.add_param(var, shape, 'var',
+                                  trainable=False, regularizable=False)
+
+    def get_output_for(self, input, deterministic=False, **kwargs):
+        input_mean = input.mean(self.axes)
+        input_var = input.var(self.axes)
+
+        # Decide whether to use the stored averages or mini-batch statistics
+        use_averages = kwargs.get('batch_norm_use_averages',
+                                  deterministic)
+        if use_averages:
+            mean = self.mean
+            var = self.var
+        else:
+            mean = input_mean
+            var = input_var
+
+        # Decide whether to update the stored averages
+        update_averages = kwargs.get('batch_norm_update_averages',
+                                     not deterministic)
+        if update_averages:
+            # Trick: To update the stored statistics, we create memory-aliased
+            # clones of the stored statistics:
+            running_mean = theano.clone(self.mean, share_inputs=False)
+            running_var = theano.clone(self.var, share_inputs=False)
+            # set a default update for them:
+            running_mean.default_update = ((1 - self.alpha) * running_mean +
+                                           self.alpha * input_mean)
+            running_var.default_update = ((1 - self.alpha) * running_var +
+                                          self.alpha * input_var)
+            # and make sure they end up in the graph without participating in
+            # the computation (this way their default_update will be collected
+            # and applied, but the computation will be optimized away):
+            mean += 0 * running_mean
+            var += 0 * running_var
+
+        # prepare dimshuffle pattern inserting broadcastable axes as needed
+        param_axes = iter(range(input.ndim - len(self.axes)))
+        pattern = ['x' if input_axis in self.axes
+                   else next(param_axes)
+                   for input_axis in range(input.ndim)]
+
+        # apply dimshuffle pattern to all parameters
+        beta = 0 if self.beta is None else self.beta.dimshuffle(pattern)
+        gamma = 1 if self.gamma is None else self.gamma.dimshuffle(pattern)
+        mean = mean.dimshuffle(pattern)
+        std = T.sqrt(var + self.epsilon).dimshuffle(pattern)
+
+        # normalize
+        # normalized = (input - mean) * (gamma / std) + beta
+        normalized = T.nnet.batch_normalization(input, gamma=gamma, beta=beta,
+                                                mean=mean, std=std,
+                                                mode=self.mode)
+        return normalized
+
+
+def batch_norm(layer, **kwargs):
+    """
+    Apply batch normalization to an existing layer. This is a convenience
+    function modifying an existing layer to include batch normalization: It
+    will steal the layer's nonlinearity if there is one (effectively
+    introducing the normalization right before the nonlinearity), remove
+    the layer's bias if there is one (because it would be redundant), and add
+    a :class:`BatchNormLayer` and :class:`NonlinearityLayer` on top.
+
+    Parameters
+    ----------
+    layer : A :class:`Layer` instance
+        The layer to apply the normalization to; note that it will be
+        irreversibly modified as specified above
+    **kwargs
+        Any additional keyword arguments are passed on to the
+        :class:`BatchNormLayer` constructor. Especially note the `mode`
+        argument, which controls a memory usage to performance tradeoff.
+
+    Returns
+    -------
+    BatchNormLayer or NonlinearityLayer instance
+        A batch normalization layer stacked on the given modified `layer`, or
+        a nonlinearity layer stacked on top of both if `layer` was nonlinear.
+
+    Examples
+    --------
+    Just wrap any layer into a :func:`batch_norm` call on creating it:
+
+    >>> from lasagne.layers import InputLayer, DenseLayer, batch_norm
+    >>> from lasagne.nonlinearities import tanh
+    >>> l1 = InputLayer((64, 768))
+    >>> l2 = batch_norm(DenseLayer(l1, num_units=500, nonlinearity=tanh))
+
+    This introduces batch normalization right before its nonlinearity:
+
+    >>> from lasagne.layers import get_all_layers
+    >>> [l.__class__.__name__ for l in get_all_layers(l2)]
+    ['InputLayer', 'DenseLayer', 'BatchNormLayer', 'NonlinearityLayer']
+    """
+    nonlinearity = getattr(layer, 'nonlinearity', None)
+    if nonlinearity is not None:
+        layer.nonlinearity = nonlinearities.identity
+    if hasattr(layer, 'b') and layer.b is not None:
+        del layer.params[layer.b]
+        layer.b = None
+    layer = BatchNormLayer(layer, **kwargs)
+    if nonlinearity is not None:
+        from .special import NonlinearityLayer
+        layer = NonlinearityLayer(layer, nonlinearity)
+    return layer

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -2,8 +2,10 @@
 
 """
 
-This file contains code from pylearn2, which is covered by the following
-license:
+The :func:`ground_truth_normalizer()`, :func:`ground_truth_normalize_row` and
+:class:`TestLocalResponseNormalization2DLayer` implementations contain code
+from `pylearn2 <http://github.com/lisa-lab/pylearn2>`_, which is covered
+by the following license:
 
 
 Copyright (c) 2011--2014, Université de Montréal
@@ -36,11 +38,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 
+from mock import Mock
 import numpy as np
 import pytest
 import theano
-
-import lasagne
 
 
 def ground_truth_normalizer(c01b, k, n, alpha, beta):
@@ -125,8 +126,9 @@ class TestLocalResponseNormalization2DLayer:
             LocalResponseNormalization2DLayer(input_layer, n=4)
 
     def test_normalization(self, input_data, input_layer, layer):
+        from lasagne.layers import get_output
         X = input_layer.input_var
-        lrn = theano.function([X], lasagne.layers.get_output(layer, X))
+        lrn = theano.function([X], get_output(layer, X))
         out = lrn(input_data)
 
         # ground_truth_normalizer assumes c01b
@@ -140,3 +142,160 @@ class TestLocalResponseNormalization2DLayer:
         assert out.shape == ground_out.shape
 
         assert np.allclose(out, ground_out)
+
+
+class TestBatchNormLayer:
+    @pytest.fixture
+    def BatchNormLayer(self):
+        from lasagne.layers.normalization import BatchNormLayer
+        return BatchNormLayer
+
+    @pytest.fixture
+    def init_unique(self):
+        # initializer for a tensor of unique values
+        return lambda shape: np.arange(np.prod(shape)).reshape(shape)
+
+    def test_init(self, BatchNormLayer, init_unique):
+        input_shape = (2, 3, 4)
+        # default: normalize over all but second axis
+        beta = BatchNormLayer(input_shape, beta=init_unique).beta
+        assert np.allclose(beta.get_value(), init_unique((3,)))
+        # normalize over first axis only
+        beta = BatchNormLayer(input_shape, beta=init_unique, axes=0).beta
+        assert np.allclose(beta.get_value(), init_unique((3, 4)))
+        # normalize over second and third axis
+        beta = BatchNormLayer(input_shape, beta=init_unique, axes=(1, 2)).beta
+        assert np.allclose(beta.get_value(), init_unique((2,)))
+
+    @pytest.mark.parametrize('update_averages', [None, True, False])
+    @pytest.mark.parametrize('use_averages', [None, True, False])
+    @pytest.mark.parametrize('deterministic', [True, False])
+    def test_get_output_for(self, BatchNormLayer, deterministic, use_averages,
+                            update_averages):
+        input_shape = (20, 30, 40)
+
+        # random input tensor, beta, gamma, mean, var and alpha
+        input = (np.random.randn(*input_shape).astype(theano.config.floatX) +
+                 np.random.randn(1, 30, 1).astype(theano.config.floatX))
+        beta = np.random.randn(30).astype(theano.config.floatX)
+        gamma = np.random.randn(30).astype(theano.config.floatX)
+        mean = np.random.randn(30).astype(theano.config.floatX)
+        var = np.random.rand(30).astype(theano.config.floatX)
+        alpha = np.random.rand()
+
+        # create layer (with default axes: normalize over all but second axis)
+        layer = BatchNormLayer(input_shape, beta=beta, gamma=gamma, mean=mean,
+                               var=var, alpha=alpha)
+
+        # call get_output_for()
+        kwargs = {'deterministic': deterministic}
+        if use_averages is not None:
+            kwargs['batch_norm_use_averages'] = use_averages
+        else:
+            use_averages = deterministic
+        if update_averages is not None:
+            kwargs['batch_norm_update_averages'] = update_averages
+        else:
+            update_averages = not deterministic
+        result = layer.get_output_for(theano.tensor.constant(input),
+                                      **kwargs).eval()
+
+        # compute expected results and expected updated parameters
+        input_mean = input.mean(axis=(0, 2))
+        input_var = input.var(axis=(0, 2))
+        if use_averages:
+            use_mean, use_var = mean, var
+        else:
+            use_mean, use_var = input_mean, input_var
+        use_std = np.sqrt(use_var + layer.epsilon)
+        exp_result = (input - use_mean[None, :, None]) / use_std[None, :, None]
+        exp_result = exp_result * gamma[None, :, None] + beta[None, :, None]
+        if update_averages:
+            new_mean = (1 - alpha) * mean + alpha * input_mean
+            new_var = (1 - alpha) * var + alpha * input_var
+        else:
+            new_mean, new_var = mean, var
+
+        # compare expected results to actual results
+        tol = {'atol': 1e-5, 'rtol': 1e-6}
+        assert np.allclose(layer.mean.get_value(), new_mean, **tol)
+        assert np.allclose(layer.var.get_value(), new_var, **tol)
+        assert np.allclose(result, exp_result, **tol)
+
+    def test_undefined_shape(self, BatchNormLayer):
+        # should work:
+        BatchNormLayer((64, None, 3), axes=(1, 2))
+        # should not work:
+        with pytest.raises(ValueError) as exc:
+            BatchNormLayer((64, None, 3), axes=(0, 2))
+        assert 'needs specified input sizes' in exc.value.args[0]
+
+    def test_skip_linear_transform(self, BatchNormLayer):
+        input_shape = (20, 30, 40)
+
+        # random input tensor, beta, gamma
+        input = (np.random.randn(*input_shape).astype(theano.config.floatX) +
+                 np.random.randn(1, 30, 1).astype(theano.config.floatX))
+        beta = np.random.randn(30).astype(theano.config.floatX)
+        gamma = np.random.randn(30).astype(theano.config.floatX)
+
+        # create layers without beta or gamma
+        layer1 = BatchNormLayer(input_shape, beta=None, gamma=gamma)
+        layer2 = BatchNormLayer(input_shape, beta=beta, gamma=None)
+
+        # check that one parameter is missing
+        assert len(layer1.get_params()) == 3
+        assert len(layer2.get_params()) == 3
+
+        # call get_output_for()
+        result1 = layer1.get_output_for(theano.tensor.constant(input),
+                                        deterministic=False).eval()
+        result2 = layer2.get_output_for(theano.tensor.constant(input),
+                                        deterministic=False).eval()
+
+        # compute expected results and expected updated parameters
+        mean = input.mean(axis=(0, 2))
+        std = np.sqrt(input.var(axis=(0, 2)) + layer1.epsilon)
+        exp_result = (input - mean[None, :, None]) / std[None, :, None]
+        exp_result1 = exp_result * gamma[None, :, None]  # no beta
+        exp_result2 = exp_result + beta[None, :, None]  # no gamma
+
+        # compare expected results to actual results
+        tol = {'atol': 1e-5, 'rtol': 1e-6}
+        assert np.allclose(result1, exp_result1, **tol)
+        assert np.allclose(result2, exp_result2, **tol)
+
+
+def test_batch_norm_macro():
+    from lasagne.layers import (Layer, BatchNormLayer, batch_norm,
+                                NonlinearityLayer)
+    from lasagne.nonlinearities import identity
+    input_shape = (2, 3)
+    obj = object()
+
+    # check if it steals the nonlinearity
+    layer = Mock(Layer, output_shape=input_shape, nonlinearity=obj)
+    bnstack = batch_norm(layer)
+    assert isinstance(bnstack, NonlinearityLayer)
+    assert isinstance(bnstack.input_layer, BatchNormLayer)
+    assert layer.nonlinearity is identity
+    assert bnstack.nonlinearity is obj
+
+    # check if it removes the bias
+    layer = Mock(Layer, output_shape=input_shape, b=obj, params={obj: set()})
+    bnstack = batch_norm(layer)
+    assert isinstance(bnstack, BatchNormLayer)
+    assert layer.b is None
+    assert obj not in layer.params
+
+    # check if it can handle an unset bias
+    layer = Mock(Layer, output_shape=input_shape, b=None, params={obj: set()})
+    bnstack = batch_norm(layer)
+    assert isinstance(bnstack, BatchNormLayer)
+    assert layer.b is None
+
+    # check if it passes on kwargs
+    layer = Mock(Layer, output_shape=input_shape)
+    bnstack = batch_norm(layer, name='foo')
+    assert isinstance(bnstack, BatchNormLayer)
+    assert bnstack.name == 'foo'


### PR DESCRIPTION
Finally started integrating my batch normalization implementation in Lasagne. Changes from [the implementation in my gist](https://gist.github.com/f0k/f1a6bd3c8585c400c190):
* Adding epsilon before taking the square root of the variance
* Change parameters to have reduced dimensionality rather than broadcastable singleton dimensions, to match with `BiasLayer` (which in turn was made to match `DenseLayer`, `Conv2DLayer` etc.)

TODO:
* [x] add tests
* [x] fix LocalResponseNormalization2DLayer docstring while we're at it

Resolves #141.