### PR TITLE
Remove forgotten `mode` argument from BatchNormLayer constructor

### DIFF
--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -120,8 +120,7 @@ class LocalResponseNormalization2DLayer(Layer):
 class BatchNormLayer(Layer):
     """
     lasagne.layers.BatchNormLayer(incoming, axes='auto', epsilon=1e-4,
-    alpha=0.1, mode='low_mem',
-    beta=lasagne.init.Constant(0), gamma=lasagne.init.Constant(1),
+    alpha=0.1, beta=lasagne.init.Constant(0), gamma=lasagne.init.Constant(1),
     mean=lasagne.init.Constant(0), inv_std=lasagne.init.Constant(1), **kwargs)
 
     Batch Normalization
@@ -229,7 +228,7 @@ class BatchNormLayer(Layer):
            Internal Covariate Shift. http://arxiv.org/abs/1502.03167.
     """
     def __init__(self, incoming, axes='auto', epsilon=1e-4, alpha=0.1,
-                 mode='low_mem', beta=init.Constant(0), gamma=init.Constant(1),
+                 beta=init.Constant(0), gamma=init.Constant(1),
                  mean=init.Constant(0), inv_std=init.Constant(1), **kwargs):
         super(BatchNormLayer, self).__init__(incoming, **kwargs)
 
@@ -242,7 +241,6 @@ class BatchNormLayer(Layer):
 
         self.epsilon = epsilon
         self.alpha = alpha
-        self.mode = mode
 
         # create parameters, ignoring all dimensions in axes
         shape = [size for axis, size in enumerate(self.input_shape)


### PR DESCRIPTION
My bad. At some point during development, `BatchNormLayer` had a `mode` argument. It was inadvertently left in the constructor when removing it from the implementation.