### PR TITLE
Update Theano dependency to 0.8.0

### DIFF
--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -13,7 +13,9 @@ http://lasagne.readthedocs.org/en/latest/user/installation.html#theano"""
 except ImportError:  # pragma: no cover
     raise ImportError("Could not import Theano." + install_instr)
 else:
-    if not hasattr(theano.tensor.nnet, 'abstract_conv'):  # pragma: no cover
+    try:
+        import theano.tensor.signal.pool
+    except ImportError:  # pragma: no cover
         raise ImportError("Your Theano version is too old." + install_instr)
     del install_instr
     del theano

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -3,7 +3,7 @@ import theano.tensor as T
 from .base import Layer
 from ..utils import as_tuple
 
-from theano.tensor.signal import downsample
+from theano.tensor.signal.pool import pool_2d
 
 
 __all__ = [
@@ -154,13 +154,13 @@ class Pool1DLayer(Layer):
     def get_output_for(self, input, **kwargs):
         input_4d = T.shape_padright(input, 1)
 
-        pooled = downsample.max_pool_2d(input_4d,
-                                        ds=(self.pool_size[0], 1),
-                                        st=(self.stride[0], 1),
-                                        ignore_border=self.ignore_border,
-                                        padding=(self.pad[0], 0),
-                                        mode=self.mode,
-                                        )
+        pooled = pool_2d(input_4d,
+                         ds=(self.pool_size[0], 1),
+                         st=(self.stride[0], 1),
+                         ignore_border=self.ignore_border,
+                         padding=(self.pad[0], 0),
+                         mode=self.mode,
+                         )
         return pooled[:, :, :, 0]
 
 
@@ -258,13 +258,13 @@ class Pool2DLayer(Layer):
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        pooled = downsample.max_pool_2d(input,
-                                        ds=self.pool_size,
-                                        st=self.stride,
-                                        ignore_border=self.ignore_border,
-                                        padding=self.pad,
-                                        mode=self.mode,
-                                        )
+        pooled = pool_2d(input,
+                         ds=self.pool_size,
+                         st=self.stride,
+                         ignore_border=self.ignore_border,
+                         padding=self.pad,
+                         mode=self.mode,
+                         )
         return pooled
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Theano/Theano.git@54186290#egg=Theano==0.8.git
+Theano==0.8.0


### PR DESCRIPTION
Probably a good idea to update to the new Theano release.

The dependency check in `__init__.py` just checks for the new "feature" we use, which is the new name and location for the `max_pool_2d` function. We don't actually require a more recent Theano version than the one that introduced this. Is that okay? Any arguments against that?