### PR TITLE
fix adadelta docs for moving average of update

### DIFF
--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -498,7 +498,7 @@ def adadelta(loss_or_grads, params, learning_rate=1.0, rho=0.95, epsilon=1e-6):
        r_t &= \\rho r_{t-1} + (1-\\rho)*g^2\\\\
        \\eta_t &= \\eta \\frac{\\sqrt{s_{t-1} + \\epsilon}}
                              {\sqrt{r_t + \epsilon}}\\\\
-       s_t &= \\rho s_{t-1} + (1-\\rho)*g^2
+       s_t &= \\rho s_{t-1} + (1-\\rho)*(\\eta_t*g)^2
 
     References
     ----------


### PR DESCRIPTION
There appeared to be a minor error. Before the change, the equations for r_t and s_t were identical.