### PR TITLE
Fixed auto_crop_array_shapes for python3 when shape contains None.

### DIFF
--- a/lasagne/layers/merge.py
+++ b/lasagne/layers/merge.py
@@ -233,7 +233,8 @@ def autocrop_array_shapes(input_shapes, cropping):
             if cr is None:
                 result.append(sh)
             elif cr in {'lower', 'center', 'upper'}:
-                result.append([min(sh)] * len(sh))
+                min_sh = None if any(x is None for x in sh) else min(sh)
+                result.append([min_sh] * len(sh))
             else:
                 raise ValueError('Unknown crop mode \'{0}\''.format(cr))
         return [tuple(sh) for sh in zip(*result)]

--- a/lasagne/tests/layers/test_merge.py
+++ b/lasagne/tests/layers/test_merge.py
@@ -24,6 +24,9 @@ class TestAutocrop:
         assert autocrop_array_shapes(
             [(1, 2, 3, 4), (5, 6, 7, 8), (5, 4, 3, 2)], crop2) == \
             [(1, 2, 3, 4), (1, 2, 7, 8), (1, 2, 3, 2)]
+        assert autocrop_array_shapes(
+            [(None, 2, 3, 4), (5, 6, 7, 8), (5, 4, 3, 2)], crop2) == \
+            [(None, 2, 3, 4), (None, 2, 7, 8), (None, 2, 3, 2)]
 
         with pytest.raises(ValueError):
             autocrop_array_shapes(


### PR DESCRIPTION
Fixes #674

This fixes the issue with calculating crop shapes in Python 3 for merge layers with `None` somewhere in their shape. The additional test case passes in Python 2.7 and 3.4. Without the fix it will pass in 2.7 but fail in 3.4, as described in #674.




