### PR TITLE
Sparse input to Lasagne

### DIFF
--- a/lasagne/layers/__init__.py
+++ b/lasagne/layers/__init__.py
@@ -11,4 +11,3 @@ from .normalization import *
 from .embedding import *
 from .recurrent import *
 from .special import *
-from . import sparse

--- a/lasagne/layers/__init__.py
+++ b/lasagne/layers/__init__.py
@@ -11,3 +11,4 @@ from .normalization import *
 from .embedding import *
 from .recurrent import *
 from .special import *
+from . import sparse

--- a/lasagne/layers/sparse/__init__.py
+++ b/lasagne/layers/sparse/__init__.py
@@ -1,0 +1,2 @@
+from .dense import *
+from .noise import *

--- a/lasagne/layers/sparse/dense.py
+++ b/lasagne/layers/sparse/dense.py
@@ -1,11 +1,6 @@
-import numpy as np
-import theano.tensor as T
 import theano.sparse as sparse
 
-from ... import init
-from ... import nonlinearities
-
-from ..base import Layer
+from ..dense import DenseLayer as Dense
 
 
 __all__ = [
@@ -13,71 +8,14 @@ __all__ = [
 ]
 
 
-class DenseLayer(Layer):
-    """
-    lasagne.layers.sparse.DenseLayer(incoming, num_units,
-    W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
-    nonlinearity=lasagne.nonlinearities.rectify, **kwargs)
-
-    A fully connected layer.
-
-    Parameters
-    ----------
-    incoming : a :class:`Layer` instance or a tuple
-        The layer feeding into this layer, or the expected input shape
-
-    num_units : int
-        The number of units of the layer
-
-    W : Theano shared variable, expression, numpy array or callable
-        Initial value, expression or initializer for the weights.
-        These should be a matrix with shape ``(num_inputs, num_units)``.
-        See :func:`lasagne.utils.create_param` for more information.
-
-    b : Theano shared variable, expression, numpy array, callable or ``None``
-        Initial value, expression or initializer for the biases. If set to
-        ``None``, the layer will have no biases. Otherwise, biases should be
-        a 1D array with shape ``(num_units,)``.
-        See :func:`lasagne.utils.create_param` for more information.
-
-    nonlinearity : callable or None
-        The nonlinearity that is applied to the layer activations. If None
-        is provided, the layer will be linear.
-
-    Examples
-    --------
-    >>> from lasagne.layers import InputLayer
-    >>> from lasagne.layers.sparse import DenseLayer
-    >>> l_in = InputLayer((100, 20))
-    >>> l1 = DenseLayer(l_in, num_units=50)
-
-    Notes
-    -----
-
-    This layer expects a sparse matrix as input.
-    """
-    def __init__(self, incoming, num_units, W=init.GlorotUniform(),
-                 b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
-                 **kwargs):
-        super(DenseLayer, self).__init__(incoming, **kwargs)
-        self.nonlinearity = (nonlinearities.identity if nonlinearity is None
-                             else nonlinearity)
-
-        self.num_units = num_units
-
-        num_inputs = int(np.prod(self.input_shape[1:]))
-
-        self.W = self.add_param(W, (num_inputs, num_units), name="W")
-        if b is None:
-            self.b = None
-        else:
-            self.b = self.add_param(b, (num_units,), name="b",
-                                    regularizable=False)
-
-    def get_output_shape_for(self, input_shape):
-        return (input_shape[0], self.num_units)
-
+class DenseLayer(Dense):
     def get_output_for(self, input, **kwargs):
+        """
+        Parameters
+        ----------
+        input : theano sparse matrix
+            output from the previous layer
+        """
         assert type(input) == sparse.basic.SparseVariable
 
         activation = sparse.basic.dot(input, self.W)

--- a/lasagne/layers/sparse/dense.py
+++ b/lasagne/layers/sparse/dense.py
@@ -1,0 +1,89 @@
+import numpy as np
+import theano.tensor as T
+
+from .. import init
+from .. import nonlinearities
+
+from .base import Layer
+
+
+__all__ = [
+    "DenseLayer",
+]
+
+
+class DenseLayer(Layer):
+    """
+    lasagne.layers.DenseLayer(incoming, num_units,
+    W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
+    nonlinearity=lasagne.nonlinearities.rectify, **kwargs)
+
+    A fully connected layer.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape
+
+    num_units : int
+        The number of units of the layer
+
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a matrix with shape ``(num_inputs, num_units)``.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
+        a 1D array with shape ``(num_units,)``.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    nonlinearity : callable or None
+        The nonlinearity that is applied to the layer activations. If None
+        is provided, the layer will be linear.
+
+    Examples
+    --------
+    >>> from lasagne.layers import InputLayer, DenseLayer
+    >>> l_in = InputLayer((100, 20))
+    >>> l1 = DenseLayer(l_in, num_units=50)
+
+    Notes
+    -----
+    If the input to this layer has more than two axes, it will flatten the
+    trailing axes. This is useful for when a dense layer follows a
+    convolutional layer, for example. It is not necessary to insert a
+    :class:`FlattenLayer` in this case.
+    """
+    def __init__(self, incoming, num_units, W=init.GlorotUniform(),
+                 b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
+                 **kwargs):
+        super(DenseLayer, self).__init__(incoming, **kwargs)
+        self.nonlinearity = (nonlinearities.identity if nonlinearity is None
+                             else nonlinearity)
+
+        self.num_units = num_units
+
+        num_inputs = int(np.prod(self.input_shape[1:]))
+
+        self.W = self.add_param(W, (num_inputs, num_units), name="W")
+        if b is None:
+            self.b = None
+        else:
+            self.b = self.add_param(b, (num_units,), name="b",
+                                    regularizable=False)
+
+    def get_output_shape_for(self, input_shape):
+        return (input_shape[0], self.num_units)
+
+    def get_output_for(self, input, **kwargs):
+        if input.ndim > 2:
+            # if the input has more than two dimensions, flatten it into a
+            # batch of feature vectors.
+            input = input.flatten(2)
+
+        activation = T.dot(input, self.W)
+        if self.b is not None:
+            activation = activation + self.b.dimshuffle('x', 0)
+        return self.nonlinearity(activation)

--- a/lasagne/layers/sparse/noise.py
+++ b/lasagne/layers/sparse/noise.py
@@ -1,9 +1,7 @@
 import theano
+import theano.sparse as sparse
 
-from ..base import Layer
-from ...random import get_rng
-
-from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
+from ..noise import DropoutLayer as Dropout
 
 
 __all__ = [
@@ -12,51 +10,7 @@ __all__ = [
 ]
 
 
-class DropoutLayer(Layer):
-    """Dropout layer
-
-    Sets values to zero with probability p. See notes for disabling dropout
-    during testing.
-
-    Parameters
-    ----------
-    incoming : a :class:`Layer` instance or a tuple
-        the layer feeding into this layer, or the expected input shape
-    p : float or scalar tensor
-        The probability of setting a value to zero
-    rescale : bool
-        If true the input is rescaled with input / (1-p) when deterministic
-        is False.
-
-    Notes
-    -----
-    The dropout layer is a regularizer that randomly sets input values to
-    zero; see [1]_, [2]_ for why this might improve generalization.
-    During training you should set deterministic to false and during
-    testing you should set deterministic to true.
-
-    If rescale is true the input is scaled with input / (1-p) when
-    deterministic is false, see references for further discussion. Note that
-    this implementation scales the input at training time.
-
-    References
-    ----------
-    .. [1] Hinton, G., Srivastava, N., Krizhevsky, A., Sutskever, I.,
-           Salakhutdinov, R. R. (2012):
-           Improving neural networks by preventing co-adaptation of feature
-           detectors. arXiv preprint arXiv:1207.0580.
-
-    .. [2] Srivastava Nitish, Hinton, G., Krizhevsky, A., Sutskever,
-           I., & Salakhutdinov, R. R. (2014):
-           Dropout: A Simple Way to Prevent Neural Networks from Overfitting.
-           Journal of Machine Learning Research, 5(Jun)(2), 1929-1958.
-    """
-    def __init__(self, incoming, p=0.5, rescale=True, **kwargs):
-        super(DropoutLayer, self).__init__(incoming, **kwargs)
-        self._srng = RandomStreams(get_rng().randint(1, 2147462579))
-        self.p = p
-        self.rescale = rescale
-
+class DropoutLayer(Dropout):
     def get_output_for(self, input, deterministic=False, **kwargs):
         """
         Parameters
@@ -69,11 +23,11 @@ class DropoutLayer(Layer):
         if deterministic or self.p == 0:
             return input
         else:
-            assert type(input) == theano.sparse.basic.SparseVariable
+            assert type(input) == sparse.basic.SparseVariable
 
             retain_prob = 1 - self.p
             if self.rescale:
-                input = theano.sparse.basic.mul(input, 1/retain_prob)
+                input = sparse.basic.mul(input, 1/retain_prob)
 
             # use nonsymbolic shape for dropout mask if possible
             input_shape = self.input_shape

--- a/lasagne/layers/sparse/noise.py
+++ b/lasagne/layers/sparse/noise.py
@@ -61,7 +61,7 @@ class DropoutLayer(Layer):
         """
         Parameters
         ----------
-        input : tensor
+        input : theano sparse matrix
             output from the previous layer
         deterministic : bool
             If true dropout and scaling is disabled, see notes
@@ -69,9 +69,11 @@ class DropoutLayer(Layer):
         if deterministic or self.p == 0:
             return input
         else:
+            assert type(input) == theano.sparse.basic.SparseVariable
+
             retain_prob = 1 - self.p
             if self.rescale:
-                input /= retain_prob
+                input = theano.sparse.basic.mul(input, 1/retain_prob)
 
             # use nonsymbolic shape for dropout mask if possible
             input_shape = self.input_shape

--- a/lasagne/layers/sparse/noise.py
+++ b/lasagne/layers/sparse/noise.py
@@ -1,0 +1,84 @@
+import theano
+
+from .base import Layer
+from ..random import get_rng
+
+from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
+
+
+__all__ = [
+    "DropoutLayer",
+    "dropout",
+]
+
+
+class DropoutLayer(Layer):
+    """Dropout layer
+
+    Sets values to zero with probability p. See notes for disabling dropout
+    during testing.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        the layer feeding into this layer, or the expected input shape
+    p : float or scalar tensor
+        The probability of setting a value to zero
+    rescale : bool
+        If true the input is rescaled with input / (1-p) when deterministic
+        is False.
+
+    Notes
+    -----
+    The dropout layer is a regularizer that randomly sets input values to
+    zero; see [1]_, [2]_ for why this might improve generalization.
+    During training you should set deterministic to false and during
+    testing you should set deterministic to true.
+
+    If rescale is true the input is scaled with input / (1-p) when
+    deterministic is false, see references for further discussion. Note that
+    this implementation scales the input at training time.
+
+    References
+    ----------
+    .. [1] Hinton, G., Srivastava, N., Krizhevsky, A., Sutskever, I.,
+           Salakhutdinov, R. R. (2012):
+           Improving neural networks by preventing co-adaptation of feature
+           detectors. arXiv preprint arXiv:1207.0580.
+
+    .. [2] Srivastava Nitish, Hinton, G., Krizhevsky, A., Sutskever,
+           I., & Salakhutdinov, R. R. (2014):
+           Dropout: A Simple Way to Prevent Neural Networks from Overfitting.
+           Journal of Machine Learning Research, 5(Jun)(2), 1929-1958.
+    """
+    def __init__(self, incoming, p=0.5, rescale=True, **kwargs):
+        super(DropoutLayer, self).__init__(incoming, **kwargs)
+        self._srng = RandomStreams(get_rng().randint(1, 2147462579))
+        self.p = p
+        self.rescale = rescale
+
+    def get_output_for(self, input, deterministic=False, **kwargs):
+        """
+        Parameters
+        ----------
+        input : tensor
+            output from the previous layer
+        deterministic : bool
+            If true dropout and scaling is disabled, see notes
+        """
+        if deterministic or self.p == 0:
+            return input
+        else:
+            retain_prob = 1 - self.p
+            if self.rescale:
+                input /= retain_prob
+
+            # use nonsymbolic shape for dropout mask if possible
+            input_shape = self.input_shape
+            if any(s is None for s in input_shape):
+                input_shape = input.shape
+
+            return input * self._srng.binomial(input_shape, p=retain_prob,
+                                               dtype=theano.config.floatX)
+
+dropout = DropoutLayer  # shortcut

--- a/lasagne/layers/sparse/noise.py
+++ b/lasagne/layers/sparse/noise.py
@@ -1,7 +1,7 @@
 import theano
 
-from .base import Layer
-from ..random import get_rng
+from ..base import Layer
+from ...random import get_rng
 
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 


### PR DESCRIPTION
Recently, I started to work with sparse data. Then I found lasagne, a very easy-to-use and handful module. However, it didn't support sparse input for networks. I started to make some small tweaks to `lasagne.layers.DenseLayer` and `lasagne.layers.DropoutLayer` to get it working with the `MLP` from MNIST example. Later, I found that other people might find it useful as well, [Sparse input to Lasagne #317](https://github.com/Lasagne/Lasagne/issues/317).

A couple days ago I did a pull request of these changes. See [Sparse input to Lasagne #595] (https://github.com/Lasagne/Lasagne/pull/595). After getting nice feedbacks, I am submitting it again for the community analysis.

Changes:
- A sparse submodule was introduced: `lasagne.layers.sparse`
- Two new classes were added, `lasagne.layers.sparse.DenseLayer` and `lasagne.layers.sparse.DropoutLayer`, that extend from `lasagne.layers.DenseLayer` and `lasagne.layers.DropoutLayer`, respectively. Both classes just overrides the `get_output_for(  )` in order to use sparse matrices instead of `theano.tensor`.