### PR TITLE
add negative shape check to inputLayer

### DIFF
--- a/lasagne/layers/input.py
+++ b/lasagne/layers/input.py
@@ -49,6 +49,12 @@ class InputLayer(Layer):
     """
     def __init__(self, shape, input_var=None, name=None, **kwargs):
         self.shape = shape
+        if any(d is not None and d <= 0 for d in self.shape):
+            raise ValueError((
+                "Cannot create InputLayer with a non-positive shape "
+                "dimension. shape=%r, self.name=%r") % (
+                    self.shape, name))
+
         ndim = len(shape)
         if input_var is None:
             # create the right TensorType for the given number of dimensions

--- a/lasagne/tests/layers/test_input.py
+++ b/lasagne/tests/layers/test_input.py
@@ -31,3 +31,11 @@ class TestInputLayer:
 
         with pytest.raises(ValueError):
             InputLayer((3, 2), input_var)
+
+    def test_nonpositive_input_dims_raises_value_error(self):
+        from lasagne.layers import InputLayer
+        with pytest.raises(ValueError):
+            InputLayer(shape=(None, -1, -1))
+        with pytest.raises(ValueError):
+            InputLayer(shape=(None, 0, 0))
+        InputLayer(shape=(None, 1, 1))


### PR DESCRIPTION
Fix https://github.com/Lasagne/Lasagne/issues/457

Add test for negative shape in input Layer. 
The `str(name)` is a bit ugly but the inputLayer might have a `None` name as far as i read the code? 