### PR TITLE
Added special case for SliceLayer for slice(negative_number, None)

### DIFF
--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -386,6 +386,12 @@ class SliceLayer(Layer):
         elif input_shape[self.axis] is not None:
             output_shape[self.axis] = len(
                 range(*self.slice.indices(input_shape[self.axis])))
+        elif (self.slice.stop is None and
+              self.slice.start is not None and
+              self.slice.start < 0):
+
+            output_shape[self.axis] = len(
+                range(0, -self.slice.start, self.slice.step or 1))
         else:
             output_shape[self.axis] = None
         return tuple(output_shape)


### PR DESCRIPTION
When SliceLayer is given a slice of `slice(negative_number, None)`, we should compute the exact axis dimension in get_output_shape_for rather than set it as None. This enables connecting to the DenseLayer with `nonlinearity=lasagne.nonlinearities.softmax`, which expects the dimension to be known.