### PR TITLE
Update Docker instructions

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -228,11 +228,11 @@ To check whether it is found by Theano, run the following command:
 It will print ``True`` if everything is fine, or an error message otherwise.
 There are no additional steps required for Theano to make use of cuDNN.
 
-Docker images
-=============
+Docker
+======
 
-Instead of manually installing Theano and Lasagne on your machines as described
-above, you may want to use a pre-made `Docker <https://www.docker.com/whatisdocker>`_
+Instead of manually installing Theano and Lasagne on your machines as described above,
+you may want to use a pre-made `Docker <https://www.docker.com/what-docker>`_
 image: `Lasagne Docker (CPU) <https://hub.docker.com/r/kaixhin/lasagne/>`_ or
 `Lasagne Docker (CUDA) <https://hub.docker.com/r/kaixhin/cuda-lasagne/>`_. These
 are updated on a weekly basis with bleeding-edge builds of Theano and Lasagne.
@@ -241,8 +241,9 @@ Examples of running bash in a Docker container are as follows:
 .. code-block:: bash
 
   sudo docker run -it kaixhin/lasagne
-  sudo docker run -it --device /dev/nvidiactl --device /dev/nvidia-uvm --device /dev/nvidia0 kaixhin/cuda-lasagne:7.0
+  sudo nvidia-docker run -it kaixhin/cuda-lasagne:7.0
 
-For a guide to Docker, see the `official docs <https://docs.docker.com/userguide/>`_.
-For more details on how to use the Lasagne Docker images, including requirements for
-CUDA support, consult the `source project <https://github.com/Kaixhin/dockerfiles>`_.
+For a guide to Docker, see the `official docs <https://docs.docker.com>`_.
+CUDA support requires `NVIDIA Docker <https://github.com/NVIDIA/nvidia-docker>`_.
+For more details on how to use the Lasagne Docker images,
+consult the `source project <https://github.com/Kaixhin/dockerfiles>`_.


### PR DESCRIPTION
The CUDA Docker images are moving to use the NVIDIA Docker program, so I've updated the docs appropriately.