### PR TITLE
Extending get_params to optionally return Theano expressions

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -49,9 +49,10 @@ class Layer(object):
     def output_shape(self):
         return self.get_output_shape_for(self.input_shape)
 
-    def get_params(self, **tags):
+    def get_params(self, unwrap_shared=True, **tags):
         """
-        Returns a list of Theano shared variables that parameterize the layer.
+        Returns a list of Theano shared variables or expressions that
+        parameterize the layer.
 
         By default, all shared variables that participate in the forward pass
         will be returned (in the order they were registered in the Layer's
@@ -62,12 +63,19 @@ class Layer(object):
         regularized (e.g., by L2 decay).
 
         If any of the layer's parameters was set to a Theano expression instead
-        of a shared variable, the shared variables involved in that expression
-        will be returned rather than the expression itself. Tag filtering
-        considers all variables within an expression to be tagged the same.
+        of a shared variable, `unwrap_shared` controls whether to return the
+        shared variables involved in that expression (``unwrap_shared=True``,
+        the default), or the expression itself (``unwrap_shared=False``). In
+        either case, tag filtering applies to the expressions, considering all
+        variables within an expression to be tagged the same.
 
         Parameters
         ----------
+        unwrap_shared : bool (default: True)
+            Affects only parameters that were set to a Theano expression. If
+            ``True`` the function returns the shared variables contained in
+            the expression, otherwise the Theano expression itself.
+
         **tags (optional)
             tags can be specified to filter the list. Specifying ``tag1=True``
             will limit the list to parameters that are tagged with ``tag1``.
@@ -77,7 +85,7 @@ class Layer(object):
 
         Returns
         -------
-        list of Theano shared variables
+        list of Theano shared variables or expressions
             A list of variables that parameterize the layer
 
         Notes
@@ -98,7 +106,10 @@ class Layer(object):
             result = [param for param in result
                       if not (self.params[param] & exclude)]
 
-        return utils.collect_shared_vars(result)
+        if unwrap_shared:
+            return utils.collect_shared_vars(result)
+        else:
+            return result
 
     def get_output_shape_for(self, input_shape):
         """

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -290,9 +290,10 @@ def get_output_shape(layer_or_layers, input_shapes=None):
         return all_shapes[layer_or_layers]
 
 
-def get_all_params(layer, **tags):
+def get_all_params(layer, unwrap_shared=True, **tags):
     """
-    Returns a list of Theano shared variables that parameterize the layer.
+    Returns a list of Theano shared variables or expressions that
+    parameterize the layer.
 
     This function gathers all parameter variables of all layers below one or
     more given :class:`Layer` instances, including the layer(s) itself. Its
@@ -311,6 +312,11 @@ def get_all_params(layer, **tags):
         The :class:`Layer` instance for which to gather all parameters, or a
         list of :class:`Layer` instances.
 
+    unwrap_shared : bool (default: True)
+        Affects only parameters that were set to a Theano expression. If
+        ``True`` the function returns the shared variables contained in
+        the expression, otherwise the Theano expression itself.
+
     **tags (optional)
         tags can be specified to filter the list. Specifying ``tag1=True``
         will limit the list to parameters that are tagged with ``tag1``.
@@ -321,7 +327,8 @@ def get_all_params(layer, **tags):
     Returns
     -------
     params : list
-        A list of Theano shared variables representing the parameters.
+        A list of Theano shared variables or expressions representing
+        the parameters.
 
     Examples
     --------
@@ -334,10 +341,12 @@ def get_all_params(layer, **tags):
 
     Notes
     -----
-    If any layer's parameter was set to a Theano expression instead of a shared
-    variable, the shared variables involved in that expression will be returned
-    rather than the expression itself. Tag filtering considers all variables
-    within an expression to be tagged the same.
+    If any of the layers' parameters was set to a Theano expression instead
+    of a shared variable, `unwrap_shared` controls whether to return the
+    shared variables involved in that expression (``unwrap_shared=True``,
+    the default), or the expression itself (``unwrap_shared=False``). In
+    either case, tag filtering applies to the expressions, considering all
+    variables within an expression to be tagged the same.
     >>> import theano
     >>> import numpy as np
     >>> from lasagne.utils import floatX
@@ -349,7 +358,8 @@ def get_all_params(layer, **tags):
     True
     """
     layers = get_all_layers(layer)
-    params = chain.from_iterable(l.get_params(**tags) for l in layers)
+    params = chain.from_iterable(l.get_params(
+            unwrap_shared=unwrap_shared, **tags) for l in layers)
     return utils.unique(params)
 
 

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -718,6 +718,23 @@ class TestGetAllParams:
                 (l2.get_params(regularizable=True) +
                  l3.get_params(regularizable=True)))
 
+    def test_get_all_params_with_unwrap_shared(self):
+        from lasagne.layers import (InputLayer, DenseLayer, get_all_params)
+        import theano.tensor as T
+        from lasagne.utils import floatX
+
+        l1 = InputLayer((10, 20))
+        l2 = DenseLayer(l1, 30)
+
+        W1 = theano.shared(floatX(numpy.zeros((30, 2))))
+        W2 = theano.shared(floatX(numpy.zeros((2, 40))))
+        W_expr = T.dot(W1, W2)
+        l3 = DenseLayer(l2, 40, W=W_expr, b=None)
+
+        l2_params = get_all_params(l2)
+        assert get_all_params(l3) == l2_params + [W1, W2]
+        assert get_all_params(l3, unwrap_shared=False) == l2_params + [W_expr]
+
 
 class TestCountParams:
     def test_get_all_params(self):


### PR DESCRIPTION
This PR fixes #641. It adds the ability to make get_params and get_all_params return Theano expressions if any of the parameters was registered as a Theano expression. To this end this PR adds the keyword *unwrap_shared* (default: True) to both methods. The default behaviour of both methods is unchanged, yet setting unwrap_shared=False will yield the Theano expressions instead of the contained shared variables.