### PR TITLE
Clarify recurrent example output flattening

### DIFF
--- a/examples/recurrent.py
+++ b/examples/recurrent.py
@@ -142,8 +142,9 @@ def main(num_epochs=NUM_EPOCHS):
 
     # lasagne.layers.get_output produces a variable for the output of the net
     network_output = lasagne.layers.get_output(l_out)
-    # The value we care about is the final value produced for each sequence
-    predicted_values = network_output[:, -1]
+    # The network output will have shape (n_batch, 1); let's flatten to get a
+    # 1-dimensional vector of predicted values
+    predicted_values = network_output.flatten()
     # Our cost will be mean-squared error
     cost = T.mean((predicted_values - target_values)**2)
     # Retrieve all parameters from the network


### PR DESCRIPTION
As pointed out here:
https://groups.google.com/d/msg/lasagne-users/MrDuFJy4qNg/1PUs1PPRDQAJ
the recurrent example was using a slice which was effectively turning the 2D output (with the final dimension being 1) into a 1D output.  This was a holdover from when we used to not use `SliceLayer`s in the recurrent example.  It makes more sense (to me) to use a `flatten`, and I've fixed the comment to describe what's actually going on.