### PR TITLE
Adamax updates

### DIFF
--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -32,6 +32,9 @@ class TestUpdateFunctions(object):
                     'adam': [0.90034972009036,
                              0.90034967993061,
                              0.90034966654402],
+                    'adamax': [0.90211749000754,
+                               0.90211748762402,
+                               0.90211748682951],
                     }
 
     def f(self, X):
@@ -45,6 +48,7 @@ class TestUpdateFunctions(object):
         ['rmsprop', {'learning_rate': 0.01}],
         ['adadelta', {}],
         ['adam', {'learning_rate': 0.01}],
+        ['adamax', {'learning_rate': 0.01}],
         ])
     def test_updates(self, method, kwargs):
         A = theano.shared(lasagne.utils.floatX([1, 1, 1]))


### PR DESCRIPTION
This is an implementation of Adamax, a variant of Adam described in the latest version of the paper ( http://arxiv.org/abs/1412.6980 ) which uses the inifinity norm instead of the L2 norm. This is argued to be more stable in the case of sparse updates (e.g. for embeddings).

I have not included tests yet since I noticed that the existing updates implementations are all tested against a Torch implementation. @ebenolson, I believe you set this up, so it would be great if you could chime in :) We may want to include a separate set of tests that do not depend on Torch, so that it's easier to add new update rules.