### PR TITLE
Added sparse submodule and test for sparse input layers

### DIFF
--- a/lasagne/layers/sparse.py
+++ b/lasagne/layers/sparse.py
@@ -1,0 +1,46 @@
+import theano.tensor as T
+import theano.sparse as S
+from .dense import DenseLayer
+from .noise import DropoutLayer
+
+
+__all__ = [
+    "SparseInputDenseLayer",
+    "SparseInputDropoutLayer"
+]
+
+
+class SparseInputDenseLayer(DenseLayer):
+    def get_output_for(self, input, **kwargs):
+        if not isinstance(input, (S.SparseVariable, S.SparseConstant,
+                                  S.sharedvar.SparseTensorSharedVariable)):
+            raise ValueError("Input for this layer must be sparse")
+
+        activation = S.dot(input, self.W)
+        if self.b is not None:
+            activation = activation + self.b.dimshuffle('x', 0)
+        return self.nonlinearity(activation)
+
+
+class SparseInputDropoutLayer(DropoutLayer):
+    def get_output_for(self, input, deterministic=False, **kwargs):
+        if not isinstance(input, (S.SparseVariable, S.SparseConstant,
+                                  S.sharedvar.SparseTensorSharedVariable)):
+            raise ValueError("Input for this layer must be sparse")
+
+        if deterministic or self.p == 0:
+            return input
+        else:
+            # Using Theano constant to prevent upcasting
+            one = T.constant(1, name='one')
+            retain_prob = one - self.p
+
+            if self.rescale:
+                input = S.mul(input, one/retain_prob)
+
+            input_shape = self.input_shape
+            if any(s is None for s in input_shape):
+                input_shape = input.shape
+
+            return input * self._srng.binomial(input_shape, p=retain_prob,
+                                               dtype=input.dtype)

--- a/lasagne/tests/layers/test_sparse.py
+++ b/lasagne/tests/layers/test_sparse.py
@@ -1,0 +1,95 @@
+from mock import Mock
+import numpy as np
+import pytest
+import theano.sparse as S
+import scipy.sparse as sp
+
+
+class TestSparseInputDenseLayer:
+    @pytest.fixture
+    def layer_vars(self, dummy_input_layer):
+        from lasagne.layers.sparse import SparseInputDenseLayer
+        W = Mock()
+        b = Mock()
+        nonlinearity = Mock()
+
+        W.return_value = np.ones((12, 3))
+        b.return_value = np.ones((3,)) * 3
+        layer = SparseInputDenseLayer(
+            dummy_input_layer,
+            num_units=3,
+            W=W,
+            b=b,
+            nonlinearity=nonlinearity)
+
+        return {
+            'W': W, 'b': b, 'nonlinearity': nonlinearity, 'layer': layer
+        }
+
+    def test_get_output_for(self, layer_vars):
+        layer = layer_vars['layer']
+        nonlinearity = layer_vars['nonlinearity']
+        W = layer_vars['W']()
+        b = layer_vars['b']()
+
+        A = sp.eye(2, 12, format='csr')
+        input = S.shared(A)
+        result = layer.get_output_for(input)
+        assert result is nonlinearity.return_value
+
+        # Check input of nonlinearity, i.e W*x + b
+        nonlinearity_arg = nonlinearity.call_args[0][0]
+        assert(nonlinearity_arg.eval() ==
+               input.get_value().dot(W) + b).all()
+
+    def test_wrong_dense_input_raises_value_error(self, layer_vars):
+        layer = layer_vars['layer']
+        wrong_input = np.ones((2, 12))
+        with pytest.raises(ValueError):
+            layer.get_output_for(wrong_input)
+
+
+class TestSparseInputDropoutLayer:
+    @pytest.fixture(params=[(100, 100), (None, 100)])
+    def input_layer(self, request):
+        from lasagne.layers.input import InputLayer
+        return InputLayer(request.param)
+
+    @pytest.fixture
+    def layer(self, input_layer):
+        from lasagne.layers.sparse import SparseInputDropoutLayer
+        return SparseInputDropoutLayer(input_layer)
+
+    @pytest.fixture
+    def layer_no_rescale(self, input_layer):
+        from lasagne.layers.sparse import SparseInputDropoutLayer
+        return SparseInputDropoutLayer(input_layer, rescale=False)
+
+    @pytest.fixture
+    def layer_p_02(self, input_layer):
+        from lasagne.layers.sparse import SparseInputDropoutLayer
+        return SparseInputDropoutLayer(input_layer, p=0.2)
+
+    def test_get_output_for_non_deterministic(self, layer):
+        input = S.shared(sp.eye(100, 100, format='csr'))
+        result = layer.get_output_for(input)
+        result_eval = result.eval()
+        assert(np.unique(result_eval.data) == [0., 2.]).all()
+        assert 0.0085 < result_eval.mean() < 0.0115
+
+    def test_get_output_for_deterministic(self, layer):
+        input = S.shared(sp.eye(100, 100, format='csr'))
+        result = layer.get_output_for(input, deterministic=True)
+        result_eval = result.eval()
+        assert (result_eval == input.get_value()).data.all()
+
+    def test_wrong_dense_input_raises_value_error(self, layer):
+        wrong_input = np.ones((100, 100))
+        with pytest.raises(ValueError):
+            layer.get_output_for(wrong_input)
+
+    def test_get_output_for_p_float32(self, input_layer):
+        from lasagne.layers.sparse import SparseInputDropoutLayer
+        layer = SparseInputDropoutLayer(input_layer, p=np.float32(0.5))
+        input = S.shared(sp.eye(100, 100, format='csr', dtype=np.float32))
+        assert layer.get_output_for(input).dtype == input.dtype


### PR DESCRIPTION
As mentioned on #596 that solves issue #317. I took the code from @eduardo4jesus and made some modifications:
 - all one file, as I think is more clean and we are reusing the dense and noise layers
- added tests to improve coverall

I also have doubts about implementation, maybe a quick discussion, so we can at least close this small change.

- Are the names of the layers clear enough? The idea is to have sparse input, but dense (in the sparse matrices sense) output in a fully connected layer. In the dropout layer the only real modification is regarding the rescaling.

- Is ok if it checks against Sparse Theano types? Or there is some standard for the project?

- Are the bounds for the ```test_get_output_for_non_deterministic``` correct, I have an intuition about them, but I'm not sure that they are tight enough.

I only tested against CSR sparse format. As I believe it's best suited for this [task](http://docs.scipy.org/doc/scipy-0.17.0/reference/sparse.html#matrix-vector-product).

Thanks in advanced,
HM