### PR TITLE
Document that corrmm, cuda_convnet and dnn layers need explicit imports

### DIFF
--- a/docs/modules/layers/corrmm.rst
+++ b/docs/modules/layers/corrmm.rst
@@ -1,6 +1,8 @@
 :mod:`lasagne.layers.corrmm`
 ----------------------------
 
+This module houses layers that require a GPU to work. Its layers are not automatically imported into the :mod:`lasagne.layers` namespace: To use these layers, you need to ``import lasagne.layers.corrmm`` explicitly.
+
 .. automodule:: lasagne.layers.corrmm
     :members:
 

--- a/docs/modules/layers/cuda_convnet.rst
+++ b/docs/modules/layers/cuda_convnet.rst
@@ -1,6 +1,8 @@
 :mod:`lasagne.layers.cuda_convnet`
 ----------------------------------
 
+This module houses layers that require `pylearn2 <https://deeplearning.net/software/pylearn2>` to work. Its layers are not automatically imported into the :mod:`lasagne.layers` namespace: To use these layers, you need to ``import lasagne.layers.cuda_convnet`` explicitly.
+
 .. automodule:: lasagne.layers.cuda_convnet
     :members:
 

--- a/docs/modules/layers/dnn.rst
+++ b/docs/modules/layers/dnn.rst
@@ -1,6 +1,11 @@
 :mod:`lasagne.layers.dnn`
 -------------------------
 
+This module houses layers that require `cuDNN <https://developer.nvidia.com/cudnn>`_ to work. Its layers are not automatically imported into the :mod:`lasagne.layers` namespace: To use these layers, you need to ``import lasagne.layers.dnn`` explicitly.
+
+Note that these layers are not required to use cuDNN: If cuDNN is available, Theano will use it for the default convolution and pooling layers anyway.
+However, they allow you to enforce the usage of cuDNN or use features not available in :mod:`lasagne.layers`.
+
 .. automodule:: lasagne.layers.dnn
     :members:
 


### PR DESCRIPTION
Closes the last TODO item of #524.