### PR TITLE
add broadcasting to elementwise merge layers

### DIFF
--- a/lasagne/layers/merge.py
+++ b/lasagne/layers/merge.py
@@ -302,9 +302,8 @@ class ElemwiseMergeLayer(MergeLayer):
 
     Parameters
     ----------
-    incomings : a list of :class:`Layer` instances or tuples
-        the layers feeding into this layer, or expected input shapes,
-        with all incoming shapes being equal
+    incomings : Unless `cropping` is given, all shapes must be equal, except
+        for dimensions that are undefined (``None``) or broadcastable (``1``).
 
     merge_function : callable
         the merge function to use. Should take two arguments and return the
@@ -324,9 +323,36 @@ class ElemwiseMergeLayer(MergeLayer):
         super(ElemwiseMergeLayer, self).__init__(incomings, **kwargs)
         self.merge_function = merge_function
         self.cropping = cropping
+        self.broadcastable = None
 
     def get_output_shape_for(self, input_shapes):
         input_shapes = autocrop_array_shapes(input_shapes, self.cropping)
+
+        input_dims = [len(shp) for shp in input_shapes]
+        if not all(input_dim == input_dims[0] for input_dim in input_dims):
+            raise ValueError('Input dimensions must be the same but were %s' %
+                             ", ".join(map(str, input_shapes)))
+
+        def broadcasting(input_dim):
+            # Identify dimensions that will be broadcasted.
+            sorted_dim = sorted(input_dim,
+                                key=lambda x: x if x is not None else -1)
+            if isinstance(sorted_dim[-1], int) and sorted_dim[-1] != 1 \
+                    and all([d == 1 for d in sorted_dim[:-1]]):
+                size_after_broadcast = sorted_dim[-1]
+                broadcast = [True if d == 1 else None for d in input_dim]
+                return ((size_after_broadcast,)*len(input_dim), broadcast)
+            else:
+                return (input_dim, [None]*len(input_dim))
+
+        # if the dimension is broadcastable we replace 1's with the size
+        # after broadcasting.
+        input_dims, broadcastable = list(zip(
+            *[broadcasting(input_dim)for input_dim in zip(*input_shapes)]))
+
+        self.broadcastable = list(zip(*broadcastable))
+        input_shapes = list(zip(*input_dims))
+
         # Infer the output shape by grabbing, for each axis, the first
         # input size that is not `None` (if there is any)
         output_shape = tuple(next((s for s in sizes if s is not None), None)
@@ -344,6 +370,13 @@ class ElemwiseMergeLayer(MergeLayer):
 
     def get_output_for(self, inputs, **kwargs):
         inputs = autocrop(inputs, self.cropping)
+        # modify broadcasting pattern.
+        if self.broadcastable is not None:
+            for n, broadcasting_dim in enumerate(self.broadcastable):
+                for dim, broadcasting in enumerate(broadcasting_dim):
+                    if broadcasting:
+                        inputs[n] = T.addbroadcast(inputs[n], dim)
+
         output = None
         for input in inputs:
             if output is not None:
@@ -360,9 +393,8 @@ class ElemwiseSumLayer(ElemwiseMergeLayer):
 
     Parameters
     ----------
-    incomings : a list of :class:`Layer` instances or tuples
-        the layers feeding into this layer, or expected input shapes,
-        with all incoming shapes being equal
+    incomings : Unless `cropping` is given, all shapes must be equal, except
+        for dimensions that are undefined (``None``) or broadcastable (``1``).
 
     coeffs: list or scalar
         A same-sized list of coefficients, or a single coefficient that

--- a/lasagne/tests/layers/test_merge.py
+++ b/lasagne/tests/layers/test_merge.py
@@ -184,12 +184,18 @@ class TestElemwiseSumLayer:
         assert layer.get_output_shape_for([(3, 2), (3, None)]) == (3, 2)
         assert layer.get_output_shape_for([(None, 2), (3, 2)]) == (3, 2)
         assert layer.get_output_shape_for([(None, 2), (None, 2)]) == (None, 2)
+        assert layer.get_output_shape_for([(None, 5), (None, 1)]) == (None, 5)
+        assert layer.get_output_shape_for([(None, 1), (None, 5)]) == (None, 5)
+        assert layer.get_output_shape_for(
+            [(None, None), (None, 5)]) == (None, 5)
         with pytest.raises(ValueError):
             layer.get_output_shape_for([(3, None), (4, 2)])
         with pytest.raises(ValueError):
             layer.get_output_shape_for([(3, 2), (4, None)])
         with pytest.raises(ValueError):
             layer.get_output_shape_for([(None, 2), (3, 2), (4, 2)])
+        with pytest.raises(ValueError):
+            layer.get_output_shape_for([(None, 2), (3, 2, 10), (4, 2)])
 
     def test_get_output_for(self, layer):
         a = numpy.array([[0, 1], [2, 3]])
@@ -215,6 +221,35 @@ class TestElemwiseSumLayer:
         from lasagne.layers.merge import ElemwiseSumLayer
         with pytest.raises(ValueError):
             ElemwiseSumLayer([Mock(), Mock()], coeffs=[2, 3, -1])
+
+    def test_broadcasting_pattern(self):
+        from lasagne.layers import ElemwiseSumLayer, InputLayer
+        import lasagne
+        import theano.tensor as T
+        import numpy as np
+        import theano
+        a, b = T.matrices('a', 'b')
+        a_ = np.ones((2, 1), dtype=theano.config.floatX)
+        b_ = np.ones((2, 5), dtype=theano.config.floatX)
+        l_a = InputLayer((2, 1))
+        l_b = InputLayer((2, 5))
+        l_o = ElemwiseSumLayer([l_a, l_b])
+        shp = l_o.output_shape  # set broadcastable table
+        output = lasagne.layers.get_output(
+            l_o, {l_a: a, l_b: b}).eval({a: a_, b: b_})
+        np.testing.assert_array_almost_equal(output, np.ones((2, 5))+1.0)
+        assert shp == output.shape
+
+        # test that None dimensions are not modified
+        l_a = InputLayer((2, None))
+        l_b = InputLayer((2, None))
+        l_o = ElemwiseSumLayer([l_a, l_b])
+        shp = l_o.output_shape  # set broadcastable table
+        a = T.addbroadcast(a, 1)
+        output = lasagne.layers.get_output(
+            l_o, {l_a: a, l_b: b}).eval({a: a_, b: b_})
+        np.testing.assert_array_almost_equal(output, np.ones((2, 5))+1.0)
+        assert shp == (2, None)
 
 
 class TestElemwiseMergeLayerMul:


### PR DESCRIPTION
Fix https://github.com/Lasagne/Lasagne/issues/584 
Adds a check to ElemwiseMergeLayer that checks if a dimension is broadcastable. 

I think the layer will fail if the tensor is not broadcastable but the shapes are. Should we take care of that or is it the users reponsiblity to not use non-broadcastable tensors? 
