### PR TITLE
Raise a warning when a keyword passed to `get_output()` is unused

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -37,6 +37,7 @@ class Layer(object):
 
         self.name = name
         self.params = OrderedDict()
+        self.get_output_kwargs = []
 
         if any(d is not None and d <= 0 for d in self.input_shape):
             raise ValueError((
@@ -241,6 +242,7 @@ class MergeLayer(Layer):
                              for incoming in incomings]
         self.name = name
         self.params = OrderedDict()
+        self.get_output_kwargs = []
 
     @Layer.output_shape.getter
     def output_shape(self):

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -265,13 +265,17 @@ class BatchNormLayer(Layer):
         self.inv_std = self.add_param(inv_std, shape, 'inv_std',
                                       trainable=False, regularizable=False)
 
-    def get_output_for(self, input, deterministic=False, **kwargs):
+    def get_output_for(self, input, deterministic=False,
+                       batch_norm_use_averages=None,
+                       batch_norm_update_averages=None, **kwargs):
         input_mean = input.mean(self.axes)
         input_inv_std = T.inv(T.sqrt(input.var(self.axes) + self.epsilon))
 
         # Decide whether to use the stored averages or mini-batch statistics
-        use_averages = kwargs.get('batch_norm_use_averages',
-                                  deterministic)
+        if batch_norm_use_averages is None:
+            batch_norm_use_averages = deterministic
+        use_averages = batch_norm_use_averages
+
         if use_averages:
             mean = self.mean
             inv_std = self.inv_std
@@ -280,8 +284,10 @@ class BatchNormLayer(Layer):
             inv_std = input_inv_std
 
         # Decide whether to update the stored averages
-        update_averages = kwargs.get('batch_norm_update_averages',
-                                     not deterministic)
+        if batch_norm_update_averages is None:
+            batch_norm_update_averages = not deterministic
+        update_averages = batch_norm_update_averages
+
         if update_averages:
             # Trick: To update the stored statistics, we create memory-aliased
             # clones of the stored statistics:

--- a/lasagne/tests/layers/test_recurrent.py
+++ b/lasagne/tests/layers/test_recurrent.py
@@ -925,7 +925,8 @@ def test_CustomRecurrentLayer_child_kwargs():
         Layer,
         output_shape=(in_shape[0]*in_shape[1], n_hid),
         input_shape=(in_shape[0]*in_shape[1], in_shape[2]),
-        input_layer=InputLayer((in_shape[0]*in_shape[1], in_shape[2])))
+        input_layer=InputLayer((in_shape[0]*in_shape[1], in_shape[2])),
+        get_output_kwargs=['foo'])
     # These two functions get called, need to return dummy values for them
     in_to_hid.get_output_for.return_value = T.matrix()
     in_to_hid.get_params.return_value = []
@@ -934,7 +935,8 @@ def test_CustomRecurrentLayer_child_kwargs():
         Layer,
         output_shape=(in_shape[0], n_hid),
         input_shape=(in_shape[0], n_hid),
-        input_layer=InputLayer((in_shape[0], n_hid)))
+        input_layer=InputLayer((in_shape[0], n_hid)),
+        get_output_kwargs=[])
     hid_to_hid.get_output_for.return_value = T.matrix()
     hid_to_hid.get_params.return_value = []
     # Construct a CustomRecurrentLayer using these Mocks


### PR DESCRIPTION
This resolves issue #557. `get_output()` uses introspection to retrieve the key word arguments from `get_output_for()`. All layers now have the attribute `get_output_kwargs`, which allows a user to explicitly specify the kwargs `get_output_for` will use. Also, I changed the signature of `BatchNormalizationLayer.get_output_for` to explicitly state the kwargs that it uses.