### PR TITLE
Add BatchNormDNNLayer and convenience function

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -210,4 +210,6 @@
     dnn.MaxPool3DDNNLayer
     dnn.Pool3DDNNLayer
     dnn.SpatialPyramidPoolingDNNLayer
+    dnn.BatchNormDNNLayer
+    dnn.batch_norm_dnn
 


### PR DESCRIPTION
This adds `lasagne.layers.dnn.BatchNormDNNLayer` and `batch_norm_dnn`, as drop-in replacements for the ordinary batch normalization layers. They improve training performance a lot over the vanilla Theano layers, and also reduce memory usage. For a 40-layer DenseNet, I observed speed improvements of 25% to 35% depending on the GPU. Closes #743.

cuDNN-based batch normalization currently requires the bleeding-edge version of Theano (specifically, after this PR: https://github.com/Theano/Theano/pull/4582). If the Theano version is too old, both the class and the convenience function are deleted from `lasagne.layers.dnn`. This allows for easy compatibility in user code such as:
```python
try:
    from lasagne.layers.dnn import batch_norm_dnn as batch_norm
except ImportError:
    from lasagne.layers import batch_norm
```
This code does a seamless fallback when no GPU is available, cuDNN is not available, Lasagne is too old or Theano is too old.