### PR TITLE
Dropout layer output type should match input type when rescale is False

### DIFF
--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -80,7 +80,7 @@ class DropoutLayer(Layer):
                 input_shape = input.shape
 
             return input * self._srng.binomial(input_shape, p=retain_prob,
-                                               dtype=theano.config.floatX)
+                                               dtype=input.dtype)
 
 dropout = DropoutLayer  # shortcut
 

--- a/lasagne/tests/layers/test_noise.py
+++ b/lasagne/tests/layers/test_noise.py
@@ -48,6 +48,11 @@ class TestDropoutLayer:
         assert 0.4 < result_eval.mean() < 0.6
         assert (numpy.unique(result_eval) == [0., 1.]).all()
 
+    def test_get_output_for_no_rescale_dtype(self, layer_no_rescale):
+        input = theano.shared(numpy.ones((100, 100), dtype=numpy.int32))
+        result = layer_no_rescale.get_output_for(input)
+        assert result.dtype == input.dtype
+
     def test_get_output_for_p_02(self, layer_p_02):
         input = theano.shared(numpy.ones((100, 100)))
         result = layer_p_02.get_output_for(input)


### PR DESCRIPTION
Closes #546.