### PR TITLE
Clarifying comment for iterate_minibatches in mnist example

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -209,6 +209,9 @@ def build_cnn(input_var=None):
 # own custom data iteration function. For small datasets, you can also copy
 # them to GPU at once for slightly improved performance. This would involve
 # several changes in the main program, though, and is not demonstrated here.
+# Notice that this function returns only mini-batches of size `batchsize`.
+# If the size of the data is not a multiple of `batchsize`, it will not
+# return the last (remaining) mini-batch.
 
 def iterate_minibatches(inputs, targets, batchsize, shuffle=False):
     assert len(inputs) == len(targets)


### PR DESCRIPTION
Fix iterate_minibatches function in case nb of inputs < batchsize, if nb inputs < batchsize it does not iterate through available inputs, I know it does not make sense to have nb inputs < batchsize but it should do the correct thing if it is.