### PR TITLE
Add ScaleLayer and standardize function

### DIFF
--- a/docs/modules/layers/special.rst
+++ b/docs/modules/layers/special.rst
@@ -11,6 +11,9 @@ Special-purpose layers
 .. autoclass:: BiasLayer
    :members:
 
+.. autoclass:: ScaleLayer
+   :members:
+
 .. autoclass:: ExpressionLayer
    :members:
 

--- a/docs/modules/layers/special.rst
+++ b/docs/modules/layers/special.rst
@@ -14,6 +14,8 @@ Special-purpose layers
 .. autoclass:: ScaleLayer
    :members:
 
+.. autofunction:: standardize
+
 .. autoclass:: ExpressionLayer
    :members:
 

--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -12,6 +12,7 @@ from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 __all__ = [
     "NonlinearityLayer",
     "BiasLayer",
+    "ScaleLayer",
     "ExpressionLayer",
     "InverseLayer",
     "TransformerLayer",
@@ -114,6 +115,67 @@ class BiasLayer(Layer):
             return input + self.b.dimshuffle(*pattern)
         else:
             return input
+
+
+class ScaleLayer(Layer):
+    """
+    lasagne.layers.ScaleLayer(incoming, scales=lasagne.init.Constant(1),
+    shared_axes='auto', **kwargs)
+
+    A layer that scales its inputs by learned coefficients.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape
+
+    scales : Theano shared variable, expression, numpy array, or callable
+        Initial value, expression or initializer for the scale.  The scale
+        shape must match the incoming shape, skipping those axes the scales are
+        shared over (see the example below).  See
+        :func:`lasagne.utils.create_param` for more information.
+
+    shared_axes : 'auto', int or tuple of int
+        The axis or axes to share scales over. If ``'auto'`` (the default),
+        share over all axes except for the second: this will share scales over
+        the minibatch dimension for dense layers, and additionally over all
+        spatial dimensions for convolutional layers.
+
+    Notes
+    -----
+    The scales parameter dimensionality is the input dimensionality minus the
+    number of axes the scales are shared over, which matches the bias parameter
+    conventions of :class:`DenseLayer` or :class:`Conv2DLayer`. For example:
+
+    >>> layer = ScaleLayer((20, 30, 40, 50), shared_axes=(0, 2))
+    >>> layer.scales.get_value().shape
+    (30, 50)
+    """
+    def __init__(self, incoming, scales=init.Constant(1), shared_axes='auto',
+                 **kwargs):
+        super(ScaleLayer, self).__init__(incoming, **kwargs)
+
+        if shared_axes == 'auto':
+            # default: share scales over all but the second axis
+            shared_axes = (0,) + tuple(range(2, len(self.input_shape)))
+        elif isinstance(shared_axes, int):
+            shared_axes = (shared_axes,)
+        self.shared_axes = shared_axes
+
+        # create scales parameter, ignoring all dimensions in shared_axes
+        shape = [size for axis, size in enumerate(self.input_shape)
+                 if axis not in self.shared_axes]
+        if any(size is None for size in shape):
+            raise ValueError("ScaleLayer needs specified input sizes for "
+                             "all axes that scales are not shared over.")
+        self.scales = self.add_param(
+            scales, shape, 'scales', regularizable=False)
+
+    def get_output_for(self, input, **kwargs):
+        axes = iter(range(self.scales.ndim))
+        pattern = ['x' if input_axis in self.shared_axes
+                   else next(axes) for input_axis in range(input.ndim)]
+        return input * self.scales.dimshuffle(*pattern)
 
 
 class ExpressionLayer(Layer):

--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -13,6 +13,7 @@ __all__ = [
     "NonlinearityLayer",
     "BiasLayer",
     "ScaleLayer",
+    "standardize",
     "ExpressionLayer",
     "InverseLayer",
     "TransformerLayer",
@@ -176,6 +177,62 @@ class ScaleLayer(Layer):
         pattern = ['x' if input_axis in self.shared_axes
                    else next(axes) for input_axis in range(input.ndim)]
         return input * self.scales.dimshuffle(*pattern)
+
+
+def standardize(layer, offset, scale, shared_axes):
+    """
+    Convenience function for standardizing inputs by applying a fixed offset
+    and scale.  This is usually useful when you want the input to your network
+    to, say, have zero mean and unit standard deviation over the feature
+    dimensions.  This layer allows you to include the appropriate statistics to
+    achieve this normalization as part of your network, and applies them to its
+    input.  The statistics are supplied as the `offset` and `scale` parameters,
+    which are applied to the input by subtracting `offset` and dividing by
+    `scale`, sharing dimensions as specified by the `shared_axes` argument.
+
+    Parameters
+    ----------
+    layer : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape.
+    offset : Theano shared variable, expression, or numpy array
+        The offset to apply (via subtraction) to the axis/axes being
+        standardized.
+    scale : Theano shared variable, expression or numpy array
+        The scale to apply (via division) to the axis/axes being standardized.
+    shared_axes : 'auto', int or tuple of int
+        The axis or axes to share the offset and scale over. If ``'auto'`` (the
+        default), share over all axes except for the second: this will share
+        scales over the minibatch dimension for dense layers, and additionally
+        over all spatial dimensions for convolutional layers.
+
+    Examples
+    --------
+    Assuming your training data exists in a 2D numpy ndarray called
+    ``training_data``, you can use this function to scale input features to the
+    [0, 1] range based on the training set statistics like so:
+
+    >>> import lasagne
+    >>> import numpy as np
+    >>> training_data = np.random.standard_normal((100, 20))
+    >>> input_shape = (None, training_data.shape[1])
+    >>> l_in = lasagne.layers.InputLayer(input_shape)
+    >>> offset = training_data.min(axis=0)
+    >>> scale = training_data.max(axis=0) - training_data.min(axis=0)
+    >>> l_std = standardize(l_in, offset, scale, shared_axes=0)
+
+    Alternatively, to z-score your inputs based on training set statistics, you
+    could set ``offset = training_data.mean(axis=0)`` and
+    ``scale = training_data.std(axis=0)`` instead.
+    """
+    # Subtract the offset
+    layer = BiasLayer(layer, -offset, shared_axes)
+    # Do not optimize the offset parameter
+    layer.params[layer.b].remove('trainable')
+    # Divide by the scale
+    layer = ScaleLayer(layer, T.inv(scale), shared_axes)
+    # Do not optimize the scales parameter
+    layer.params[layer.scales].remove('trainable')
+    return layer
 
 
 class ExpressionLayer(Layer):


### PR DESCRIPTION
The motivation behind this layer is this: Usually, part of your ML pipeline is to compute some statistics on the training set (mean and standard deviation, or min and max) and then use them to normalize/standardize all inputs to the network.  Currently, this needs to be done "outside of the model", i.e. when you save your model you must also save the training set statistics to use later when passing data through the model.  There's no convenient way to store this information in the model itself.  This layer simply stores these statistics, and then applies them in `get_output` in a smart way which hopefully covers most use-cases.  See the example in the docstring for an example.

As another (personally relevant) example, say you are passing sequences of feature tensors into a convolutional network.  Your input data is of shape `(n_batch, n_filters, n_time_steps, n_feature)`.  You want to normalize over the `n_filters` and `n_feature` (feature) dimensions, not the `n_batch` or `n_time_steps` (sample) dimensions.  After reshaping/dimshuffling your training data (call it `X`) to shape `(n_batch*n_time_steps, n_filters, n_feature)`, you could compute the mean and standard deviation over these dimensions as `offset = X.mean(axis=0)`, `scale = X.std(axis=0)` and then apply them using the `StandardizationLayer` as follows:

```Python
l_in = lasagne.layers.InputLayer((None, n_filters, None, n_features))
l_std = lasagne.layers.normalization.StandardizationLayer(
    l_in, scale, offset, axis=(1, 3))
```

If this makes sense and seems useful, I will create some unit tests for it and/or add/remove/change features.