### PR TITLE
don't use O(N^2) algorithm in get_all_params

### DIFF
--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -1,4 +1,5 @@
 from collections import deque
+from itertools import chain
 
 import theano
 import numpy as np
@@ -322,7 +323,7 @@ def get_all_params(layer, **tags):
     True
     """
     layers = get_all_layers(layer)
-    params = sum([l.get_params(**tags) for l in layers], [])
+    params = chain.from_iterable(l.get_params(**tags) for l in layers)
     return utils.unique(params)
 
 


### PR DESCRIPTION
`sum` allocates space for all the intermediary lists. For timings, see [this post](http://stackoverflow.com/questions/952914/making-a-flat-list-out-of-list-of-lists-in-python/952952#952952) on StackOverflow. 