### PR TITLE
mnist.py: Exit with error when model name isn't recognised.

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -249,6 +249,7 @@ def main(model='mlp', num_epochs=500):
         network = build_cnn(input_var)
     else:
         print("Unrecognized model type %r." % model)
+        return
 
     # Create a loss expression for training, i.e., a scalar objective we want
     # to minimize (for our multi-class problem, it is the cross-entropy loss):


### PR DESCRIPTION
mnist.py expects the first command line argument to the a model
name. If the model isn't recognised there is an UnboundedLocal
error as `network` is used before assignment.

Since there's nothing that can be done in this case, exit with
error letting the user pick a valid model.