### PR TITLE
Add Conv3DDNNLayer

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -186,6 +186,7 @@
     :nosignatures:
 
     dnn.Conv2DDNNLayer
+    dnn.Conv3DDNNLayer
     dnn.MaxPool2DDNNLayer
     dnn.Pool2DDNNLayer
 

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -17,6 +17,7 @@ __all__ = [
     "Pool2DDNNLayer",
     "MaxPool2DDNNLayer",
     "Conv2DDNNLayer",
+    "Conv3DDNNLayer",
 ]
 
 
@@ -313,4 +314,192 @@ class Conv2DDNNLayer(DNNLayer):
             activation = conved + self.b.dimshuffle('x', 0, 1, 2)
         else:
             activation = conved + self.b.dimshuffle('x', 0, 'x', 'x')
+        return self.nonlinearity(activation)
+
+
+class Conv3DDNNLayer(DNNLayer):
+    """
+    lasagne.layers.Conv3DDNNLayer(incoming, num_filters, filter_size,
+    stride=(1, 1, 1), pad=0, untie_biases=False,
+    W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
+    nonlinearity=lasagne.nonlinearities.rectify, flip_filters=False,
+    **kwargs)
+
+    3D convolutional layer
+
+    Performs a 3D convolution on its input and optionally adds a bias and
+    applies an elementwise nonlinearity.  This implementation uses
+    ``theano.sandbox.cuda.dnn.dnn_conv3d`` directly.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape. The
+        output of this layer should be a 5D tensor, with shape ``(batch_size,
+        num_input_channels, input_rows, input_columns, input_depth)``.
+
+    num_filters : int
+        The number of learnable convolutional filters this layer has.
+
+    filter_size : int or iterable of int
+        An integer or a 3-element tuple specifying the size of the filters.
+
+    stride : int or iterable of int
+        An integer or a 3-element tuple specifying the stride of the
+        convolution operation.
+
+    pad : int, iterable of int, 'full', 'same' or 'valid' (default: 0)
+        By default, the convolution is only computed where the input and the
+        filter fully overlap (a valid convolution). When ``stride=1``, this
+        yields an output that is smaller than the input by ``filter_size - 1``.
+        The `pad` argument allows you to implicitly pad the input with zeros,
+        extending the output size.
+
+        A single integer results in symmetric zero-padding of the given size on
+        all borders, a tuple of three integers allows different symmetric
+        padding per dimension.
+
+        ``'full'`` pads with one less than the filter size on both sides. This
+        is equivalent to computing the convolution wherever the input and the
+        filter overlap by at least one position.
+
+        ``'same'`` pads with half the filter size (rounded down) on both sides.
+        When ``stride=1`` this results in an output size equal to the input
+        size. Even filter size is not supported.
+
+        ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
+
+        Note that ``'full'`` and ``'same'`` can be faster than equivalent
+        integer values due to optimizations by Theano.
+
+    untie_biases : bool (default: False)
+        If ``False``, the layer will have a bias parameter for each channel,
+        which is shared across all positions in this channel. As a result, the
+        `b` attribute will be a vector (1D).
+
+        If True, the layer will have separate bias parameters for each
+        position in each channel. As a result, the `b` attribute will be a
+        4D tensor.
+
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a 5D tensor with shape ``(num_filters,
+        num_input_channels, filter_rows, filter_columns, filter_depth)``.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
+        a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
+        ``False``. If it is set to ``True``, its shape should be
+        ``(num_filters, output_rows, output_columns, output_depth)`` instead.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    nonlinearity : callable or None
+        The nonlinearity that is applied to the layer activations. If None
+        is provided, the layer will be linear.
+
+    flip_filters : bool (default: False)
+        Whether to flip the filters and perform a convolution, or not to flip
+        them and perform a correlation. Flipping adds a bit of overhead, so it
+        is disabled by default. In most cases this does not make a difference
+        anyway because the filters are learned, but if you want to compute
+        predictions with pre-trained weights, take care if they need flipping.
+
+    **kwargs
+        Any additional keyword arguments are passed to the `Layer` superclass.
+
+    Attributes
+    ----------
+    W : Theano shared variable or expression
+        Variable or expression representing the filter weights.
+
+    b : Theano shared variable or expression
+        Variable or expression representing the biases.
+    """
+    def __init__(self, incoming, num_filters, filter_size, stride=(1, 1, 1),
+                 pad=0, untie_biases=False, W=init.GlorotUniform(),
+                 b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
+                 flip_filters=False, **kwargs):
+        super(Conv3DDNNLayer, self).__init__(incoming, **kwargs)
+        if nonlinearity is None:
+            self.nonlinearity = nonlinearities.identity
+        else:
+            self.nonlinearity = nonlinearity
+
+        self.num_filters = num_filters
+        self.filter_size = as_tuple(filter_size, 3)
+        self.stride = as_tuple(stride, 3)
+        self.untie_biases = untie_biases
+        self.flip_filters = flip_filters
+
+        if pad == 'valid':
+            self.pad = (0, 0, 0)
+        elif pad == 'full':
+            self.pad = 'full'
+        elif pad == 'same':
+            if any(s % 2 == 0 for s in self.filter_size):
+                raise NotImplementedError(
+                    '`same` padding requires odd filter size.')
+            self.pad = (self.filter_size[0] // 2, self.filter_size[1] // 2,
+                        self.filter_size[1] // 2)
+        else:
+            self.pad = as_tuple(pad, 3, int)
+
+        self.W = self.add_param(W, self.get_W_shape(), name="W")
+        if b is None:
+            self.b = None
+        else:
+            if self.untie_biases:
+                biases_shape = (num_filters, self.output_shape[2],
+                                self.output_shape[3], self.output_shape[4])
+            else:
+                biases_shape = (num_filters,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
+
+    def get_W_shape(self):
+        num_input_channels = self.input_shape[1]
+        return (self.num_filters, num_input_channels, self.filter_size[0],
+                self.filter_size[1], self.filter_size[2])
+
+    def get_output_shape_for(self, input_shape):
+        batch_size = input_shape[0]
+        pad = self.pad if isinstance(self.pad, tuple) else (self.pad,) * 3
+
+        output_rows = conv_output_length(input_shape[2],
+                                         self.filter_size[0],
+                                         self.stride[0],
+                                         pad[0])
+
+        output_columns = conv_output_length(input_shape[3],
+                                            self.filter_size[1],
+                                            self.stride[1],
+                                            pad[1])
+
+        output_depth = conv_output_length(input_shape[4],
+                                          self.filter_size[2],
+                                          self.stride[2],
+                                          pad[2])
+
+        return (batch_size, self.num_filters, output_rows, output_columns,
+                output_depth)
+
+    def get_output_for(self, input, **kwargs):
+        # by default we assume 'cross', consistent with corrmm.
+        conv_mode = 'conv' if self.flip_filters else 'cross'
+
+        conved = dnn.dnn_conv3d(img=input,
+                                kerns=self.W,
+                                subsample=self.stride,
+                                border_mode=self.pad,
+                                conv_mode=conv_mode
+                                )
+
+        if self.b is None:
+            activation = conved
+        elif self.untie_biases:
+            activation = conved + self.b.dimshuffle('x', 0, 1, 2, 3)
+        else:
+            activation = conved + self.b.dimshuffle('x', 0, 'x', 'x', 'x')
         return self.nonlinearity(activation)

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -47,8 +47,18 @@ def convNd(input, kernel, pad, stride=1, n=None):
                 output[:, :,
                        i:i + input.shape[2],
                        j:j + input.shape[3]] += c
+    elif n == 3:
+        for i in range(kernel.shape[2]):
+            for j in range(kernel.shape[3]):
+                for k in range(kernel.shape[4]):
+                    f = kernel[:, :, i:i+1, j:j+1, k:k+1]
+                    c = (input[:, np.newaxis] * f).sum(axis=2)
+                    output[:, :,
+                           i:i + input.shape[2],
+                           j:j + input.shape[3],
+                           k:k + input.shape[4]] += c
     else:
-        raise NotImplementedError("convNd() only supports n in (1, 2)")
+        raise NotImplementedError("convNd() only supports n in (1, 2, 3)")
 
     if pad == 'valid':
         trim = tuple(k - 1 for k in kernel.shape[2:])
@@ -74,7 +84,7 @@ def convNd_test_sets(n, pads=(0,)):
     def _convert(input, kernel, output, kwargs):
         return [theano.shared(floatX(input)), floatX(kernel), output, kwargs]
 
-    extra_shape = (16, 23)
+    extra_shape = (11, 16, 23)
     input_shape = (3, 1) + extra_shape[-n:]
 
     for pad in pads + ('full', 'same'):
@@ -98,6 +108,8 @@ def convNd_test_sets(n, pads=(0,)):
     yield _convert(input, kernel, output, {'pad': 'valid'})
 
 
+def conv3d_test_sets():
+    return convNd_test_sets(3)
 
 
 def conv2d_test_sets():
@@ -272,7 +284,7 @@ class TestConv2DLayerImplementations:
         assert layer.b is None
 
     def test_invalid_pad(self, Conv2DImpl, DummyInputLayer):
-        input_layer = DummyInputLayer((1, 2, 3))
+        input_layer = DummyInputLayer((1, 2, 3, 3))
         with pytest.raises(TypeError) as exc:
             layer = Conv2DImpl(input_layer, num_filters=16, filter_size=(3, 3),
                                pad='_nonexistent_mode')
@@ -286,6 +298,117 @@ class TestConv2DLayerImplementations:
     def test_get_params(self, Conv2DImpl, DummyInputLayer):
         input_layer = DummyInputLayer((128, 3, 32, 32))
         layer = Conv2DImpl(input_layer, num_filters=16, filter_size=(3, 3))
+        assert layer.get_params() == [layer.W, layer.b]
+        assert layer.get_params(regularizable=False) == [layer.b]
+        assert layer.get_params(regularizable=True) == [layer.W]
+        assert layer.get_params(trainable=True) == [layer.W, layer.b]
+        assert layer.get_params(trainable=False) == []
+        assert layer.get_params(_nonexistent_tag=True) == []
+        assert layer.get_params(_nonexistent_tag=False) == [layer.W, layer.b]
+
+
+class TestConv3DLayerImplementations:
+
+    @pytest.fixture(
+        params=[
+            ('lasagne.layers.dnn', 'Conv3DDNNLayer', {'flip_filters': True}),
+        ],
+    )
+    def Conv3DImpl(self, request):
+        impl_module_name, impl_name, impl_default_kwargs = request.param
+        try:
+            mod = importlib.import_module(impl_module_name)
+        except ImportError:
+            pytest.skip("{} not available".format(impl_module_name))
+
+        impl = getattr(mod, impl_name)
+
+        def wrapper(*args, **kwargs):
+            kwargs2 = impl_default_kwargs.copy()
+            kwargs2.update(kwargs)
+            return impl(*args, **kwargs2)
+
+        wrapper.__name__ = impl_name
+        return wrapper
+
+    @pytest.mark.parametrize(
+        "input, kernel, output, kwargs", list(conv3d_test_sets()))
+    @pytest.mark.parametrize("extra_kwargs", [
+        {},
+        {'untie_biases': True},
+    ])
+    def test_defaults(self, Conv3DImpl, DummyInputLayer,
+                      input, kernel, output, kwargs, extra_kwargs):
+        kwargs.update(extra_kwargs)
+        b, c, h, w, d = input.shape.eval()
+        input_layer = DummyInputLayer((b, c, h, w, d))
+        try:
+            layer = Conv3DImpl(
+                input_layer,
+                num_filters=kernel.shape[0],
+                filter_size=kernel.shape[2:],
+                W=kernel,
+                **kwargs
+            )
+            actual = layer.get_output_for(input).eval()
+            assert actual.shape == output.shape
+            assert actual.shape == layer.output_shape
+            assert np.allclose(actual, output)
+
+        except NotImplementedError:
+            pytest.skip()
+
+    @pytest.mark.parametrize(
+        "input, kernel, output, kwargs", list(conv3d_test_sets()))
+    def test_with_nones(self, Conv3DImpl, DummyInputLayer,
+                        input, kernel, output, kwargs):
+        b, c, h, w, d = input.shape.eval()
+        input_layer = DummyInputLayer((None, c, None, None, None))
+        try:
+            layer = Conv3DImpl(
+                input_layer,
+                num_filters=kernel.shape[0],
+                filter_size=kernel.shape[2:],
+                W=kernel,
+                **kwargs
+            )
+            actual = layer.get_output_for(input).eval()
+
+            assert layer.output_shape == (None,
+                                          kernel.shape[0],
+                                          None,
+                                          None,
+                                          None)
+            assert actual.shape == output.shape
+            assert np.allclose(actual, output)
+
+        except NotImplementedError:
+            pytest.skip()
+
+    def test_init_none_nonlinearity_bias(self, Conv3DImpl, DummyInputLayer):
+        input_layer = DummyInputLayer((1, 2, 3, 3, 3))
+        layer = Conv3DImpl(input_layer, num_filters=16, filter_size=(3, 3, 3),
+                           nonlinearity=None, b=None)
+        assert layer.nonlinearity == lasagne.nonlinearities.identity
+        assert layer.b is None
+
+    def test_invalid_pad(self, Conv3DImpl, DummyInputLayer):
+        input_layer = DummyInputLayer((1, 2, 3, 3, 3))
+        with pytest.raises(TypeError) as exc:
+            layer = Conv3DImpl(input_layer, num_filters=16,
+                               filter_size=(3, 3, 3),
+                               pad='_nonexistent_mode')
+        assert "iterable of int" in exc.value.args[0]
+
+        with pytest.raises(NotImplementedError) as exc:
+            layer = Conv3DImpl(input_layer, num_filters=16,
+                               filter_size=(4, 4, 4),
+                               pad='same')
+        assert "requires odd filter size" in exc.value.args[0]
+
+    def test_get_params(self, Conv3DImpl, DummyInputLayer):
+        input_layer = DummyInputLayer((128, 3, 32, 32, 32))
+        layer = Conv3DImpl(input_layer, num_filters=16, filter_size=(3, 3, 3))
         assert layer.get_params() == [layer.W, layer.b]
         assert layer.get_params(regularizable=False) == [layer.b]
         assert layer.get_params(regularizable=True) == [layer.W]


### PR DESCRIPTION
This adds a `Conv3DDNNLayer` class for cuDNN-based 3D convolution. It also refactors the convolution tests to reduce some of the code duplication in setting up the test cases (there's still a lot of duplication, but that's harder to tackle).

In a follow-up PR, I'd like to refactor all convolutional layers (all dimensionalities and all implementations) to be derived from a common `BaseConvLayer` that contains most of the code. This will make it much easier to add additional checks such as matching input and convolution dimensionality.