### PR TITLE
Fixed mask shape to suit arbitrary number of feature dimensions

### DIFF
--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -450,7 +450,13 @@ class CustomRecurrentLayer(MergeLayer):
             return [hid_out]
 
         if mask is not None:
-            mask = mask.dimshuffle(1, 0, 'x')
+            # After processing, the input has shape
+            # (seq_len, batch_size, feature_dim_0, feature_dim_1, ..., feature_dim_N)
+            # We have to determine N, which is the number of feature dimensions in order to adjust the shape of the
+            # masking variable to
+            # (seq_len, batch_size, 1, ..., 1)
+            num_feature_dims = input.ndim - 2
+            mask = mask.dimshuffle((1, 0) +  ('x',) * num_feature_dims)
             sequences = [input, mask]
             step_fun = step_masked
         else:

--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -451,12 +451,13 @@ class CustomRecurrentLayer(MergeLayer):
 
         if mask is not None:
             # After processing, the input has shape
-            # (seq_len, batch_size, feature_dim_0, feature_dim_1, ..., feature_dim_N)
-            # We have to determine N, which is the number of feature dimensions in order to adjust the shape of the
-            # masking variable to
+            # (seq_len, batch_size, f_0, f_1, ..., f_N)
+            # We have to determine N, which is the number of feature dimensions
+            # in order to adjust the shape of the masking variable to
             # (seq_len, batch_size, 1, ..., 1)
+            #                       |---N---|
             num_feature_dims = input.ndim - 2
-            mask = mask.dimshuffle((1, 0) +  ('x',) * num_feature_dims)
+            mask = mask.dimshuffle((1, 0) + ('x',) * num_feature_dims)
             sequences = [input, mask]
             step_fun = step_masked
         else:

--- a/lasagne/tests/layers/test_recurrent.py
+++ b/lasagne/tests/layers/test_recurrent.py
@@ -208,10 +208,12 @@ def test_custom_recurrent_arbitrary_shape_with_mask():
         l_in, l_in_to_hid, l_hid_to_hid, mask_input=l_mask)
     assert l_rec.output_shape == (n_batch, n_steps, n_out_filters, width,
                                   height)
-    out = theano.function([l_in.input_var, l_mask.input_var], lasagne.layers.get_output(l_rec))
+    out = theano.function([l_in.input_var, l_mask.input_var],
+                          lasagne.layers.get_output(l_rec))
     out_shape = out(np.zeros((n_batch, n_steps, n_channels, width, height),
                              dtype=theano.config.floatX),
-                    np.zeros((n_batch, n_steps), dtype=theano.config.floatX)).shape
+                    np.zeros((n_batch, n_steps),
+                             dtype=theano.config.floatX)).shape
     assert out_shape == (n_batch, n_steps, n_out_filters, width, height)
 
 

--- a/lasagne/tests/layers/test_recurrent.py
+++ b/lasagne/tests/layers/test_recurrent.py
@@ -189,6 +189,32 @@ def test_custom_recurrent_arbitrary_shape():
     assert out_shape == (n_batch, n_steps, n_out_filters, width, height)
 
 
+def test_custom_recurrent_arbitrary_shape_with_mask():
+    # Check that the custom recurrent layer can handle more than 1 feature dim
+    # when masking the input
+    n_batch, n_steps, n_channels, width, height = (2, 3, 4, 5, 6)
+    n_out_filters = 7
+    filter_shape = (3, 3)
+    l_in = lasagne.layers.InputLayer(
+        (n_batch, n_steps, n_channels, width, height))
+    l_mask = lasagne.layers.InputLayer((n_batch, n_steps))
+    l_in_to_hid = lasagne.layers.Conv2DLayer(
+        lasagne.layers.InputLayer((None, n_channels, width, height)),
+        n_out_filters, filter_shape, pad='same')
+    l_hid_to_hid = lasagne.layers.Conv2DLayer(
+        lasagne.layers.InputLayer((None, n_out_filters, width, height)),
+        n_out_filters, filter_shape, pad='same')
+    l_rec = lasagne.layers.CustomRecurrentLayer(
+        l_in, l_in_to_hid, l_hid_to_hid, mask_input=l_mask)
+    assert l_rec.output_shape == (n_batch, n_steps, n_out_filters, width,
+                                  height)
+    out = theano.function([l_in.input_var, l_mask.input_var], lasagne.layers.get_output(l_rec))
+    out_shape = out(np.zeros((n_batch, n_steps, n_channels, width, height),
+                             dtype=theano.config.floatX),
+                    np.zeros((n_batch, n_steps), dtype=theano.config.floatX)).shape
+    assert out_shape == (n_batch, n_steps, n_out_filters, width, height)
+
+
 def test_custom_recurrent_arbitrary_depth():
     # Check that the custom recurrent layer can handle a hidden-to-hidden
     # network with an arbitrary depth


### PR DESCRIPTION
If you use the `CustomRecurrentLayer` in order to perform a recurrent convolution, then the masking did not work properly because the masking variable assumed input to have the shape `(batch_size, seq_len, num_features)`. This PR fixes this bug and makes masking work with an arbitrary number of feature dimensions. 