### PR TITLE
binary hinge loss: Add log_odds argument

### DIFF
--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -254,7 +254,8 @@ def binary_hinge_loss(predictions, targets, binary=True, delta=1):
     Parameters
     ----------
     predictions : Theano tensor
-        Predictions in (0, 1), such as sigmoidal output of a neural network.
+        Log-odds of predictions, such as the input to a sigmoidal layer in
+        a neural network.
     targets : Theano tensor
         Targets in {0, 1} (or in {-1, 1} depending on `binary`), such as
         ground truth labels.
@@ -271,7 +272,12 @@ def binary_hinge_loss(predictions, targets, binary=True, delta=1):
     Notes
     -----
     This is an alternative to the binary cross-entropy loss for binary
-    classification problems
+    classification problems.
+    It is not a drop-in replacement, as it requires the inputs to the
+    sigmoid, not the outputs. To obtain those, you may have to split the
+    output layer of your network into a linear layer (``nonlinearity=None``)
+    and a :class:`~lasagne.layers.NonlinearityLayer` for the sigmoid, or just
+    use a linear output layer.
     """
     if binary:
         targets = 2 * targets - 1

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -246,7 +246,8 @@ def aggregate(loss, weights=None, mode='mean'):
                          "got %r" % mode)
 
 
-def binary_hinge_loss(predictions, targets, binary=True, delta=1):
+def binary_hinge_loss(predictions, targets, delta=1, log_odds=None,
+                      binary=True):
     """Computes the binary hinge loss between predictions and targets.
 
     .. math:: L_i = \\max(0, \\delta - t_i p_i)
@@ -254,15 +255,19 @@ def binary_hinge_loss(predictions, targets, binary=True, delta=1):
     Parameters
     ----------
     predictions : Theano tensor
-        Log-odds of predictions, such as the input to a sigmoidal layer in
-        a neural network.
+        Predictions in (0, 1), such as sigmoidal output of a neural network
+        (or log-odds of predictions depending on `log_odds`).
     targets : Theano tensor
         Targets in {0, 1} (or in {-1, 1} depending on `binary`), such as
         ground truth labels.
-    binary : bool, default True
-        ``True`` if targets are in {0, 1}, ``False`` if they are in {-1, 1}
     delta : scalar, default 1
         The hinge loss margin
+    log_odds : bool, default None
+        ``False`` if predictions are sigmoid outputs in (0, 1), ``True`` if
+        predictions are sigmoid inputs, or log-odds. If ``None``, will assume
+        ``True``, but warn that the default will change to ``False``.
+    binary : bool, default True
+        ``True`` if targets are in {0, 1}, ``False`` if they are in {-1, 1}
 
     Returns
     -------
@@ -273,12 +278,21 @@ def binary_hinge_loss(predictions, targets, binary=True, delta=1):
     -----
     This is an alternative to the binary cross-entropy loss for binary
     classification problems.
-    It is not a drop-in replacement, as it requires the inputs to the
-    sigmoid, not the outputs. To obtain those, you may have to split the
-    output layer of your network into a linear layer (``nonlinearity=None``)
-    and a :class:`~lasagne.layers.NonlinearityLayer` for the sigmoid, or just
-    use a linear output layer.
+
+    Note that it is a drop-in replacement only when giving ``log_odds=False``.
+    Otherwise, it requires log-odds rather than sigmoid outputs. Be aware that
+    depending on the Theano version, ``log_odds=False`` with a sigmoid
+    output layer may be less stable than ``log_odds=True`` with a linear layer.
     """
+    if log_odds is None:  # pragma: no cover
+        raise FutureWarning(
+                "The `log_odds` argument to `binary_hinge_loss` will change "
+                "its default to `False` in a future version. Explicitly give "
+                "`log_odds=True` to retain current behavior in your code, "
+                "but also check the documentation if this is what you want.")
+        log_odds = True
+    if not log_odds:
+        predictions = theano.tensor.log(predictions / (1 - predictions))
     if binary:
         targets = 2 * targets - 1
     predictions, targets = align_targets(predictions, targets)

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -140,9 +140,9 @@ def test_binary_hinge_loss(colvect):
     p = theano.tensor.vector('p')
     t = theano.tensor.ivector('t')
     if not colvect:
-        c = binary_hinge_loss(p, t)
+        c = binary_hinge_loss(p, t, log_odds=True)
     else:
-        c = binary_hinge_loss(p.dimshuffle(0, 'x'), t)[:, 0]
+        c = binary_hinge_loss(p.dimshuffle(0, 'x'), t, log_odds=True)[:, 0]
     # numeric version
     floatX = theano.config.floatX
     predictions = np.random.rand(10).astype(floatX)
@@ -158,15 +158,31 @@ def test_binary_hinge_loss_not_binary_targets(colvect):
     p = theano.tensor.vector('p')
     t = theano.tensor.ivector('t')
     if not colvect:
-        c = binary_hinge_loss(p, t, binary=False)
+        c = binary_hinge_loss(p, t, log_odds=True, binary=False)
     else:
-        c = binary_hinge_loss(p.dimshuffle(0, 'x'), t, binary=False)[:, 0]
+        c = binary_hinge_loss(p.dimshuffle(0, 'x'), t,
+                              log_odds=True, binary=False)[:, 0]
     # numeric version
     floatX = theano.config.floatX
     predictions = np.random.rand(10, ).astype(floatX)
     targets = np.random.random_integers(0, 1, (10, )).astype("int8")
     targets = 2 * targets - 1
     hinge = np.maximum(0, 1 - predictions * targets)
+    # compare
+    assert np.allclose(hinge, c.eval({p: predictions, t: targets}))
+
+
+def test_binary_hinge_loss_sigmoid_predictions():
+    from lasagne.objectives import binary_hinge_loss
+    p = theano.tensor.vector('p')
+    t = theano.tensor.ivector('t')
+    c = binary_hinge_loss(p, t, log_odds=False)
+    # numeric version
+    floatX = theano.config.floatX
+    predictions = np.random.rand(10, ).astype(floatX)
+    targets = np.random.random_integers(0, 1, (10, )).astype("int8")
+    targets2 = 2 * targets - 1
+    hinge = np.maximum(0, 1 - np.log(predictions / (1-predictions)) * targets2)
     # compare
     assert np.allclose(hinge, c.eval({p: predictions, t: targets}))
 


### PR DESCRIPTION
The `binary_hinge_loss` looks like it would be a drop-in replacement for `binary_crossentropy`, but it isn't: It requires the log odds of the network predictions (i.e., the sigmoid input, not the sigmoid output). This PR documents this and adds a `log_odds` argument. Similar to the existing `binary` argument which allows using the objective both with 0/1 and +/-1 targets, it allows to use the objective both with sigmoid outputs and sigmoid inputs. Closes #744.