### PR TITLE
Allow PadLayer to accept None dimensions

### DIFF
--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -322,11 +322,14 @@ class PadLayer(Layer):
             widths = self.width
 
         for k, w in enumerate(widths):
-            try:
-                l, r = w
-            except TypeError:
-                l = r = w
-            output_shape[k + self.batch_ndim] += l + r
+            if output_shape[k + self.batch_ndim] is None:
+                continue
+            else:
+                try:
+                    l, r = w
+                except TypeError:
+                    l = r = w
+                output_shape[k + self.batch_ndim] += l + r
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):

--- a/lasagne/tests/layers/test_shape.py
+++ b/lasagne/tests/layers/test_shape.py
@@ -67,6 +67,9 @@ class TestPadLayer:
         [(3, (2, 3, 4, 5), (2, 3, 10, 11)),
          ((2, 3), (2, 3, 4, 5), (2, 3, 8, 11)),
          (((1, 2), (3, 4)), (2, 3, 4, 5), (2, 3, 7, 12)),
+         (3, (2, 3, None, 5), (2, 3, None, 11)),
+         ((2, 3), (2, 3, 4, None), (2, 3, 8, None)),
+         (((1, 2), (3, 4)), (None, 3, None, None), (None, 3, None, None)),
          ])
     def test_get_output_shape_for(self, layerclass,
                                   width, input_shape, output_shape):


### PR DESCRIPTION
This makes it so that the `PadLayer` can accept shapes with `None` in them past their "batch" dimension, e.g.

```Python
import numpy as np
import lasagne

input_shape = (None, 3, None, 40)
dummy_input = np.random.standard_normal((100, 3, 30, 40)).astype(theano.config.floatX)

l_in = lasagne.layers.InputLayer(input_shape)
l_pad = lasagne.layers.PadLayer(l_in, width=4)
l_conv = lasagne.layers.Conv2DLayer(l_pad, 16, (3, 3))
print lasagne.layers.get_output(l_conv).eval({l_in.input_var: dummy_input}).shape
```

Without this change, this would result in 
```Python
lasagne/layers/shape.py in get_output_shape_for(self, input_shape)
    327             except TypeError:
    328                 l = r = w
--> 329             output_shape[k + self.batch_ndim] += l + r
    330         return tuple(output_shape)
    331 

TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'
```

After this change, it results in `(100, 16, 36, 46)`.