### PR TITLE
Add num_leading_axes argument to DenseLayer

### DIFF
--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -17,7 +17,7 @@ class DenseLayer(Layer):
     """
     lasagne.layers.DenseLayer(incoming, num_units,
     W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
-    nonlinearity=lasagne.nonlinearities.rectify, **kwargs)
+    nonlinearity=lasagne.nonlinearities.rectify, num_leading_axes=1, **kwargs)
 
     A fully connected layer.
 
@@ -44,29 +44,61 @@ class DenseLayer(Layer):
         The nonlinearity that is applied to the layer activations. If None
         is provided, the layer will be linear.
 
+    num_leading_axes : int
+        Number of leading axes to distribute the dot product over. These axes
+        will be kept in the output tensor, remaining axes will be collapsed and
+        multiplied against the weight matrix. A negative number gives the
+        (negated) number of trailing axes to involve in the dot product.
+
     Examples
     --------
     >>> from lasagne.layers import InputLayer, DenseLayer
     >>> l_in = InputLayer((100, 20))
     >>> l1 = DenseLayer(l_in, num_units=50)
 
-    Notes
-    -----
-    If the input to this layer has more than two axes, it will flatten the
-    trailing axes. This is useful for when a dense layer follows a
-    convolutional layer, for example. It is not necessary to insert a
-    :class:`FlattenLayer` in this case.
+    If the input has more than two axes, by default, all trailing axes will be
+    flattened. This is useful when a dense layer follows a convolutional layer.
+
+    >>> l_in = InputLayer((None, 10, 20, 30))
+    >>> DenseLayer(l_in, num_units=50).output_shape
+    (None, 50)
+
+    Using the `num_leading_axes` argument, you can specify to keep more than
+    just the first axis. E.g., to apply the same dot product to each step of a
+    batch of time sequences, you would want to keep the first two axes.
+
+    >>> DenseLayer(l_in, num_units=50, num_leading_axes=2).output_shape
+    (None, 10, 50)
+    >>> DenseLayer(l_in, num_units=50, num_leading_axes=-1).output_shape
+    (None, 10, 20, 50)
     """
     def __init__(self, incoming, num_units, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
-                 **kwargs):
+                 num_leading_axes=1, **kwargs):
         super(DenseLayer, self).__init__(incoming, **kwargs)
         self.nonlinearity = (nonlinearities.identity if nonlinearity is None
                              else nonlinearity)
 
         self.num_units = num_units
 
-        num_inputs = int(np.prod(self.input_shape[1:]))
+        if num_leading_axes >= len(self.input_shape):
+            raise ValueError(
+                    "Got num_leading_axes=%d for a %d-dimensional input, "
+                    "leaving no trailing axes for the dot product." %
+                    (num_leading_axes, len(self.input_shape)))
+        elif num_leading_axes < -len(self.input_shape):
+            raise ValueError(
+                    "Got num_leading_axes=%d for a %d-dimensional input, "
+                    "requesting more trailing axes than there are input "
+                    "dimensions." % (num_leading_axes, len(self.input_shape)))
+        self.num_leading_axes = num_leading_axes
+
+        if any(s is None for s in self.input_shape[num_leading_axes:]):
+            raise ValueError(
+                    "A DenseLayer requires a fixed input shape (except for "
+                    "the leading axes). Got %r for num_leading_axes=%d." %
+                    (self.input_shape, self.num_leading_axes))
+        num_inputs = int(np.prod(self.input_shape[num_leading_axes:]))
 
         self.W = self.add_param(W, (num_inputs, num_units), name="W")
         if b is None:
@@ -76,17 +108,19 @@ class DenseLayer(Layer):
                                     regularizable=False)
 
     def get_output_shape_for(self, input_shape):
-        return (input_shape[0], self.num_units)
+        return input_shape[:self.num_leading_axes] + (self.num_units,)
 
     def get_output_for(self, input, **kwargs):
-        if input.ndim > 2:
-            # if the input has more than two dimensions, flatten it into a
-            # batch of feature vectors.
-            input = input.flatten(2)
+        num_leading_axes = self.num_leading_axes
+        if num_leading_axes < 0:
+            num_leading_axes += input.ndim
+        if input.ndim > num_leading_axes + 1:
+            # flatten trailing axes (into (n+1)-tensor for num_leading_axes=n)
+            input = input.flatten(num_leading_axes + 1)
 
         activation = T.dot(input, self.W)
         if self.b is not None:
-            activation = activation + self.b.dimshuffle('x', 0)
+            activation = activation + self.b
         return self.nonlinearity(activation)
 
 

--- a/lasagne/tests/test_regularization.py
+++ b/lasagne/tests/test_regularization.py
@@ -33,7 +33,7 @@ class TestRegularizationPenalties(object):
 class TestRegularizationHelpers(object):
     @pytest.fixture
     def layers(self):
-        l_1 = lasagne.layers.InputLayer((10,))
+        l_1 = lasagne.layers.InputLayer((None, 10))
         l_2 = lasagne.layers.DenseLayer(l_1, num_units=20)
         l_3 = lasagne.layers.DenseLayer(l_2, num_units=30)
         return l_1, l_2, l_3


### PR DESCRIPTION
As proposed in #719, this adds a `leading_axes` argument to `DenseLayer` which allows to specify how many axes of the input tensor should be treated as leading axes, only collapsing the remaining axes for the matrix product. For example, with `leading_axes=2`, this corresponds to the time-distributed dense layer of Keras.
I've slightly changed the dense layer tests to use a parameterized fixture, so existing tests run with different settings for `leading_axes`.
I've also added a check to the constructor to give a meaningful error if any trailing axes have an unspecified size. Before, it would just run into an exception in `np.prod`.

Closes #719.