### PR TITLE
Spatial Pyramid Pooling

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -205,4 +205,5 @@
     dnn.Pool2DDNNLayer
     dnn.MaxPool3DDNNLayer
     dnn.Pool3DDNNLayer
+    dnn.SpatialPyramidPoolingDNNLayer
 


### PR DESCRIPTION
Hi everyone,

This PR would include spatial pyramid pooling following reference http://arxiv.org/abs/1406.4729.
The SpatialPyramidPoolingLayer will reduce the output of the convolutional/pooling part of a DNN to a fixed size independent of the original image dimension. Hence, a dense network structure with a fixed number of nodes may be added even though the input dimension is undetermined.

This implementation allows for any level of pooling (the paper uses 3-level and 4-level structures, but in principle it is arbitrary). All this is possible because dnn.dnn_pool can now take Theano expressions as input (https://github.com/Theano/Theano/pull/3965).

I hope this is of interest. 

best,

Philipp