### PR TITLE
Revamp Convolutional Layers

### DIFF
--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -13,7 +13,7 @@ http://lasagne.readthedocs.org/en/latest/user/installation.html#theano"""
 except ImportError:  # pragma: no cover
     raise ImportError("Could not import Theano." + install_instr)
 else:
-    if not hasattr(theano.tensor.nnet, 'h_softmax'):  # pragma: no cover
+    if not hasattr(theano.tensor.nnet, 'abstract_conv'):  # pragma: no cover
         raise ImportError("Your Theano version is too old." + install_instr)
     del install_instr
     del theano

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -80,7 +80,202 @@ def conv_output_length(input_length, filter_size, stride, pad=0):
     return output_length
 
 
-class Conv1DLayer(Layer):
+class BaseConvLayer(Layer):
+    """
+    lasagne.layers.BaseConvLayer(incoming, num_filters, filter_size,
+    stride=1, pad=0, untie_biases=False,
+    W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
+    nonlinearity=lasagne.nonlinearities.rectify,
+    n=None, **kwargs)
+
+    Convolutional layer base class
+
+    Base class for performing an `n`-dimensional convolution on its input,
+    optionally adding a bias and applying an elementwise nonlinearity. Note
+    that this class cannot be used in a Lasagne network, only its subclasses
+    can (e.g., :class:`Conv1DLayer`, :class:`Conv2DLayer`).
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape. Must
+        be a tensor of 2+`n` dimensions:
+        ``(batch_size, num_input_channels, <n spatial dimensions>)``.
+
+    num_filters : int
+        The number of learnable convolutional filters this layer has.
+
+    filter_size : int or iterable of int
+        An integer or an `n`-element tuple specifying the size of the filters.
+
+    stride : int or iterable of int
+        An integer or an `n`-element tuple specifying the stride of the
+        convolution operation.
+
+    pad : int, iterable of int, 'full', 'same' or 'valid' (default: 0)
+        By default, the convolution is only computed where the input and the
+        filter fully overlap (a valid convolution). When ``stride=1``, this
+        yields an output that is smaller than the input by ``filter_size - 1``.
+        The `pad` argument allows you to implicitly pad the input with zeros,
+        extending the output size.
+
+        A single integer results in symmetric zero-padding of the given size on
+        all borders, a tuple of `n` integers allows different symmetric padding
+        per dimension.
+
+        ``'full'`` pads with one less than the filter size on both sides. This
+        is equivalent to computing the convolution wherever the input and the
+        filter overlap by at least one position.
+
+        ``'same'`` pads with half the filter size (rounded down) on both sides.
+        When ``stride=1`` this results in an output size equal to the input
+        size. Even filter size is not supported.
+
+        ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
+
+        Note that ``'full'`` and ``'same'`` can be faster than equivalent
+        integer values due to optimizations by Theano.
+
+    untie_biases : bool (default: False)
+        If ``False``, the layer will have a bias parameter for each channel,
+        which is shared across all positions in this channel. As a result, the
+        `b` attribute will be a vector (1D).
+
+        If ``True``, the layer will have separate bias parameters for each
+        position in each channel. As a result, the `b` attribute will be an
+        `n`-dimensional tensor.
+
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a tensor of 2+`n` dimensions with shape
+        ``(num_filters, num_input_channels, <n spatial dimensions>)``.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
+        a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
+        ``False``. If it is set to ``True``, its shape should be
+        ``(num_filters, <n spatial dimensions>)`` instead.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    nonlinearity : callable or None
+        The nonlinearity that is applied to the layer activations. If None
+        is provided, the layer will be linear.
+
+    n : int or None
+        The dimensionality of the convolution (i.e., the number of spatial
+        dimensions of each feature map and each convolutional filter). If
+        ``None``, will be inferred from the input shape.
+
+    **kwargs
+        Any additional keyword arguments are passed to the `Layer` superclass.
+
+    Attributes
+    ----------
+    W : Theano shared variable or expression
+        Variable or expression representing the filter weights.
+
+    b : Theano shared variable or expression
+        Variable or expression representing the biases.
+    """
+    def __init__(self, incoming, num_filters, filter_size, stride=1, pad=0,
+                 untie_biases=False,
+                 W=init.GlorotUniform(), b=init.Constant(0.),
+                 nonlinearity=nonlinearities.rectify,
+                 n=None, **kwargs):
+        super(BaseConvLayer, self).__init__(incoming, **kwargs)
+        if nonlinearity is None:
+            self.nonlinearity = nonlinearities.identity
+        else:
+            self.nonlinearity = nonlinearity
+
+        if n is None:
+            n = len(self.input_shape) - 2
+        self.n = n
+        self.num_filters = num_filters
+        self.filter_size = as_tuple(filter_size, n, int)
+        self.stride = as_tuple(stride, n, int)
+        self.untie_biases = untie_biases
+
+        if pad == 'same':
+            if any(s % 2 == 0 for s in self.filter_size):
+                raise NotImplementedError(
+                    '`same` padding requires odd filter size.')
+        if pad == 'valid':
+            self.pad = as_tuple(0, n)
+        elif pad in ('full', 'same'):
+            self.pad = pad
+        else:
+            self.pad = as_tuple(pad, n, int)
+
+        self.W = self.add_param(W, self.get_W_shape(), name="W")
+        if b is None:
+            self.b = None
+        else:
+            if self.untie_biases:
+                biases_shape = (num_filters,) + self.output_shape[2:]
+            else:
+                biases_shape = (num_filters,)
+            self.b = self.add_param(b, biases_shape, name="b",
+                                    regularizable=False)
+
+    def get_W_shape(self):
+        """Get the shape of the weight matrix `W`.
+
+        Returns
+        -------
+        tuple of int
+            The shape of the weight matrix.
+        """
+        num_input_channels = self.input_shape[1]
+        return (self.num_filters, num_input_channels) + self.filter_size
+
+    def get_output_shape_for(self, input_shape):
+        pad = self.pad if isinstance(self.pad, tuple) else (self.pad,) * self.n
+        batchsize = input_shape[0]
+        return ((batchsize, self.num_filters) +
+                tuple(conv_output_length(input, filter, stride, p)
+                      for input, filter, stride, p
+                      in zip(input_shape[2:], self.filter_size,
+                             self.stride, pad)))
+
+    def get_output_for(self, input, **kwargs):
+        conved = self.convolve(input, **kwargs)
+
+        if self.b is None:
+            activation = conved
+        elif self.untie_biases:
+            activation = conved + T.shape_padleft(self.b, 1)
+        else:
+            activation = conved + self.b.dimshuffle(('x', 0) + ('x',) * self.n)
+
+        return self.nonlinearity(activation)
+
+    def convolve(self, input, **kwargs):
+        """
+        Symbolically convolves `input` with ``self.W``, producing an output of
+        shape ``self.output_shape``. To be implemented by subclasses.
+
+        Parameters
+        ----------
+        input : Theano tensor
+            The input minibatch to convolve
+        **kwargs
+            Any additional keyword arguments from :meth:`get_output_for`
+
+        Returns
+        -------
+        Theano tensor
+            `input` convolved according to the configuration of this layer,
+            without any bias or nonlinearity applied.
+        """
+        raise NotImplementedError("BaseConvLayer does not implement the "
+                                  "convolve() method. You will want to "
+                                  "use a subclass such as Conv2DLayer.")
+
+
+class Conv1DLayer(BaseConvLayer):
     """
     lasagne.layers.Conv1DLayer(incoming, num_filters, filter_size, stride=1,
     pad=0, untie_biases=False, W=lasagne.init.GlorotUniform(),
@@ -185,72 +380,16 @@ class Conv1DLayer(Layer):
                  W=init.GlorotUniform(), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify,
                  convolution=conv.conv1d_mc0, **kwargs):
-        super(Conv1DLayer, self).__init__(incoming, **kwargs)
-        if nonlinearity is None:
-            self.nonlinearity = nonlinearities.identity
-        else:
-            self.nonlinearity = nonlinearity
-
-        self.num_filters = num_filters
-        self.filter_size = as_tuple(filter_size, 1)
-        self.stride = as_tuple(stride, 1)
-        self.untie_biases = untie_biases
+        super(Conv1DLayer, self).__init__(incoming, num_filters, filter_size,
+                                          stride, pad, untie_biases, W, b,
+                                          nonlinearity, n=1, **kwargs)
         self.convolution = convolution
 
-        if pad == 'same':
-            if self.filter_size[0] % 2 == 0:
-                raise NotImplementedError(
-                    '`same` padding requires odd filter size.')
-
-        if pad == 'valid':
-            self.pad = (0,)
-        elif pad in ('full', 'same'):
-            self.pad = pad
-        else:
-            self.pad = as_tuple(pad, 1, int)
-
-        self.W = self.add_param(W, self.get_W_shape(), name="W")
-        if b is None:
-            self.b = None
-        else:
-            if self.untie_biases:
-                biases_shape = (num_filters, self.output_shape[2])
-            else:
-                biases_shape = (num_filters,)
-            self.b = self.add_param(b, biases_shape, name="b",
-                                    regularizable=False)
-
-    def get_W_shape(self):
-        """Get the shape of the weight matrix `W`.
-
-        Returns
-        -------
-        tuple of int
-            The shape of the weight matrix.
-        """
-        num_input_channels = self.input_shape[1]
-        return (self.num_filters, num_input_channels, self.filter_size[0])
-
-    def get_output_shape_for(self, input_shape):
-        pad = self.pad if isinstance(self.pad, tuple) else (self.pad,)
-
-        output_length = conv_output_length(input_shape[2],
-                                           self.filter_size[0],
-                                           self.stride[0],
-                                           pad[0])
-
-        return (input_shape[0], self.num_filters, output_length)
-
-    def get_output_for(self, input, input_shape=None, **kwargs):
-        # the optional input_shape argument is for when get_output_for is
-        # called directly with a different shape than self.input_shape.
-        if input_shape is None:
-            input_shape = self.input_shape
-
+    def convolve(self, input, **kwargs):
         if self.stride == (1,) and self.pad == 'same':
             # simulate same convolution by cropping a full convolution
             conved = self.convolution(input, self.W, subsample=self.stride,
-                                      image_shape=input_shape,
+                                      image_shape=self.input_shape,
                                       filter_shape=self.get_W_shape(),
                                       border_mode='full')
             crop = self.filter_size[0] // 2
@@ -268,25 +407,19 @@ class Conv1DLayer(Layer):
                 pad = (self.pad[0], self.pad[0])
             if pad != (0, 0):
                 input = padding.pad(input, [pad], batch_ndim=2)
-                input_shape = (input_shape[0], input_shape[1],
-                               None if input_shape[2] is None else
-                               input_shape[2] + pad[0] + pad[1])
+                input_shape = (self.input_shape[0], self.input_shape[1],
+                               None if self.input_shape[2] is None else
+                               self.input_shape[2] + pad[0] + pad[1])
+            else:
+                input_shape = self.input_shape
             conved = self.convolution(input, self.W, subsample=self.stride,
                                       image_shape=input_shape,
                                       filter_shape=self.get_W_shape(),
                                       border_mode=border_mode)
-
-        if self.b is None:
-            activation = conved
-        elif self.untie_biases:
-            activation = conved + self.b.dimshuffle('x', 0, 1)
-        else:
-            activation = conved + self.b.dimshuffle('x', 0, 'x')
-
-        return self.nonlinearity(activation)
+        return conved
 
 
-class Conv2DLayer(Layer):
+class Conv2DLayer(BaseConvLayer):
     """
     lasagne.layers.Conv2DLayer(incoming, num_filters, filter_size,
     stride=(1, 1), pad=0, untie_biases=False,
@@ -393,79 +526,16 @@ class Conv2DLayer(Layer):
                  W=init.GlorotUniform(), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify,
                  convolution=T.nnet.conv2d, **kwargs):
-        super(Conv2DLayer, self).__init__(incoming, **kwargs)
-        if nonlinearity is None:
-            self.nonlinearity = nonlinearities.identity
-        else:
-            self.nonlinearity = nonlinearity
-
-        self.num_filters = num_filters
-        self.filter_size = as_tuple(filter_size, 2)
-        self.stride = as_tuple(stride, 2)
-        self.untie_biases = untie_biases
+        super(Conv2DLayer, self).__init__(incoming, num_filters, filter_size,
+                                          stride, pad, untie_biases, W, b,
+                                          nonlinearity, n=2, **kwargs)
         self.convolution = convolution
 
-        if pad == 'same':
-            if any(s % 2 == 0 for s in self.filter_size):
-                raise NotImplementedError(
-                    '`same` padding requires odd filter size.')
-
-        if pad == 'valid':
-            self.pad = (0, 0)
-        elif pad in ('full', 'same'):
-            self.pad = pad
-        else:
-            self.pad = as_tuple(pad, 2, int)
-
-        self.W = self.add_param(W, self.get_W_shape(), name="W")
-        if b is None:
-            self.b = None
-        else:
-            if self.untie_biases:
-                biases_shape = (num_filters, self.output_shape[2], self.
-                                output_shape[3])
-            else:
-                biases_shape = (num_filters,)
-            self.b = self.add_param(b, biases_shape, name="b",
-                                    regularizable=False)
-
-    def get_W_shape(self):
-        """Get the shape of the weight matrix `W`.
-
-        Returns
-        -------
-        tuple of int
-            The shape of the weight matrix.
-        """
-        num_input_channels = self.input_shape[1]
-        return (self.num_filters, num_input_channels, self.filter_size[0],
-                self.filter_size[1])
-
-    def get_output_shape_for(self, input_shape):
-        pad = self.pad if isinstance(self.pad, tuple) else (self.pad,) * 2
-
-        output_rows = conv_output_length(input_shape[2],
-                                         self.filter_size[0],
-                                         self.stride[0],
-                                         pad[0])
-
-        output_columns = conv_output_length(input_shape[3],
-                                            self.filter_size[1],
-                                            self.stride[1],
-                                            pad[1])
-
-        return (input_shape[0], self.num_filters, output_rows, output_columns)
-
-    def get_output_for(self, input, input_shape=None, **kwargs):
-        # The optional input_shape argument is for when get_output_for is
-        # called directly with a different shape than self.input_shape.
-        if input_shape is None:
-            input_shape = self.input_shape
-
+    def convolve(self, input, **kwargs):
         if self.stride == (1, 1) and self.pad == 'same':
             # simulate same convolution by cropping a full convolution
             conved = self.convolution(input, self.W, subsample=self.stride,
-                                      image_shape=input_shape,
+                                      image_shape=self.input_shape,
                                       filter_shape=self.get_W_shape(),
                                       border_mode='full')
             crop_x = self.filter_size[0] // 2
@@ -488,23 +558,17 @@ class Conv2DLayer(Layer):
                 pad = [(self.pad[0], self.pad[0]), (self.pad[1], self.pad[1])]
             if pad != [(0, 0), (0, 0)]:
                 input = padding.pad(input, pad, batch_ndim=2)
-                input_shape = (input_shape[0], input_shape[1],
-                               None if input_shape[2] is None else
-                               input_shape[2] + pad[0][0] + pad[0][1],
-                               None if input_shape[3] is None else
-                               input_shape[3] + pad[1][0] + pad[1][1])
+                input_shape = (self.input_shape[0], self.input_shape[1],
+                               None if self.input_shape[2] is None else
+                               self.input_shape[2] + pad[0][0] + pad[0][1],
+                               None if self.input_shape[3] is None else
+                               self.input_shape[3] + pad[1][0] + pad[1][1])
+            else:
+                input_shape = self.input_shape
             conved = self.convolution(input, self.W, subsample=self.stride,
                                       image_shape=input_shape,
                                       filter_shape=self.get_W_shape(),
                                       border_mode=border_mode)
-
-        if self.b is None:
-            activation = conved
-        elif self.untie_biases:
-            activation = conved + self.b.dimshuffle('x', 0, 1, 2)
-        else:
-            activation = conved + self.b.dimshuffle('x', 0, 'x', 'x')
-
-        return self.nonlinearity(activation)
+        return conved
 
 # TODO: add Conv3DLayer

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -192,6 +192,11 @@ class BaseConvLayer(Layer):
 
         if n is None:
             n = len(self.input_shape) - 2
+        elif n != len(self.input_shape) - 2:
+            raise ValueError("Tried to create a %dD convolution layer with "
+                             "input shape %r. Expected %d input dimensions "
+                             "(batchsize, channels, %d spatial dimensions)." %
+                             (n, self.input_shape, n+2, n))
         self.n = n
         self.num_filters = num_filters
         self.filter_size = as_tuple(filter_size, n, int)

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -121,12 +121,6 @@ class Conv2DMMLayer(BaseConvLayer):
 
     b : Theano shared variable
         Variable representing the biases.
-
-    Notes
-    -----
-    Unlike :class:`lasagne.layers.Conv2DLayer`, this layer properly supports
-    ``pad='same'``. It is not emulated. This should result in better
-    performance.
     """
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
                  pad=0, untie_biases=False, W=init.GlorotUniform(),
@@ -134,8 +128,8 @@ class Conv2DMMLayer(BaseConvLayer):
                  flip_filters=False, **kwargs):
         super(Conv2DMMLayer, self).__init__(incoming, num_filters, filter_size,
                                             stride, pad, untie_biases, W, b,
-                                            nonlinearity, n=2, **kwargs)
-        self.flip_filters = flip_filters
+                                            nonlinearity, flip_filters, n=2,
+                                            **kwargs)
         border_mode = 'half' if self.pad == 'same' else self.pad
         self.corr_mm_op = GpuCorrMM(subsample=self.stride,
                                     border_mode=border_mode)

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -5,7 +5,7 @@ from .. import nonlinearities
 
 from .base import Layer
 
-from .conv import conv_output_length
+from .conv import conv_output_length, BaseConvLayer
 from ..utils import as_tuple
 
 from theano.sandbox.cuda.basic_ops import gpu_contiguous
@@ -13,7 +13,6 @@ from theano.sandbox.cuda.blas import GpuCorrMM
 
 
 __all__ = [
-    "MMLayer",
     "Conv2DMMLayer",
 ]
 
@@ -22,12 +21,7 @@ if not theano.config.device.startswith("gpu"):
     raise ImportError("requires a GPU to work")  # pragma: no cover
 
 
-# base class for all layers that rely on GpuCorrMM directly
-class MMLayer(Layer):
-    pass
-
-
-class Conv2DMMLayer(MMLayer):
+class Conv2DMMLayer(BaseConvLayer):
     """
     lasagne.layers.Conv2DMMLayer(incoming, num_filters, filter_size,
     stride=(1, 1), pad=0, untie_biases=False,
@@ -138,67 +132,15 @@ class Conv2DMMLayer(MMLayer):
                  pad=0, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  flip_filters=False, **kwargs):
-        super(Conv2DMMLayer, self).__init__(incoming, **kwargs)
-        if nonlinearity is None:
-            self.nonlinearity = nonlinearities.identity
-        else:
-            self.nonlinearity = nonlinearity
-
-        self.num_filters = num_filters
-        self.filter_size = as_tuple(filter_size, 2)
-        self.stride = as_tuple(stride, 2)
-        self.untie_biases = untie_biases
+        super(Conv2DMMLayer, self).__init__(incoming, num_filters, filter_size,
+                                            stride, pad, untie_biases, W, b,
+                                            nonlinearity, n=2, **kwargs)
         self.flip_filters = flip_filters
-
-        if pad == 'valid':
-            self.pad = (0, 0)
-        elif pad == 'full':
-            self.pad = (self.filter_size[0] - 1, self.filter_size[1] - 1)
-        elif pad == 'same':
-            if any(s % 2 == 0 for s in self.filter_size):
-                raise NotImplementedError(
-                    '`same` padding requires odd filter size.')
-            self.pad = (self.filter_size[0] // 2, self.filter_size[1] // 2)
-        else:
-            self.pad = as_tuple(pad, 2, int)
-
-        self.W = self.add_param(W, self.get_W_shape(), name="W")
-        if b is None:
-            self.b = None
-        else:
-            if self.untie_biases:
-                biases_shape = (num_filters, self.output_shape[2],
-                                self.output_shape[3])
-            else:
-                biases_shape = (num_filters,)
-            self.b = self.add_param(b, biases_shape, name="b",
-                                    regularizable=False)
-
+        border_mode = 'half' if self.pad == 'same' else self.pad
         self.corr_mm_op = GpuCorrMM(subsample=self.stride,
-                                    border_mode=self.pad)
+                                    border_mode=border_mode)
 
-    def get_W_shape(self):
-        num_input_channels = self.input_shape[1]
-        return (self.num_filters, num_input_channels, self.filter_size[0],
-                self.filter_size[1])
-
-    def get_output_shape_for(self, input_shape):
-        batch_size = input_shape[0]
-        pad = self.pad if isinstance(self.pad, tuple) else (self.pad,) * 2
-
-        output_rows = conv_output_length(input_shape[2],
-                                         self.filter_size[0],
-                                         self.stride[0],
-                                         pad[0])
-
-        output_columns = conv_output_length(input_shape[3],
-                                            self.filter_size[1],
-                                            self.stride[1],
-                                            pad[1])
-
-        return (batch_size, self.num_filters, output_rows, output_columns)
-
-    def get_output_for(self, input, **kwargs):
+    def convolve(self, input, **kwargs):
         filters = self.W
         if self.flip_filters:
             filters = filters[:, :, ::-1, ::-1]  # flip top-down, left-right
@@ -206,12 +148,4 @@ class Conv2DMMLayer(MMLayer):
         contiguous_filters = gpu_contiguous(filters)
         contiguous_input = gpu_contiguous(input)
         conved = self.corr_mm_op(contiguous_input, contiguous_filters)
-
-        if self.b is None:
-            activation = conved
-        elif self.untie_biases:
-            activation = conved + self.b.dimshuffle('x', 0, 1, 2)
-        else:
-            activation = conved + self.b.dimshuffle('x', 0, 'x', 'x')
-
-        return self.nonlinearity(activation)
+        return conved

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -167,10 +167,6 @@ class Conv2DCCLayer(BaseConvLayer):
 
     Notes
     -----
-    Unlike :class:`lasagne.layers.Conv2DLayer`, this layer properly supports
-    ``pad='same'``. It is not emulated. This should result in better
-    performance.
-
     The cuda-convnet convolution implementation has several limitations:
 
     * only square filters are supported.
@@ -211,8 +207,8 @@ class Conv2DCCLayer(BaseConvLayer):
 
         super(Conv2DCCLayer, self).__init__(incoming, num_filters, filter_size,
                                             stride, pad, untie_biases, W, b,
-                                            nonlinearity, n=2, **kwargs)
-        self.flip_filters = flip_filters
+                                            nonlinearity, flip_filters, n=2,
+                                            **kwargs)
         self.partial_sum = partial_sum
 
         if self.filter_size[0] != self.filter_size[1]:

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -7,7 +7,7 @@ from .. import nonlinearities
 
 from .base import Layer
 
-from .conv import conv_output_length
+from .conv import conv_output_length, BaseConvLayer
 from .pool import pool_output_length
 from ..utils import as_tuple
 
@@ -15,7 +15,6 @@ from theano.sandbox.cuda.basic_ops import gpu_contiguous
 from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs
 
 __all__ = [
-    "CCLayer",
     "Conv2DCCLayer",
     "MaxPool2DCCLayer",
     "ShuffleBC01ToC01BLayer",
@@ -30,12 +29,7 @@ if not theano.config.device.startswith("gpu"):
     raise ImportError("requires a GPU to work")  # pragma: no cover
 
 
-# base class for all layers that use ops from pylearn2.sandbox.cuda_convnet
-class CCLayer(Layer):
-    pass
-
-
-class Conv2DCCLayer(CCLayer):
+class Conv2DCCLayer(BaseConvLayer):
     """
     lasagne.layers.Conv2DCCLayer(incoming, num_filters, filter_size,
     stride=(1, 1), pad=0, untie_biases=False, W=None,
@@ -208,35 +202,31 @@ class Conv2DCCLayer(CCLayer):
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  dimshuffle=True, flip_filters=False, partial_sum=1,
                  **kwargs):
-        super(Conv2DCCLayer, self).__init__(incoming, **kwargs)
-        if nonlinearity is None:
-            self.nonlinearity = nonlinearities.identity
-        else:
-            self.nonlinearity = nonlinearity
+        if W is None:
+            if dimshuffle:
+                W = init.GlorotUniform()
+            else:
+                W = init.GlorotUniform(c01b=True)
+        self.dimshuffle = dimshuffle
 
-        filter_size = as_tuple(filter_size, 2)
-        stride = as_tuple(stride, 2)
+        super(Conv2DCCLayer, self).__init__(incoming, num_filters, filter_size,
+                                            stride, pad, untie_biases, W, b,
+                                            nonlinearity, n=2, **kwargs)
+        self.flip_filters = flip_filters
+        self.partial_sum = partial_sum
 
-        if filter_size[0] != filter_size[1]:
+        if self.filter_size[0] != self.filter_size[1]:
             raise RuntimeError("Conv2DCCLayer only supports square filters, "
                                "but filter_size=(%d, %d)" % filter_size)
 
-        if stride[0] != stride[1]:
+        if self.stride[0] != self.stride[1]:
             raise RuntimeError("Conv2DCCLayer only supports square strides, "
                                "but stride=(%d, %d)" % stride)
 
-        if num_filters % 16 != 0:
+        if self.num_filters % 16 != 0:
             raise RuntimeError("Conv2DCCLayer requires num_filters to be a "
                                "multiple of 16, but num_filters is "
                                "%d" % num_filters)
-
-        self.num_filters = num_filters
-        self.filter_size = filter_size[0]
-        self.stride = stride[0]
-        self.untie_biases = untie_biases
-        self.dimshuffle = dimshuffle
-        self.flip_filters = flip_filters
-        self.partial_sum = partial_sum
 
         if not (self.num_input_channels < 4 or
                 self.num_input_channels % 4 == 0):
@@ -244,46 +234,26 @@ class Conv2DCCLayer(CCLayer):
                                "channels to be 1, 2, 3 or a multiple of 4, "
                                "but it is %d" % self.num_input_channels)
 
-        if pad == 'valid':
-            self.pad = 0
-        elif pad == 'full':
-            self.pad = self.filter_size - 1
-        elif pad == 'same':
-            if self.filter_size % 2 == 0:
-                raise NotImplementedError(
-                    '`same` padding requires odd filter size.')
-            self.pad = self.filter_size // 2
-        else:
-            pad = as_tuple(pad, 2, int)
-            if pad[0] != pad[1]:
+        if isinstance(self.pad, tuple):
+            if self.pad[0] != self.pad[1]:
                 raise RuntimeError("Conv2DCCLayer only supports square "
                                    "padding, but pad=(%d, %d)" % pad)
-            self.pad = pad[0]
+            pad = self.pad[0]
+        elif self.pad == 'same':
+            pad = self.filter_size[0] // 2
+        elif self.pad == 'full':
+            pad = self.filter_size[0] - 1
 
-        if W is None:
-            if dimshuffle:
-                W = init.GlorotUniform()
-            else:
-                W = init.GlorotUniform(c01b=True)
-
-        self.W = self.add_param(W, self.get_W_shape(), name="W")
-        if b is None:
-            self.b = None
-        else:
-            if self.untie_biases:
-                if self.dimshuffle:
-                    biases_shape = (num_filters, self.output_shape[2],
-                                    self.output_shape[3])
-                else:
-                    biases_shape = (num_filters, self.output_shape[1],
-                                    self.output_shape[2])
-            else:
-                biases_shape = (num_filters,)
+        if not self.dimshuffle and self.untie_biases and self.b is not None:
+            del self.params[self.b]
+            biases_shape = (num_filters, self.output_shape[1],
+                            self.output_shape[2])
             self.b = self.add_param(b, biases_shape, name="b",
                                     regularizable=False)
 
-        self.filter_acts_op = FilterActs(
-            stride=self.stride, partial_sum=self.partial_sum, pad=self.pad)
+        self.filter_acts_op = FilterActs(stride=self.stride[0],
+                                         partial_sum=self.partial_sum,
+                                         pad=pad)
 
     @property
     def num_input_channels(self):
@@ -294,34 +264,22 @@ class Conv2DCCLayer(CCLayer):
 
     def get_W_shape(self):
         if self.dimshuffle:
-            return (self.num_filters, self.num_input_channels,
-                    self.filter_size, self.filter_size)
+            return super(Conv2DCCLayer, self).get_W_shape()
         else:
-            return (self.num_input_channels, self.filter_size,
-                    self.filter_size, self.num_filters)
+            return ((self.num_input_channels,) +
+                    self.filter_size +
+                    (self.num_filters,))
 
     def get_output_shape_for(self, input_shape):
-        if self.dimshuffle:
-            batch_size = input_shape[0]
-            input_rows, input_columns = input_shape[2:4]
-        else:
-            batch_size = input_shape[3]
-            input_rows, input_columns = input_shape[1:3]
-
-        output_rows = conv_output_length(input_rows,
-                                         self.filter_size,
-                                         self.stride,
-                                         self.pad)
-
-        output_columns = conv_output_length(input_columns,
-                                            self.filter_size,
-                                            self.stride,
-                                            self.pad)
-
-        if self.dimshuffle:
-            return (batch_size, self.num_filters, output_rows, output_columns)
-        else:
-            return (self.num_filters, output_rows, output_columns, batch_size)
+        if not self.dimshuffle:
+            # c01b to bc01
+            input_shape = (input_shape[3], input_shape[0],
+                           input_shape[1], input_shape[2])
+        shape = super(Conv2DCCLayer, self).get_output_shape_for(input_shape)
+        if not self.dimshuffle:
+            # bc01 to c01b
+            shape = (shape[1], shape[2], shape[3], shape[0])
+        return shape
 
     def get_output_for(self, input, **kwargs):
         if self.dimshuffle:
@@ -340,14 +298,15 @@ class Conv2DCCLayer(CCLayer):
         if self.stride != 1:
             # cuda-convnet calculates a non-standard strided output shape,
             # so we need to truncate the output in this case
+            pad = self.pad if isinstance(self.pad, tuple) else (self.pad,) * 2
             true_rows = conv_output_length(input.shape[1],
-                                           self.filter_size,
-                                           self.stride,
-                                           self.pad)
+                                           self.filter_size[0],
+                                           self.stride[0],
+                                           pad[0])
             true_columns = conv_output_length(input.shape[2],
-                                              self.filter_size,
-                                              self.stride,
-                                              self.pad)
+                                              self.filter_size[1],
+                                              self.stride[1],
+                                              pad[1])
             conved = conved[:, :true_rows, :true_columns, :]
 
         if self.b is not None:
@@ -365,7 +324,7 @@ class Conv2DCCLayer(CCLayer):
             return conved
 
 
-class MaxPool2DCCLayer(CCLayer):
+class MaxPool2DCCLayer(Layer):
     """
     2D max-pooling layer
 

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -5,7 +5,7 @@ from .. import init
 from .. import nonlinearities
 from .base import Layer
 
-from .conv import conv_output_length
+from .conv import conv_output_length, BaseConvLayer
 from .pool import pool_output_length
 from ..utils import as_tuple
 
@@ -21,11 +21,7 @@ __all__ = [
 ]
 
 
-class DNNLayer(Layer):
-    pass
-
-
-class Pool2DDNNLayer(DNNLayer):
+class Pool2DDNNLayer(Layer):
     """
     2D pooling layer
 
@@ -129,7 +125,7 @@ class MaxPool2DDNNLayer(Pool2DDNNLayer):
                                                 **kwargs)
 
 
-class Conv2DDNNLayer(DNNLayer):
+class Conv2DDNNLayer(BaseConvLayer):
     """
     lasagne.layers.Conv2DDNNLayer(incoming, num_filters, filter_size,
     stride=(1, 1), pad=0, untie_biases=False,
@@ -240,84 +236,29 @@ class Conv2DDNNLayer(DNNLayer):
                  pad=0, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  flip_filters=False, **kwargs):
-        super(Conv2DDNNLayer, self).__init__(incoming, **kwargs)
-        if nonlinearity is None:
-            self.nonlinearity = nonlinearities.identity
-        else:
-            self.nonlinearity = nonlinearity
-
-        self.num_filters = num_filters
-        self.filter_size = as_tuple(filter_size, 2)
-        self.stride = as_tuple(stride, 2)
-        self.untie_biases = untie_biases
+        super(Conv2DDNNLayer, self).__init__(incoming, num_filters,
+                                             filter_size, stride, pad,
+                                             untie_biases, W, b, nonlinearity,
+                                             n=2, **kwargs)
         self.flip_filters = flip_filters
 
-        if pad == 'valid':
-            self.pad = (0, 0)
-        elif pad == 'full':
-            self.pad = 'full'
-        elif pad == 'same':
-            if any(s % 2 == 0 for s in self.filter_size):
-                raise NotImplementedError(
-                    '`same` padding requires odd filter size.')
-            self.pad = (self.filter_size[0] // 2, self.filter_size[1] // 2)
-        else:
-            self.pad = as_tuple(pad, 2, int)
-
-        self.W = self.add_param(W, self.get_W_shape(), name="W")
-        if b is None:
-            self.b = None
-        else:
-            if self.untie_biases:
-                biases_shape = (num_filters, self.output_shape[2],
-                                self.output_shape[3])
-            else:
-                biases_shape = (num_filters,)
-            self.b = self.add_param(b, biases_shape, name="b",
-                                    regularizable=False)
-
-    def get_W_shape(self):
-        num_input_channels = self.input_shape[1]
-        return (self.num_filters, num_input_channels, self.filter_size[0],
-                self.filter_size[1])
-
-    def get_output_shape_for(self, input_shape):
-        batch_size = input_shape[0]
-        pad = self.pad if isinstance(self.pad, tuple) else (self.pad,) * 2
-
-        output_rows = conv_output_length(input_shape[2],
-                                         self.filter_size[0],
-                                         self.stride[0],
-                                         pad[0])
-
-        output_columns = conv_output_length(input_shape[3],
-                                            self.filter_size[1],
-                                            self.stride[1],
-                                            pad[1])
-
-        return (batch_size, self.num_filters, output_rows, output_columns)
-
-    def get_output_for(self, input, **kwargs):
+    def convolve(self, input, **kwargs):
         # by default we assume 'cross', consistent with corrmm.
         conv_mode = 'conv' if self.flip_filters else 'cross'
+        border_mode = self.pad
+        if border_mode == 'same':
+            border_mode = tuple(s // 2 for s in self.filter_size)
 
         conved = dnn.dnn_conv(img=input,
                               kerns=self.W,
                               subsample=self.stride,
-                              border_mode=self.pad,
+                              border_mode=border_mode,
                               conv_mode=conv_mode
                               )
-
-        if self.b is None:
-            activation = conved
-        elif self.untie_biases:
-            activation = conved + self.b.dimshuffle('x', 0, 1, 2)
-        else:
-            activation = conved + self.b.dimshuffle('x', 0, 'x', 'x')
-        return self.nonlinearity(activation)
+        return conved
 
 
-class Conv3DDNNLayer(DNNLayer):
+class Conv3DDNNLayer(BaseConvLayer):
     """
     lasagne.layers.Conv3DDNNLayer(incoming, num_filters, filter_size,
     stride=(1, 1, 1), pad=0, untie_biases=False,
@@ -421,85 +362,23 @@ class Conv3DDNNLayer(DNNLayer):
                  pad=0, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  flip_filters=False, **kwargs):
-        super(Conv3DDNNLayer, self).__init__(incoming, **kwargs)
-        if nonlinearity is None:
-            self.nonlinearity = nonlinearities.identity
-        else:
-            self.nonlinearity = nonlinearity
-
-        self.num_filters = num_filters
-        self.filter_size = as_tuple(filter_size, 3)
-        self.stride = as_tuple(stride, 3)
-        self.untie_biases = untie_biases
+        super(Conv3DDNNLayer, self).__init__(incoming, num_filters,
+                                             filter_size, stride, pad,
+                                             untie_biases, W, b, nonlinearity,
+                                             n=3, **kwargs)
         self.flip_filters = flip_filters
 
-        if pad == 'valid':
-            self.pad = (0, 0, 0)
-        elif pad == 'full':
-            self.pad = 'full'
-        elif pad == 'same':
-            if any(s % 2 == 0 for s in self.filter_size):
-                raise NotImplementedError(
-                    '`same` padding requires odd filter size.')
-            self.pad = (self.filter_size[0] // 2, self.filter_size[1] // 2,
-                        self.filter_size[1] // 2)
-        else:
-            self.pad = as_tuple(pad, 3, int)
-
-        self.W = self.add_param(W, self.get_W_shape(), name="W")
-        if b is None:
-            self.b = None
-        else:
-            if self.untie_biases:
-                biases_shape = (num_filters, self.output_shape[2],
-                                self.output_shape[3], self.output_shape[4])
-            else:
-                biases_shape = (num_filters,)
-            self.b = self.add_param(b, biases_shape, name="b",
-                                    regularizable=False)
-
-    def get_W_shape(self):
-        num_input_channels = self.input_shape[1]
-        return (self.num_filters, num_input_channels, self.filter_size[0],
-                self.filter_size[1], self.filter_size[2])
-
-    def get_output_shape_for(self, input_shape):
-        batch_size = input_shape[0]
-        pad = self.pad if isinstance(self.pad, tuple) else (self.pad,) * 3
-
-        output_rows = conv_output_length(input_shape[2],
-                                         self.filter_size[0],
-                                         self.stride[0],
-                                         pad[0])
-
-        output_columns = conv_output_length(input_shape[3],
-                                            self.filter_size[1],
-                                            self.stride[1],
-                                            pad[1])
-
-        output_depth = conv_output_length(input_shape[4],
-                                          self.filter_size[2],
-                                          self.stride[2],
-                                          pad[2])
-
-        return (batch_size, self.num_filters, output_rows, output_columns,
-                output_depth)
-
-    def get_output_for(self, input, **kwargs):
+    def convolve(self, input, **kwargs):
         # by default we assume 'cross', consistent with corrmm.
         conv_mode = 'conv' if self.flip_filters else 'cross'
+        border_mode = self.pad
+        if border_mode == 'same':
+            border_mode = tuple(s // 2 for s in self.filter_size)
 
         conved = dnn.dnn_conv3d(img=input,
                                 kerns=self.W,
                                 subsample=self.stride,
-                                border_mode=self.pad,
+                                border_mode=border_mode,
                                 conv_mode=conv_mode
                                 )
-
-        if self.b is None:
-            activation = conved
-        elif self.untie_biases:
-            activation = conved + self.b.dimshuffle('x', 0, 1, 2, 3)
-        else:
-            activation = conved + self.b.dimshuffle('x', 0, 'x', 'x', 'x')
-        return self.nonlinearity(activation)
+        return conved

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -225,12 +225,6 @@ class Conv2DDNNLayer(BaseConvLayer):
 
     b : Theano shared variable or expression
         Variable or expression representing the biases.
-
-    Notes
-    -----
-    Unlike :class:`lasagne.layers.Conv2DLayer`, this layer properly supports
-    ``pad='same'``. It is not emulated. This should result in better
-    performance.
     """
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
                  pad=0, untie_biases=False, W=init.GlorotUniform(),
@@ -239,8 +233,7 @@ class Conv2DDNNLayer(BaseConvLayer):
         super(Conv2DDNNLayer, self).__init__(incoming, num_filters,
                                              filter_size, stride, pad,
                                              untie_biases, W, b, nonlinearity,
-                                             n=2, **kwargs)
-        self.flip_filters = flip_filters
+                                             flip_filters, n=2, **kwargs)
 
     def convolve(self, input, **kwargs):
         # by default we assume 'cross', consistent with corrmm.
@@ -365,8 +358,7 @@ class Conv3DDNNLayer(BaseConvLayer):
         super(Conv3DDNNLayer, self).__init__(incoming, num_filters,
                                              filter_size, stride, pad,
                                              untie_biases, W, b, nonlinearity,
-                                             n=3, **kwargs)
-        self.flip_filters = flip_filters
+                                             flip_filters, n=3, **kwargs)
 
     def convolve(self, input, **kwargs):
         # by default we assume 'cross', consistent with corrmm.

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -80,14 +80,14 @@ def convNd(input, kernel, pad, stride=1, n=None):
     return output
 
 
-def convNd_test_sets(n, pads=(0,)):
+def convNd_test_sets(n):
     def _convert(input, kernel, output, kwargs):
         return [theano.shared(floatX(input)), floatX(kernel), output, kwargs]
 
     extra_shape = (11, 16, 23)
     input_shape = (3, 1) + extra_shape[-n:]
 
-    for pad in pads + ('full', 'same'):
+    for pad in (0, 1, 2, 'full', 'same'):
         for stride in (1, 2, 3):
             for filter_size in (1, 3):
                 if stride > filter_size:
@@ -97,15 +97,24 @@ def convNd_test_sets(n, pads=(0,)):
                 output = convNd(input, kernel, pad, stride, n=n)
                 yield _convert(input, kernel, output, {'pad': pad,
                                                        'stride': stride,
+                                                       'flip_filters': True,
                                                        })
 
     # bias-less case
     input = np.random.random(input_shape)
     kernel = np.random.random((16, 1) + (3,) * n)
     output = convNd(input, kernel, pad='valid')
-    yield _convert(input, kernel, output, {'b': None})
+    yield _convert(input, kernel, output, {'b': None, 'flip_filters': True})
+    # untie_biases=True case
+    yield _convert(input, kernel, output, {'untie_biases': True,
+                                           'flip_filters': True})
     # pad='valid' case
-    yield _convert(input, kernel, output, {'pad': 'valid'})
+    yield _convert(input, kernel, output, {'pad': 'valid',
+                                           'flip_filters': True})
+    # flip_filters=False case
+    flip = (slice(None), slice(None)) + (slice(None, None, -1),) * n
+    output = convNd(input, kernel[flip], pad='valid')
+    yield _convert(input, kernel, output, {'flip_filters': False})
 
 
 def conv3d_test_sets():
@@ -117,7 +126,7 @@ def conv2d_test_sets():
 
 
 def conv1d_test_sets():
-    return convNd_test_sets(1, pads=(0, 1, 2))
+    return convNd_test_sets(1)
 
 
 def test_conv_output_length():
@@ -171,13 +180,8 @@ class TestConv1DLayer:
 
     @pytest.mark.parametrize(
         "input, kernel, output, kwargs", list(conv1d_test_sets()))
-    @pytest.mark.parametrize("extra_kwargs", [
-        {},
-        {'untie_biases': True},
-    ])
     def test_defaults(self, DummyInputLayer,
-                      input, kernel, output, kwargs, extra_kwargs):
-        kwargs.update(extra_kwargs)
+                      input, kernel, output, kwargs):
         b, c, w = input.shape.eval()
         input_layer = DummyInputLayer((b, c, w))
         try:
@@ -223,40 +227,25 @@ class TestConv2DLayerImplementations:
 
     @pytest.fixture(
         params=[
-            ('lasagne.layers', 'Conv2DLayer', {}),
-            ('lasagne.layers.cuda_convnet',
-             'Conv2DCCLayer',
-             {'flip_filters': True}),
-            ('lasagne.layers.corrmm', 'Conv2DMMLayer', {'flip_filters': True}),
-            ('lasagne.layers.dnn', 'Conv2DDNNLayer', {'flip_filters': True}),
+            ('lasagne.layers', 'Conv2DLayer'),
+            ('lasagne.layers.cuda_convnet', 'Conv2DCCLayer'),
+            ('lasagne.layers.corrmm', 'Conv2DMMLayer'),
+            ('lasagne.layers.dnn', 'Conv2DDNNLayer'),
         ],
     )
     def Conv2DImpl(self, request):
-        impl_module_name, impl_name, impl_default_kwargs = request.param
+        impl_module_name, impl_name = request.param
         try:
             mod = importlib.import_module(impl_module_name)
         except ImportError:
             pytest.skip("{} not available".format(impl_module_name))
 
-        impl = getattr(mod, impl_name)
-
-        def wrapper(*args, **kwargs):
-            kwargs2 = impl_default_kwargs.copy()
-            kwargs2.update(kwargs)
-            return impl(*args, **kwargs2)
-
-        wrapper.__name__ = impl_name
-        return wrapper
+        return getattr(mod, impl_name)
 
     @pytest.mark.parametrize(
         "input, kernel, output, kwargs", list(conv2d_test_sets()))
-    @pytest.mark.parametrize("extra_kwargs", [
-        {},
-        {'untie_biases': True},
-    ])
     def test_defaults(self, Conv2DImpl, DummyInputLayer,
-                      input, kernel, output, kwargs, extra_kwargs):
-        kwargs.update(extra_kwargs)
+                      input, kernel, output, kwargs):
         b, c, h, w = input.shape.eval()
         input_layer = DummyInputLayer((b, c, h, w))
         try:
@@ -279,6 +268,8 @@ class TestConv2DLayerImplementations:
         "input, kernel, output, kwargs", list(conv2d_test_sets()))
     def test_with_nones(self, Conv2DImpl, DummyInputLayer,
                         input, kernel, output, kwargs):
+        if kwargs.get('untie_biases', False):
+            pytest.skip()
         b, c, h, w = input.shape.eval()
         input_layer = DummyInputLayer((None, c, None, None))
         try:
@@ -336,35 +327,22 @@ class TestConv3DLayerImplementations:
 
     @pytest.fixture(
         params=[
-            ('lasagne.layers.dnn', 'Conv3DDNNLayer', {'flip_filters': True}),
+            ('lasagne.layers.dnn', 'Conv3DDNNLayer'),
         ],
     )
     def Conv3DImpl(self, request):
-        impl_module_name, impl_name, impl_default_kwargs = request.param
+        impl_module_name, impl_name = request.param
         try:
             mod = importlib.import_module(impl_module_name)
         except ImportError:
             pytest.skip("{} not available".format(impl_module_name))
 
-        impl = getattr(mod, impl_name)
-
-        def wrapper(*args, **kwargs):
-            kwargs2 = impl_default_kwargs.copy()
-            kwargs2.update(kwargs)
-            return impl(*args, **kwargs2)
-
-        wrapper.__name__ = impl_name
-        return wrapper
+        return getattr(mod, impl_name)
 
     @pytest.mark.parametrize(
         "input, kernel, output, kwargs", list(conv3d_test_sets()))
-    @pytest.mark.parametrize("extra_kwargs", [
-        {},
-        {'untie_biases': True},
-    ])
     def test_defaults(self, Conv3DImpl, DummyInputLayer,
-                      input, kernel, output, kwargs, extra_kwargs):
-        kwargs.update(extra_kwargs)
+                      input, kernel, output, kwargs):
         b, c, h, w, d = input.shape.eval()
         input_layer = DummyInputLayer((b, c, h, w, d))
         try:
@@ -387,6 +365,8 @@ class TestConv3DLayerImplementations:
         "input, kernel, output, kwargs", list(conv3d_test_sets()))
     def test_with_nones(self, Conv3DImpl, DummyInputLayer,
                         input, kernel, output, kwargs):
+        if kwargs.get('untie_biases', False):
+            pytest.skip()
         b, c, h, w, d = input.shape.eval()
         input_layer = DummyInputLayer((None, c, None, None, None))
         try:
@@ -452,18 +432,6 @@ class TestConv2DDNNLayer:
             with pytest.raises(ImportError):
                 import lasagne.layers.dnn
 
-    def test_pad(self, DummyInputLayer):
-        try:
-            from lasagne.layers.dnn import Conv2DDNNLayer
-        except ImportError:
-            pytest.skip("dnn not available")
-
-        input_layer = DummyInputLayer((1, 2, 3, 3))
-
-        layer = Conv2DDNNLayer(input_layer, num_filters=4, filter_size=(3, 3),
-                               pad=(3, 3))
-        assert layer.output_shape == (1, 4, 7, 7)
-
 
 class TestConv2DMMLayer:
     def test_import_without_gpu_raises(self):
@@ -472,18 +440,6 @@ class TestConv2DMMLayer:
         else:
             with pytest.raises(ImportError):
                 import lasagne.layers.corrmm
-
-    def test_pad(self, DummyInputLayer):
-        try:
-            from lasagne.layers.corrmm import Conv2DMMLayer
-        except ImportError:
-            pytest.skip("corrmm not available")
-
-        input_layer = DummyInputLayer((1, 2, 3, 3))
-
-        layer = Conv2DMMLayer(input_layer, num_filters=4, filter_size=(3, 3),
-                              pad=(3, 3))
-        assert layer.output_shape == (1, 4, 7, 7)
 
 
 class TestConv2DCCLayer:

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -157,6 +157,15 @@ class TestBaseConvLayer:
         with pytest.raises(NotImplementedError):
             layer.convolve(theano.tensor.tensor3())
 
+    def test_fail_on_mismatching_dimensionality(self):
+        from lasagne.layers.conv import BaseConvLayer
+        with pytest.raises(ValueError) as exc:
+            BaseConvLayer((10, 20, 30), 1, 3, n=2)
+        assert "Expected 4 input dimensions" in exc.value.args[0]
+        with pytest.raises(ValueError) as exc:
+            BaseConvLayer((10, 20, 30, 40), 1, 3, n=1)
+        assert "Expected 3 input dimensions" in exc.value.args[0]
+
 
 class TestConv1DLayer:
 

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -142,6 +142,22 @@ def DummyInputLayer():
     return factory
 
 
+class TestBaseConvLayer:
+
+    def test_infer_dimensionality(self):
+        from lasagne.layers.conv import BaseConvLayer
+        shape = (10, 20, 30, 40, 50, 60)
+        for n in range(1, 4):
+            layer = BaseConvLayer(shape[:n+2], 1, 3)
+            assert layer.n == n
+
+    def test_convolve_not_implemented(self):
+        from lasagne.layers.conv import BaseConvLayer
+        layer = BaseConvLayer((10, 20, 30), 1, 3)
+        with pytest.raises(NotImplementedError):
+            layer.convolve(theano.tensor.tensor3())
+
+
 class TestConv1DLayer:
 
     @pytest.mark.parametrize(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Theano/Theano.git@a85a44fc#egg=Theano==0.8.git
+git+https://github.com/Theano/Theano.git@24ace594#egg=Theano==0.8.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Theano/Theano.git@24ace594#egg=Theano==0.8.git
+git+https://github.com/Theano/Theano.git@54186290#egg=Theano==0.8.git


### PR DESCRIPTION
Starting to address #524. First two commits:
* Add a `BaseConvLayer` class that has all the common code and derive all other convolutional layer implementations from that. Was pretty easy except for all the special-casing in `Conv2DCCLayer`: It has a `dimshuffle` argument that optionally makes it operate directly on data in c01b layout, and it stored `self.filter_size`, `self.pad` etc. as a single integer despite being a 2D layer. I had to change the latter because I couldn't call the super constructor otherwise, also I think it's better to be consistent with other layers.
* Added a check to `BaseConvLayer` to test whether the input dimensionality fits the convolution dimensionality. There were some reports on the mailing list about users getting this wrong and getting difficult-to-interpret error messages.

Next step: Make use of the new conv2d interface in Theano -- specifically, get rid of the custom padding code in Conv2DLayer and Conv1DLayer, rename `image_shape` to `input_shape`, and move the `filter_flip` argument to the base class and add it to Conv2DLayer (adding it to Conv1DLayer is too much work for now, this would require changing all the underlying provided convolution implementations).