### PR TITLE
Have create_param() set the broadcast pattern

### DIFF
--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -274,6 +274,15 @@ def test_create_param_retain_ndarray_dtype():
     assert (result.dtype == param.dtype)
 
 
+def test_create_param_broadcast_pattern():
+    from lasagne.utils import create_param
+    for shape in (10, 1, 20), (1, 2), (3, 1), (2, 3):
+        bcast = tuple(s == 1 for s in shape)
+        assert create_param(np.zeros, shape).broadcastable == bcast
+        assert create_param(np.zeros(shape, np.float32),
+                            shape).broadcastable == bcast
+
+
 def test_unroll_scan():
     from lasagne.utils import unroll_scan
     k = 2

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -348,7 +348,11 @@ def create_param(spec, shape, name=None):
         if spec.shape != shape:
             raise ValueError("%s has shape %s, should be %s" %
                              (err_prefix % "numpy array", spec.shape, shape))
-        spec = theano.shared(spec)
+        # We assume parameter variables do not change shape after creation.
+        # We can thus fix their broadcast pattern, to allow Theano to infer
+        # broadcastable dimensions of expressions involving these parameters.
+        bcast = tuple(s == 1 for s in shape)
+        spec = theano.shared(spec, broadcastable=bcast)
 
     if isinstance(spec, theano.Variable):
         # We cannot check the shape here, Theano expressions (even shared

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -354,13 +354,11 @@ def create_param(spec, shape, name=None):
         # We cannot check the shape here, Theano expressions (even shared
         # variables) do not have a fixed compile-time shape. We can check the
         # dimensionality though.
-        # Note that we cannot assign a name here. We could assign to the
-        # `name` attribute of the variable, but the user may have already
-        # named the variable and we don't want to override this.
         if spec.ndim != len(shape):
             raise ValueError("%s has %d dimensions, should be %d" %
                              (err_prefix % "Theano variable", spec.ndim,
                               len(shape)))
+        # We only assign a name if the user hasn't done so already.
         if not spec.name:
             spec.name = name
         return spec


### PR DESCRIPTION
This PR makes create_param() set the broadcast pattern when creating a shared variable. We assume our network parameters never change shape, so we can at least fix the broadcast pattern (shared variables don't allow setting a fixed shape). This saves some headaches when users have a DenseLayer of 1 unit and try to do something fancy with the output (as here: https://groups.google.com/d/msg/lasagne-users/MQfjYI-tV2I/pf-z_NnyBQAJ), since now Theano can infer that the output is broadcastable on the last axis.