### PR TITLE
Add missing layers to layer overview

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -167,9 +167,12 @@
 
     NonlinearityLayer
     BiasLayer
+    ScaleLayer
+    standardize
     ExpressionLayer
     InverseLayer
     TransformerLayer
+    TPSTransformerLayer
     ParametricRectifierLayer
     prelu
     RandomizedRectifierLayer


### PR DESCRIPTION
`ScaleLayer`, `standardize` and `TPSTransformerLayer` are listed in `doc/layers/special.rst`, but were missing from `doc/layers.rst`.