### PR TITLE
Don't use T.inv in standardize

### DIFF
--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -3,7 +3,7 @@ import theano.tensor as T
 
 from .. import init
 from .. import nonlinearities
-from ..utils import as_tuple
+from ..utils import as_tuple, floatX
 from ..random import get_rng
 from .base import Layer, MergeLayer
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
@@ -194,10 +194,10 @@ def standardize(layer, offset, scale, shared_axes='auto'):
     ----------
     layer : a :class:`Layer` instance or a tuple
         The layer feeding into this layer, or the expected input shape.
-    offset : Theano shared variable, expression, or numpy array
+    offset : Theano shared variable or numpy array
         The offset to apply (via subtraction) to the axis/axes being
         standardized.
-    scale : Theano shared variable, expression or numpy array
+    scale : Theano shared variable or numpy array
         The scale to apply (via division) to the axis/axes being standardized.
     shared_axes : 'auto', int or tuple of int
         The axis or axes to share the offset and scale over. If ``'auto'`` (the
@@ -229,7 +229,7 @@ def standardize(layer, offset, scale, shared_axes='auto'):
     # Do not optimize the offset parameter
     layer.params[layer.b].remove('trainable')
     # Divide by the scale
-    layer = ScaleLayer(layer, T.inv(scale), shared_axes)
+    layer = ScaleLayer(layer, floatX(1.)/scale, shared_axes)
     # Do not optimize the scales parameter
     layer.params[layer.scales].remove('trainable')
     return layer

--- a/lasagne/tests/layers/test_special.py
+++ b/lasagne/tests/layers/test_special.py
@@ -2,7 +2,7 @@ from mock import Mock
 import numpy as np
 import pytest
 import theano
-from lasagne.layers import InputLayer, standardize, get_output
+from lasagne.layers import InputLayer, standardize, get_output, get_all_params
 
 
 class TestExpressionLayer:
@@ -279,6 +279,7 @@ def test_standardize():
     out = get_output(l_std).eval({l_in.input_var: X})
     assert np.allclose(out.max(axis=0), 1.)
     assert np.allclose(out.min(axis=0), 0.)
+    assert len(get_all_params(l_std)) == 2
     # More complicated example
     X = np.random.standard_normal(
         (50, 3, 100, 10)).astype(theano.config.floatX)


### PR DESCRIPTION
Using `T.inv` with `type(scale) = np.ndarray` resulted in `scales` not being returned by `get_all_params` because it would be converted to a Theano constant, not a shared variable, so `collect_all_shared` missed it.  Here, I've changed to `utils.floatX(1.)/scale` instead.  This means `standardize` can't accept Theano expressions, which is fine, that is sort of a crazy use-case for the intended purpose.  I also added a simple additional test to make sure the problem is fixed.  Should resolve #583