### PR TITLE
Sparse input to Lasagne #317

### DIFF
--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -87,7 +87,7 @@ class DenseLayer(Layer):
 
         # It needs a proper call in case the input is a SparseVariable.
         # Though it might be the case, the layer activation will remain
-        # dense since W represents a dense matrix. 
+        # dense since W represents a dense matrix.
         if type(input) == sparse.basic.SparseVariable:
             activation = sparse.basic.dot(input, self.W)
         else:

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -1,5 +1,6 @@
 import numpy as np
 import theano.tensor as T
+import theano.sparse as sparse
 
 from .. import init
 from .. import nonlinearities
@@ -84,7 +85,14 @@ class DenseLayer(Layer):
             # batch of feature vectors.
             input = input.flatten(2)
 
-        activation = T.dot(input, self.W)
+        # It needs a proper call in case the input is a SparseVariable.
+        # Though it might be the case, the layer activation will remain
+        # dense since W represents a dense matrix. 
+        if type(input) == sparse.basic.SparseVariable:
+            activation = sparse.basic.dot(input, self.W)
+        else:
+            activation = T.dot(input, self.W)
+
         if self.b is not None:
             activation = activation + self.b.dimshuffle('x', 0)
         return self.nonlinearity(activation)

--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -73,6 +73,7 @@ class DropoutLayer(Layer):
         else:
             retain_prob = 1 - self.p
             if self.rescale:
+                # It needs a proper call in case the input is a SparseVariable
                 if type(input) == sparse.basic.SparseVariable:
                     input = sparse.basic.mul(input, 1/retain_prob)
                 else:

--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -1,4 +1,5 @@
 import theano
+import theano.sparse as sparse
 
 from .base import Layer
 from ..random import get_rng
@@ -72,7 +73,10 @@ class DropoutLayer(Layer):
         else:
             retain_prob = 1 - self.p
             if self.rescale:
-                input /= retain_prob
+                if type(input) == sparse.basic.SparseVariable:
+                    input = sparse.basic.mul(input, 1/retain_prob)
+                else:
+                    input /= retain_prob
 
             # use nonsymbolic shape for dropout mask if possible
             input_shape = self.input_shape


### PR DESCRIPTION
I recently started to work with Natural Language Processing, which contains lots of sparse data. After noticing that Lasagne doesn't accept sparse inputs for its layers. I quickly realized that I would need to make some adjusts to make it work for my application. Thankfully, Theano does support sparse representation. I took me just a few tweaks.

Later, I found that there is an open issue regarding [Sparse input to Lasagne #317](https://github.com/Lasagne/Lasagne/issues/317). In this issue, it was suggested to create a `lasagne.layers.sparse` submodule. However, since it is just about using sparse variable as inputs, I thought more convenient to just adapt the `DenseLayer`. After all the Layer will be still produce a dense model `W`.

So, for a quick start, I adapted the Dense Layer and the Dropout to work with sparse inputs, this way I was able to use a network exactly* similar to the MLP in the MNIST example below. (* I just changed the input `shape` ). 

```
# ##################### Build the neural network model #######################
# This script supports three types of models. For each one, we define a
# function that takes a Theano variable representing the input and returns
# the output layer of a neural network model built in Lasagne.

def build_mlp(num_features, num_targets, input_var=None):
    # This creates an MLP of two hidden layers of 800 units each, followed by
    # a soft_max output layer of 10 units. It applies 20% dropout to the input
    # data and 50% dropout to the hidden layers.

    # Input layer, specifying the expected input shape of the network
    # (unspecified batch size, number of features) and
    # linking it to the given Theano variable `input_var`, if any:
    l_in = lasagne.layers.InputLayer(shape=(None, num_features),
                                     input_var=input_var)

    # Apply 20% dropout to the input data:
    l_in_drop = lasagne.layers.DropoutLayer(l_in, p=0.2)

    # Add a fully-connected layer of 800 units, using the linear rectifier, and
    # initializing weights with Glorot's scheme (which is the default anyway):
    l_hid1 = lasagne.layers.DenseLayer(
            l_in_drop, num_units=800,
            nonlinearity=lasagne.nonlinearities.rectify,
            W=lasagne.init.GlorotUniform())

    # We'll now add dropout of 50%:
    l_hid1_drop = lasagne.layers.DropoutLayer(l_hid1, p=0.5)

    # Another 800-unit layer:
    l_hid2 = lasagne.layers.DenseLayer(
            l_hid1_drop, num_units=800,
            nonlinearity=lasagne.nonlinearities.rectify)

    # 50% dropout again:
    l_hid2_drop = lasagne.layers.DropoutLayer(l_hid2, p=0.5)

    # Finally, we'll add the fully-connected output layer, of 10 softmax units:
    l_out = lasagne.layers.DenseLayer(
            l_hid2_drop, num_units=num_targets,
            nonlinearity=lasagne.nonlinearities.softmax)

    # Each layer is linked to its incoming layer(s), so we only need to pass
    # the output layer to give access to a network in Lasagne:
    return l_out
```
 
I also have to tweak the Theano variable for the inputs. In my case I my dataset uses `scipy.sparse.csr_matrix`.

```
# Prepare Theano variables for inputs and targets. Here we use sparse matrices instead of tensors
    input_var = theano.sparse.csr_matrix(name='inputs', dtype='float32')
    target_var = T.ivector('targets')
```

With this step up I was able to use sparse inputs.