### PR TITLE
Fix SpatialPyramidPoolingDNNLayer mismatch between output shape and data

### DIFF
--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -583,10 +583,10 @@ class SpatialPyramidPoolingDNNLayer(Layer):
             str_size = tuple(i // pool_dim for i in input_size)
 
             pool = dnn.dnn_pool(input, win_size, str_size, self.mode, (0, 0))
-            pool = pool.flatten(2)
+            pool = pool.flatten(3)
             pool_list.append(pool)
 
-        return theano.tensor.concatenate(pool_list, axis=1)
+        return theano.tensor.concatenate(pool_list, axis=2)
 
     def get_output_shape_for(self, input_shape):
         num_features = sum(p*p for p in self.pool_dims)


### PR DESCRIPTION
Follow-up to #650, which produced output data not matching the reported output shape (batchsize, channels * features) vs. (batchsize, channels, features), see https://github.com/Lasagne/Lasagne/pull/650/files#r61360880. Changed the layer to return (batchsize, channels, features) and extended the tests to ensure the returned data shape matches the computed output shape.

Thanks to @kli-nlpr for reporting it!