### PR TITLE
Have `output_shape` property error out for symbolic shapes

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 
+import theano.tensor as T
+
 from .. import utils
 
 
@@ -47,7 +49,14 @@ class Layer(object):
 
     @property
     def output_shape(self):
-        return self.get_output_shape_for(self.input_shape)
+        shape = self.get_output_shape_for(self.input_shape)
+        if any(isinstance(s, T.Variable) for s in shape):
+            raise ValueError("%s returned a symbolic output shape from its "
+                             "get_output_shape_for() method: %r. This is not "
+                             "allowed; shapes must be tuples of integers for "
+                             "fixed-size dimensions and Nones for variable "
+                             "dimensions." % (self.__class__.__name__, shape))
+        return shape
 
     def get_params(self, **tags):
         """
@@ -246,7 +255,14 @@ class MergeLayer(Layer):
 
     @Layer.output_shape.getter
     def output_shape(self):
-        return self.get_output_shape_for(self.input_shapes)
+        shape = self.get_output_shape_for(self.input_shapes)
+        if any(isinstance(s, T.Variable) for s in shape):
+            raise ValueError("%s returned a symbolic output shape from its "
+                             "get_output_shape_for() method: %r. This is not "
+                             "allowed; shapes must be tuples of integers for "
+                             "fixed-size dimensions and Nones for variable "
+                             "dimensions." % (self.__class__.__name__, shape))
+        return shape
 
     def get_output_shape_for(self, input_shapes):
         """

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -121,6 +121,16 @@ class TestLayer:
             Layer(zero_input_layer)
         Layer(pos_input_layer)
 
+    def test_symbolic_output_shape(self):
+        from lasagne.layers.base import Layer
+
+        class WrongLayer(Layer):
+            def get_output_shape_for(self, input_shape):
+                return theano.tensor.vector().shape
+        with pytest.raises(ValueError) as exc:
+            WrongLayer((None,)).output_shape
+        assert "symbolic output shape" in exc.value.args[0]
+
 
 class TestMergeLayer:
     @pytest.fixture
@@ -158,3 +168,13 @@ class TestMergeLayer:
     def test_get_output_for_notimplemented(self, layer):
         with pytest.raises(NotImplementedError):
             layer.get_output_for(Mock())
+
+    def test_symbolic_output_shape(self):
+        from lasagne.layers.base import MergeLayer
+
+        class WrongLayer(MergeLayer):
+            def get_output_shape_for(self, input_shapes):
+                return theano.tensor.vector().shape
+        with pytest.raises(ValueError) as exc:
+            WrongLayer([(None,)]).output_shape
+        assert "symbolic output shape" in exc.value.args[0]


### PR DESCRIPTION
Closes #645.