### PR TITLE
Name layers created using batch_norm() utility

### DIFF
--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -365,8 +365,11 @@ def batch_norm(layer, **kwargs):
     if hasattr(layer, 'b') and layer.b is not None:
         del layer.params[layer.b]
         layer.b = None
-    layer = BatchNormLayer(layer, **kwargs)
+    bn_name = (kwargs.pop('name', None) or
+               (getattr(layer, 'name', None) and layer.name + '_bn'))
+    layer = BatchNormLayer(layer, name=bn_name, **kwargs)
     if nonlinearity is not None:
         from .special import NonlinearityLayer
-        layer = NonlinearityLayer(layer, nonlinearity)
+        nonlin_name = bn_name and bn_name + '_nonlin'
+        layer = NonlinearityLayer(layer, nonlinearity, name=nonlin_name)
     return layer

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -299,3 +299,29 @@ def test_batch_norm_macro():
     bnstack = batch_norm(layer, name='foo')
     assert isinstance(bnstack, BatchNormLayer)
     assert bnstack.name == 'foo'
+
+    # check if created layers are named with kwargs name
+    layer = Mock(Layer, output_shape=input_shape, nonlinearity=obj)
+    layer.name = 'foo'
+    bnstack = batch_norm(layer, name='foo_bnorm')
+    assert isinstance(bnstack, NonlinearityLayer)
+    assert isinstance(bnstack.input_layer, BatchNormLayer)
+    assert bnstack.name == 'foo_bnorm_nonlin'
+    assert bnstack.input_layer.name == 'foo_bnorm'
+
+    # check if created layers are named with wrapped layer name
+    layer = Mock(Layer, output_shape=input_shape, nonlinearity=obj)
+    layer.name = 'foo'
+    bnstack = batch_norm(layer)
+    assert isinstance(bnstack, NonlinearityLayer)
+    assert isinstance(bnstack.input_layer, BatchNormLayer)
+    assert bnstack.name == 'foo_bn_nonlin'
+    assert bnstack.input_layer.name == 'foo_bn'
+
+    # check if created layers remain unnamed if no names are given
+    layer = Mock(Layer, output_shape=input_shape, nonlinearity=obj)
+    bnstack = batch_norm(layer)
+    assert isinstance(bnstack, NonlinearityLayer)
+    assert isinstance(bnstack.input_layer, BatchNormLayer)
+    assert bnstack.name is None
+    assert bnstack.input_layer.name is None


### PR DESCRIPTION
Closes #670.

Using suffixes '_bn' and '_bn_nonlin' (rather than just '_nonlin' for consistency w.r.t. case where BN layer is named through kwargs) for `BatchNormLayer` and `NonlinearityLayer` respectively.

Did not modify the docstring to mention this behavior.