### PR TITLE
Fixed theano error on truedivision of integers

### DIFF
--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -423,7 +423,7 @@ class TransformerLayer(MergeLayer):
     def get_output_shape_for(self, input_shapes):
         shape = input_shapes[0]
         factors = self.downsample_factor
-        return (shape[:2] + tuple(None if s is None else int(s / f)
+        return (shape[:2] + tuple(None if s is None else int(s // f)
                                   for s, f in zip(shape[2:], factors)))
 
     def get_output_for(self, inputs, **kwargs):
@@ -437,8 +437,8 @@ def _transform_affine(theta, input, downsample_factor):
     theta = T.reshape(theta, (-1, 2, 3))
 
     # grid of (x_t, y_t, 1), eq (1) in ref [1]
-    out_height = T.cast(height / downsample_factor[0], 'int64')
-    out_width = T.cast(width / downsample_factor[1], 'int64')
+    out_height = T.cast(height // downsample_factor[0], 'int64')
+    out_width = T.cast(width // downsample_factor[1], 'int64')
     grid = _meshgrid(out_height, out_width)
 
     # Transform A x (x_t, y_t, 1)^T -> (x_s, y_s)
@@ -676,7 +676,7 @@ class TPSTransformerLayer(MergeLayer):
     def get_output_shape_for(self, input_shapes):
         shape = input_shapes[0]
         factors = self.downsample_factor
-        return (shape[:2] + tuple(None if s is None else int(s / f)
+        return (shape[:2] + tuple(None if s is None else int(s // f)
                                   for s, f in zip(shape[2:], factors)))
 
     def get_output_for(self, inputs, **kwargs):
@@ -713,8 +713,8 @@ def _transform_thin_plate_spline(
     else:
 
         # Transformed grid
-        out_height = T.cast(height / downsample_factor[0], 'int64')
-        out_width = T.cast(width / downsample_factor[1], 'int64')
+        out_height = T.cast(height // downsample_factor[0], 'int64')
+        out_width = T.cast(width // downsample_factor[1], 'int64')
         orig_grid = _meshgrid(out_height, out_width)
         orig_grid = orig_grid[0:2, :]
         orig_grid = T.tile(orig_grid, (num_batch, 1, 1))
@@ -870,8 +870,8 @@ def _initialize_tps(num_control_points, input_shape, downsample_factor,
 
     if precompute_grid:
         # Construct grid
-        out_height = np.array(height / downsample_factor[0]).astype('int64')
-        out_width = np.array(width / downsample_factor[1]).astype('int64')
+        out_height = np.array(height // downsample_factor[0]).astype('int64')
+        out_width = np.array(width // downsample_factor[1]).astype('int64')
         x_t, y_t = np.meshgrid(np.linspace(-1, 1, out_width),
                                np.linspace(-1, 1, out_height))
         ones = np.ones(np.prod(x_t.shape))


### PR DESCRIPTION
The TestTransformLayer.test_transform_affine_identity and TestTPSTransformLayer.test_transform_thin_plate_spline_variable_input tests were  failing on my machine due to my .theanorc file:

```
[global]
...
int_division = raise
...
```

They both raised this theano error:

```
                raise IntegerDivisionError(
>                   "With `config.int_division` set to 'raise', dividing two "
                    "integer types with '/' is forbidden to avoid confusion "
                    "between integer and floating point divisions. Please "
                    "use // for integer division, or if you want a float result "
                    "either cast one of the arguments to a float or directly call "
E                   IntegerDivisionError: With `config.int_division` set to 'raise', dividing two integer types with '/' is forbidden to avoid confusion between integer and floating point divisions. Please use // for integer division, or if you want a float result either cast one of the arguments to a float or directly call `x.__truediv__(y)`.
```

The tracebacks were: 

```
lasagne/layers/special.py:432: in get_output_for
    return _transform_affine(theta, input, self.downsample_factor)
lasagne/layers/special.py:440: in _transform_affine
    out_height = T.cast(height / downsample_factor[0], 'int64')
../Theano/theano/tensor/var.py:171: in __div__
    return theano.tensor.basic.div_proxy(self, other)
../Theano/theano/tensor/basic.py:3265: in div_proxy
    as_tensor_variable(y).dtype in discrete_dtypes)
```

and 

```
lasagne/layers/special.py:689: in get_output_for
    self.precompute_grid, self.downsample_factor)
lasagne/layers/special.py:716: in _transform_thin_plate_spline
    out_height = T.cast(height / downsample_factor[0], 'int64')
../Theano/theano/tensor/var.py:171: in __div__
    return theano.tensor.basic.div_proxy(self, other)
../Theano/theano/tensor/basic.py:3265: in div_proxy
    as_tensor_variable(y).dtype in discrete_dtypes)
```

I was able to fix these tests on my machine by simply using integer division. This should not cause any change in behavior because the outputs of the previous true-division were always cast to integers. 