### PR TITLE
Fix lasagne updates

### DIFF
--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -1,4 +1,5 @@
 import theano
+import theano.tensor as T
 
 from .base import Layer
 from ..random import get_rng
@@ -70,7 +71,10 @@ class DropoutLayer(Layer):
         if deterministic or self.p == 0:
             return input
         else:
-            retain_prob = 1 - self.p
+            # Using theano constant to prevent upcasting
+            one = T.constant(1)
+
+            retain_prob = one - self.p
             if self.rescale:
                 input /= retain_prob
 

--- a/lasagne/tests/layers/test_noise.py
+++ b/lasagne/tests/layers/test_noise.py
@@ -60,6 +60,12 @@ class TestDropoutLayer:
         assert 0.9 < result_eval.mean() < 1.1
         assert (numpy.round(numpy.unique(result_eval), 2) == [0., 1.25]).all()
 
+    def test_get_output_for_p_float32(self, input_layer):
+        from lasagne.layers.noise import DropoutLayer
+        layer = DropoutLayer(input_layer, p=numpy.float32(0.5))
+        input = theano.shared(numpy.ones((100, 100), dtype=numpy.float32))
+        assert layer.get_output_for(input).dtype == input.dtype
+
     def test_specified_rng(self, input_layer):
         from lasagne.layers.noise import DropoutLayer
         input = theano.shared(numpy.ones((100, 100)))


### PR DESCRIPTION
These changes fix the upcasting issue in lasagne.update functions rmsprop, adadelta, adam and adamax where float32 inputs are given float64 updates 
A test method, test_update_returntype has also been added to the class TestUpdateFunctions which checks for this error.
Closes #402. Closes #563. Closes #578.