### PR TITLE
Change GPU check to allow theano.sandbox.cuda.use()

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,6 +322,7 @@ import theano
 import theano.sandbox.cuda
 
 theano.config = Mock(device='gpu')
+theano.sandbox.cuda.cuda_enabled = True
 theano.sandbox.cuda.dnn = Mock(dnn_available=lambda: True)
 
 import sys

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -17,8 +17,10 @@ __all__ = [
 ]
 
 
-if not theano.config.device.startswith("gpu"):
-    raise ImportError("requires a GPU to work")  # pragma: no cover
+if not theano.sandbox.cuda.cuda_enabled:
+    raise ImportError(
+            "requires GPU support -- see http://lasagne.readthedocs.org/en/"
+            "latest/user/installation.html#gpu-support")  # pragma: no cover
 
 
 class Conv2DMMLayer(BaseConvLayer):

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -25,8 +25,10 @@ __all__ = [
 ]
 
 
-if not theano.config.device.startswith("gpu"):
-    raise ImportError("requires a GPU to work")  # pragma: no cover
+if not theano.sandbox.cuda.cuda_enabled:
+    raise ImportError(
+            "requires GPU support -- see http://lasagne.readthedocs.org/en/"
+            "latest/user/installation.html#gpu-support")  # pragma: no cover
 
 
 class Conv2DCCLayer(BaseConvLayer):

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -9,8 +9,15 @@ from .conv import conv_output_length, BaseConvLayer
 from .pool import pool_output_length
 from ..utils import as_tuple
 
-if not theano.config.device.startswith("gpu") or not dnn.dnn_available():
-    raise ImportError("dnn not available")  # pragma: no cover
+if not theano.sandbox.cuda.cuda_enabled:
+    raise ImportError(
+            "requires GPU support -- see http://lasagne.readthedocs.org/en/"
+            "latest/user/installation.html#gpu-support")  # pragma: no cover
+elif not dnn.dnn_available():
+    raise ImportError(
+            "cuDNN not available: %s\nSee http://lasagne.readthedocs.org/en/"
+            "latest/user/installation.html#cudnn" %
+            dnn.dnn_available.msg)  # pragma: no cover
 
 
 __all__ = [

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -425,8 +425,8 @@ class TestConv3DLayerImplementations:
 
 class TestConv2DDNNLayer:
     def test_import_without_gpu_or_cudnn_raises(self):
-        from theano.sandbox.cuda import dnn
-        if theano.config.device.startswith("gpu") and dnn.dnn_available():
+        from theano.sandbox import cuda
+        if cuda.cuda_enabled and cuda.dnn.dnn_available():
             pytest.skip()
         else:
             with pytest.raises(ImportError):
@@ -435,7 +435,8 @@ class TestConv2DDNNLayer:
 
 class TestConv2DMMLayer:
     def test_import_without_gpu_raises(self):
-        if theano.config.device.startswith("gpu"):
+        from theano.sandbox import cuda
+        if cuda.cuda_enabled:
             pytest.skip()
         else:
             with pytest.raises(ImportError):
@@ -444,7 +445,8 @@ class TestConv2DMMLayer:
 
 class TestConv2DCCLayer:
     def test_import_without_gpu_raises(self):
-        if theano.config.device.startswith("gpu"):
+        from theano.sandbox import cuda
+        if cuda.cuda_enabled:
             pytest.skip()
         else:
             with pytest.raises(ImportError):


### PR DESCRIPTION
Closes #379 by replacing `theano.config.device.startswith("gpu")` with `theano.sandbox.cuda.cuda_enabled`. This allows CUDA to be enabled in a script via `theano.sandbox.cuda.use("gpu0")` instead of only via the Theano configuration.

While we're at it, this changes the import error messages to point at the corresponding documentation on readthedocs.