### PR TITLE
Avoid dependency on pkg_resources for lasagne.__version__

### DIFF
--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -29,6 +29,4 @@ from . import updates
 from . import utils
 
 
-import pkg_resources
-__version__ = pkg_resources.get_distribution("Lasagne").version
-del pkg_resources
+__version__ = "0.2.dev1"

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 import os
+import re
 from setuptools import find_packages
 from setuptools import setup
 
-version = '0.2.dev1'
-
 here = os.path.abspath(os.path.dirname(__file__))
 try:
+    # obtain version string from __init__.py
+    init_py = open(os.path.join(here, 'lasagne', '__init__.py')).read()
+    version = re.search('__version__ = "(.*)"', init_py).groups()[0]
+except Exception:
+    version = ''
+try:
+    # obtain long description from README and CHANGES
     README = open(os.path.join(here, 'README.rst')).read()
     CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 except IOError:


### PR DESCRIPTION
Instead of using `pkg_resources.get_distribution()` to set `lasagne.__version__` to whatever version of Lasagne is currently installed, this PR hard-codes `lasagne.__version__` to a plain string and reads that string from `setup.py` to avoid maintaining it in two places.

Resolves #477, closes #478.

The less adventurous alternative would be hard-coding it both in `__init__.py` and in `setup.py`. Any preference?