### PR TITLE
Add collect_shared_vars() to Sphinx docs

### DIFF
--- a/docs/modules/utils.rst
+++ b/docs/modules/utils.rst
@@ -6,6 +6,7 @@
 .. autofunction:: floatX
 .. autofunction:: shared_empty
 .. autofunction:: as_theano_expression
+.. autofunction:: collect_shared_vars
 .. autofunction:: one_hot
 .. autofunction:: unique
 .. autofunction:: compute_norms


### PR DESCRIPTION
Noticed they were missing. My bad (#404)!