### PR TITLE
Support negative axis in ConcatLayer

### DIFF
--- a/lasagne/layers/merge.py
+++ b/lasagne/layers/merge.py
@@ -274,8 +274,9 @@ class ConcatLayer(MergeLayer):
                         for sizes in zip(*input_shapes)]
 
         def match(shape1, shape2):
+            axis = self.axis if self.axis >= 0 else len(shape1) + self.axis
             return (len(shape1) == len(shape2) and
-                    all(i == self.axis or s1 is None or s2 is None or s1 == s2
+                    all(i == axis or s1 is None or s2 is None or s1 == s2
                         for i, (s1, s2) in enumerate(zip(shape1, shape2))))
 
         # Check for compatibility with inferred output shape

--- a/lasagne/tests/layers/test_merge.py
+++ b/lasagne/tests/layers/test_merge.py
@@ -110,10 +110,9 @@ class TestAutocrop:
 
 
 class TestConcatLayer:
-    @pytest.fixture
-    def layer(self):
+    def layer(self, axis):
         from lasagne.layers.merge import ConcatLayer
-        return ConcatLayer([Mock(), Mock()], axis=1)
+        return ConcatLayer([Mock(), Mock()], axis=axis)
 
     @pytest.fixture
     def crop_layer_0(self):
@@ -127,7 +126,9 @@ class TestConcatLayer:
         return ConcatLayer([Mock(), Mock()], axis=1,
                            cropping=['lower'] * 2)
 
-    def test_get_output_shape_for(self, layer):
+    @pytest.mark.parametrize("axis", (1, -1))
+    def test_get_output_shape_for(self, axis):
+        layer = self.layer(axis)
         assert layer.get_output_shape_for([(3, 2), (3, 5)]) == (3, 7)
         assert layer.get_output_shape_for([(3, 2), (3, None)]) == (3, None)
         assert layer.get_output_shape_for([(None, 2), (3, 5)]) == (3, 7)
@@ -146,7 +147,9 @@ class TestConcatLayer:
         assert result_0 == (7, 2)
         assert result_1 == (3, 7)
 
-    def test_get_output_for(self, layer):
+    @pytest.mark.parametrize("axis", (1, -1))
+    def test_get_output_for(self, axis):
+        layer = self.layer(axis)
         inputs = [theano.shared(numpy.ones((3, 3))),
                   theano.shared(numpy.ones((3, 2)))]
         result = layer.get_output_for(inputs)


### PR DESCRIPTION
Fixes #723 by allowing negative axes in `lasagne.layers.ConcatLayer`. Specifically, the shape matching check in `get_output_shape_for()` had to be changed.