### PR TITLE
Generic 3D conv layer and 3D pool layer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -338,3 +338,21 @@ sys.modules['pylearn2.sandbox.cuda_convnet.filter_acts'] = \
     Mock(FilterActs=None)
 
 sys.modules['theano.sandbox.cuda.blas'] = Mock(GpuCorrMM=None)
+
+# fool rtd into thinking it has a recent enough Theano version to support
+# all optional features that otherwise require a bleeding-edge Theano
+try:
+    reload
+except NameError:
+    try:
+        from importlib import reload
+    except ImportError:
+        from imp import reload
+
+if not hasattr(theano.tensor.nnet, 'conv3d'):
+    theano.tensor.nnet.conv3d = Mock()
+    reload(lasagne.layers.conv)
+if not hasattr(theano.tensor.signal.pool, 'pool_3d'):
+    theano.tensor.signal.pool.pool_3d = Mock()
+    reload(lasagne.layers.pool)
+reload(lasagne.layers)

--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -72,6 +72,7 @@
 
     Conv1DLayer
     Conv2DLayer
+    Conv3DLayer
     TransposedConv2DLayer
     Deconv2DLayer
     DilatedConv2DLayer
@@ -92,8 +93,10 @@
 
     MaxPool1DLayer
     MaxPool2DLayer
+    MaxPool3DLayer
     Pool1DLayer
     Pool2DLayer
+    Pool3DLayer
     Upscale1DLayer
     Upscale2DLayer
     Upscale3DLayer

--- a/docs/modules/layers/conv.rst
+++ b/docs/modules/layers/conv.rst
@@ -24,6 +24,9 @@ Convolutional layers
     gemm-based one, :class:`lasagne.layers.cuda_convnet.Conv2DCCLayer` for
     Krizhevsky's `cuda-convnet`_.
 
+.. autoclass:: Conv3DLayer
+    :members:
+
 .. _cuda-convnet: https://code.google.com/p/cuda-convnet/
 .. _cuDNN: https://developer.nvidia.com/cudnn
 .. _Theano convolution documentation: http://deeplearning.net/software/theano/library/tensor/nnet/conv.html

--- a/docs/modules/layers/pool.rst
+++ b/docs/modules/layers/pool.rst
@@ -11,10 +11,16 @@ Pooling layers
 .. autoclass:: MaxPool2DLayer
     :members:
 
+.. autoclass:: MaxPool3DLayer
+    :members:
+
 .. autoclass:: Pool1DLayer
     :members:
 
 .. autoclass:: Pool2DLayer
+    :members:
+
+.. autoclass:: Pool3DLayer
     :members:
 
 .. autoclass:: Upscale1DLayer

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -610,7 +610,7 @@ class Conv2DLayer(BaseConvLayer):
         return conved
 
 
-class Conv3DLayer(BaseConvLayer):
+class Conv3DLayer(BaseConvLayer):  # pragma: no cover
     """
     lasagne.layers.Conv3DLayer(incoming, num_filters, filter_size,
     stride=(1, 1, 1), pad=0, untie_biases=False,
@@ -716,11 +716,13 @@ class Conv3DLayer(BaseConvLayer):
                  pad=0, untie_biases=False,
                  W=init.GlorotUniform(), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify, flip_filters=True,
-                 convolution=T.nnet.conv3d, **kwargs):
+                 convolution=None, **kwargs):
         super(Conv3DLayer, self).__init__(incoming, num_filters, filter_size,
                                           stride, pad, untie_biases, W, b,
                                           nonlinearity, flip_filters, n=3,
                                           **kwargs)
+        if convolution is None:
+            convolution = T.nnet.conv3d
         self.convolution = convolution
 
     def convolve(self, input, **kwargs):
@@ -731,6 +733,12 @@ class Conv3DLayer(BaseConvLayer):
                                   border_mode=border_mode,
                                   filter_flip=self.flip_filters)
         return conved
+
+
+if not hasattr(T.nnet, 'conv3d'):  # pragma: no cover
+    # Hide Conv3DLayer for old Theano versions
+    del Conv3DLayer
+    __all__.remove('Conv3DLayer')
 
 
 class TransposedConv2DLayer(BaseConvLayer):

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -11,6 +11,7 @@ from .base import Layer
 __all__ = [
     "Conv1DLayer",
     "Conv2DLayer",
+    "Conv3DLayer",
     "TransposedConv2DLayer",
     "Deconv2DLayer",
     "DilatedConv2DLayer",
@@ -608,7 +609,128 @@ class Conv2DLayer(BaseConvLayer):
                                   filter_flip=self.flip_filters)
         return conved
 
-# TODO: add Conv3DLayer
+
+class Conv3DLayer(BaseConvLayer):
+    """
+    lasagne.layers.Conv3DLayer(incoming, num_filters, filter_size,
+    stride=(1, 1, 1), pad=0, untie_biases=False,
+    W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.),
+    nonlinearity=lasagne.nonlinearities.rectify, flip_filters=True,
+    convolution=theano.tensor.nnet.conv3d, **kwargs)
+
+    3D convolutional layer
+
+    Performs a 3D convolution on its input and optionally adds a bias and
+    applies an elementwise nonlinearity.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or a tuple
+        The layer feeding into this layer, or the expected input shape. The
+        output of this layer should be a 5D tensor, with shape ``(batch_size,
+        num_input_channels, input_depth, input_rows, input_columns)``.
+    num_filters : int
+        The number of learnable convolutional filters this layer has.
+
+    filter_size : int or iterable of int
+        An integer or a 3-element tuple specifying the size of the filters.
+
+    stride : int or iterable of int
+        An integer or a 3-element tuple specifying the stride of the
+        convolution operation.
+
+    pad : int, iterable of int, 'full', 'same' or 'valid' (default: 0)
+        By default, the convolution is only computed where the input and the
+        filter fully overlap (a valid convolution). When ``stride=1``, this
+        yields an output that is smaller than the input by ``filter_size - 1``.
+        The `pad` argument allows you to implicitly pad the input with zeros,
+        extending the output size.
+
+        A single integer results in symmetric zero-padding of the given size on
+        all borders, a tuple of two integers allows different symmetric padding
+        per dimension.
+
+        ``'full'`` pads with one less than the filter size on both sides. This
+        is equivalent to computing the convolution wherever the input and the
+        filter overlap by at least one position.
+
+        ``'same'`` pads with half the filter size (rounded down) on both sides.
+        When ``stride=1`` this results in an output size equal to the input
+        size. Even filter size is not supported.
+
+        ``'valid'`` is an alias for ``0`` (no padding / a valid convolution).
+
+        Note that ``'full'`` and ``'same'`` can be faster than equivalent
+        integer values due to optimizations by Theano.
+
+    untie_biases : bool (default: False)
+        If ``False``, the layer will have a bias parameter for each channel,
+        which is shared across all positions in this channel. As a result, the
+        `b` attribute will be a vector (1D).
+
+        If True, the layer will have separate bias parameters for each
+        position in each channel. As a result, the `b` attribute will be a
+        4D tensor.
+
+    W : Theano shared variable, expression, numpy array or callable
+        Initial value, expression or initializer for the weights.
+        These should be a 5D tensor with shape ``(num_filters,
+        num_input_channels, filter_depth, filter_rows, filter_columns)``.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    b : Theano shared variable, expression, numpy array, callable or ``None``
+        Initial value, expression or initializer for the biases. If set to
+        ``None``, the layer will have no biases. Otherwise, biases should be
+        a 1D array with shape ``(num_filters,)`` if `untied_biases` is set to
+        ``False``. If it is set to ``True``, its shape should be
+        ``(num_filters, output_depth, output_rows, output_columns)`` instead.
+        See :func:`lasagne.utils.create_param` for more information.
+
+    nonlinearity : callable or None
+        The nonlinearity that is applied to the layer activations. If None
+        is provided, the layer will be linear.
+
+    flip_filters : bool (default: True)
+        Whether to flip the filters before sliding them over the input,
+        performing a convolution (this is the default), or not to flip them and
+        perform a correlation. Note that for some other convolutional layers in
+        Lasagne, flipping incurs an overhead and is disabled by default --
+        check the documentation when using learned weights from another layer.
+
+    convolution : callable
+        The convolution implementation to use. Usually it should be fine to
+        leave this at the default value.
+
+    **kwargs
+        Any additional keyword arguments are passed to the `Layer` superclass.
+
+    Attributes
+    ----------
+    W : Theano shared variable or expression
+        Variable or expression representing the filter weights.
+
+    b : Theano shared variable or expression
+        Variable or expression representing the biases.
+    """
+    def __init__(self, incoming, num_filters, filter_size, stride=(1, 1, 1),
+                 pad=0, untie_biases=False,
+                 W=init.GlorotUniform(), b=init.Constant(0.),
+                 nonlinearity=nonlinearities.rectify, flip_filters=True,
+                 convolution=T.nnet.conv3d, **kwargs):
+        super(Conv3DLayer, self).__init__(incoming, num_filters, filter_size,
+                                          stride, pad, untie_biases, W, b,
+                                          nonlinearity, flip_filters, n=3,
+                                          **kwargs)
+        self.convolution = convolution
+
+    def convolve(self, input, **kwargs):
+        border_mode = 'half' if self.pad == 'same' else self.pad
+        conved = self.convolution(input, self.W,
+                                  self.input_shape, self.get_W_shape(),
+                                  subsample=self.stride,
+                                  border_mode=border_mode,
+                                  filter_flip=self.flip_filters)
+        return conved
 
 
 class TransposedConv2DLayer(BaseConvLayer):

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -90,7 +90,7 @@ def pool_2d(input, **kwargs):
         return T.signal.pool.pool_2d(input, **kwargs)
 
 
-def pool_3d(input, **kwargs):
+def pool_3d(input, **kwargs):  # pragma: no cover
     """
     Wrapper function that calls :func:`theano.tensor.signal.pool_3d` either
     with the new or old keyword argument names expected by Theano.
@@ -299,7 +299,7 @@ class Pool2DLayer(Layer):
         return pooled
 
 
-class Pool3DLayer(Layer):
+class Pool3DLayer(Layer):  # pragma: no cover
     """
     3D pooling layer
 
@@ -518,7 +518,7 @@ class MaxPool2DLayer(Pool2DLayer):
 # TODO: add reshape-based implementation to MaxPool*DLayer
 
 
-class MaxPool3DLayer(Pool3DLayer):
+class MaxPool3DLayer(Pool3DLayer):  # pragma: no cover
     """
     3D max-pooling layer
 
@@ -570,6 +570,13 @@ class MaxPool3DLayer(Pool3DLayer):
                                              ignore_border,
                                              mode='max',
                                              **kwargs)
+
+
+if not hasattr(T.signal.pool, 'pool_3d'):  # pragma: no cover
+    # Hide Pool3DLayer/MaxPool3DLayer for old Theano versions
+    del Pool3DLayer, MaxPool3DLayer
+    __all__.remove('Pool3DLayer')
+    __all__.remove('MaxPool3DLayer')
 
 
 class Upscale1DLayer(Layer):

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -6,8 +6,10 @@ from ..utils import as_tuple
 __all__ = [
     "MaxPool1DLayer",
     "MaxPool2DLayer",
+    "MaxPool3DLayer",
     "Pool1DLayer",
     "Pool2DLayer",
+    "Pool3DLayer",
     "Upscale1DLayer",
     "Upscale2DLayer",
     "Upscale3DLayer",
@@ -86,6 +88,21 @@ def pool_2d(input, **kwargs):
         kwargs['st'] = kwargs.pop('stride')
         kwargs['padding'] = kwargs.pop('pad')
         return T.signal.pool.pool_2d(input, **kwargs)
+
+
+def pool_3d(input, **kwargs):
+    """
+    Wrapper function that calls :func:`theano.tensor.signal.pool_3d` either
+    with the new or old keyword argument names expected by Theano.
+    """
+    try:
+        return T.signal.pool.pool_3d(input, **kwargs)
+    except TypeError:  # pragma: no cover
+        # convert from new to old interface
+        kwargs['ds'] = kwargs.pop('ws')
+        kwargs['st'] = kwargs.pop('stride')
+        kwargs['padding'] = kwargs.pop('pad')
+        return T.signal.pool.pool_3d(input, **kwargs)
 
 
 class Pool1DLayer(Layer):
@@ -282,6 +299,117 @@ class Pool2DLayer(Layer):
         return pooled
 
 
+class Pool3DLayer(Layer):
+    """
+    3D pooling layer
+
+    Performs 3D mean or max-pooling over the three trailing axes
+    of a 5D input tensor.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or tuple
+        The layer feeding into this layer, or the expected input shape.
+
+    pool_size : integer or iterable
+        The length of the pooling region in each dimension.  If an integer, it
+        is promoted to a cubic pooling region. If an iterable, it should have
+        three elements.
+
+    stride : integer, iterable or ``None``
+        The strides between sucessive pooling regions in each dimension.
+        If ``None`` then ``stride = pool_size``.
+
+    pad : integer or iterable
+        Number of elements to be added on each side of the input
+        in each dimension. Each value must be less than
+        the corresponding stride.
+
+    ignore_border : bool
+        If ``True``, partial pooling regions will be ignored.
+        Must be ``True`` if ``pad != (0, 0, 0)``.
+
+    mode : {'max', 'average_inc_pad', 'average_exc_pad'}
+        Pooling mode: max-pooling or mean-pooling including/excluding zeros
+        from partially padded pooling regions. Default is 'max'.
+
+    **kwargs
+        Any additional keyword arguments are passed to the :class:`Layer`
+        superclass.
+
+    See Also
+    --------
+    MaxPool3DLayer : Shortcut for max pooling layer.
+
+    Notes
+    -----
+    The value used to pad the input is chosen to be less than
+    the minimum of the input, so that the output of each pooling region
+    always corresponds to some element in the unpadded input region.
+
+    Using ``ignore_border=False`` prevents Theano from using cuDNN for the
+    operation, so it will fall back to a slower implementation.
+    """
+
+    def __init__(self, incoming, pool_size, stride=None, pad=(0, 0, 0),
+                 ignore_border=True, mode='max', **kwargs):
+        super(Pool3DLayer, self).__init__(incoming, **kwargs)
+
+        self.pool_size = as_tuple(pool_size, 3)
+
+        if len(self.input_shape) != 5:
+            raise ValueError("Tried to create a 3D pooling layer with "
+                             "input shape %r. Expected 5 input dimensions "
+                             "(batchsize, channels, 3 spatial dim)."
+                             % (self.input_shape,))
+
+        if stride is None:
+            self.stride = self.pool_size
+        else:
+            self.stride = as_tuple(stride, 3)
+
+        self.pad = as_tuple(pad, 3)
+
+        self.ignore_border = ignore_border
+        self.mode = mode
+
+    def get_output_shape_for(self, input_shape):
+        output_shape = list(input_shape)  # copy / convert to mutable list
+
+        output_shape[2] = pool_output_length(input_shape[2],
+                                             pool_size=self.pool_size[0],
+                                             stride=self.stride[0],
+                                             pad=self.pad[0],
+                                             ignore_border=self.ignore_border,
+                                             )
+
+        output_shape[3] = pool_output_length(input_shape[3],
+                                             pool_size=self.pool_size[1],
+                                             stride=self.stride[1],
+                                             pad=self.pad[1],
+                                             ignore_border=self.ignore_border,
+                                             )
+
+        output_shape[4] = pool_output_length(input_shape[4],
+                                             pool_size=self.pool_size[2],
+                                             stride=self.stride[2],
+                                             pad=self.pad[2],
+                                             ignore_border=self.ignore_border,
+                                             )
+
+        return tuple(output_shape)
+
+    def get_output_for(self, input, **kwargs):
+        pooled = pool_3d(input,
+                         ws=self.pool_size,
+                         stride=self.stride,
+                         ignore_border=self.ignore_border,
+                         pad=self.pad,
+                         mode=self.mode,
+                         )
+        return pooled
+
+
 class MaxPool1DLayer(Pool1DLayer):
     """
     1D max-pooling layer
@@ -388,7 +516,60 @@ class MaxPool2DLayer(Pool2DLayer):
                                              **kwargs)
 
 # TODO: add reshape-based implementation to MaxPool*DLayer
-# TODO: add MaxPool3DLayer
+
+
+class MaxPool3DLayer(Pool3DLayer):
+    """
+    3D max-pooling layer
+
+    Performs 3D max-pooling over the three trailing axes of a 5D input tensor.
+
+    Parameters
+    ----------
+    incoming : a :class:`Layer` instance or tuple
+        The layer feeding into this layer, or the expected input shape.
+
+    pool_size : integer or iterable
+        The length of the pooling region in each dimension.  If an integer, it
+        is promoted to a cubic pooling region. If an iterable, it should have
+        three elements.
+
+    stride : integer, iterable or ``None``
+        The strides between sucessive pooling regions in each dimension.
+        If ``None`` then ``stride = pool_size``.
+
+    pad : integer or iterable
+        Number of elements to be added on each side of the input
+        in each dimension. Each value must be less than
+        the corresponding stride.
+
+    ignore_border : bool
+        If ``True``, partial pooling regions will be ignored.
+        Must be ``True`` if ``pad != (0, 0, 0)``.
+
+    **kwargs
+        Any additional keyword arguments are passed to the :class:`Layer`
+        superclass.
+
+    Notes
+    -----
+    The value used to pad the input is chosen to be less than
+    the minimum of the input, so that the output of each pooling region
+    always corresponds to some element in the unpadded input region.
+
+    Using ``ignore_border=False`` prevents Theano from using cuDNN for the
+    operation, so it will fall back to a slower implementation.
+    """
+
+    def __init__(self, incoming, pool_size, stride=None, pad=(0, 0, 0),
+                 ignore_border=True, **kwargs):
+        super(MaxPool3DLayer, self).__init__(incoming,
+                                             pool_size,
+                                             stride,
+                                             pad,
+                                             ignore_border,
+                                             mode='max',
+                                             **kwargs)
 
 
 class Upscale1DLayer(Layer):

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -458,6 +458,7 @@ class TestConv3DLayerImplementations:
 
     @pytest.fixture(
         params=[
+            ('lasagne.layers', 'Conv3DLayer'),
             ('lasagne.layers.dnn', 'Conv3DDNNLayer'),
         ],
     )

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -466,10 +466,9 @@ class TestConv3DLayerImplementations:
         impl_module_name, impl_name = request.param
         try:
             mod = importlib.import_module(impl_module_name)
-        except ImportError:
+            return getattr(mod, impl_name)
+        except (ImportError, AttributeError):
             pytest.skip("{} not available".format(impl_module_name))
-
-        return getattr(mod, impl_name)
 
     @pytest.mark.parametrize(
         "input, kernel, output, kwargs", list(conv3d_test_sets()))

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -655,7 +655,10 @@ class TestPool3DLayer:
         return Mock(output_shape=output_shape)
 
     def layer(self, input_layer, pool_size, stride, pad):
-        from lasagne.layers.pool import Pool3DLayer
+        try:
+            from lasagne.layers.pool import Pool3DLayer
+        except ImportError:
+            pytest.skip("theano.signal.pool.pool_3d not available")
 
         return Pool3DLayer(
             input_layer,
@@ -712,7 +715,10 @@ class TestPool3DLayer:
         #    pytest.skip()
 
     def test_fail_on_mismatching_dimensionality(self):
-        from lasagne.layers.pool import Pool3DLayer
+        try:
+            from lasagne.layers.pool import Pool3DLayer
+        except ImportError:
+            pytest.skip("theano.signal.pool.pool_3d not available")
         with pytest.raises(ValueError) as exc:
             Pool3DLayer((10, 20, 30, 40), 3, 2)
         assert "Expected 5 input dimensions" in exc.value.args[0]

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -644,6 +644,83 @@ class TestMaxPool2DNNLayer:
         assert "Expected 4 input dimensions" in exc.value.args[0]
 
 
+class TestPool3DLayer:
+    def pool_test_sets_ignoreborder():
+        for pool_size in [2, 3]:
+            for stride in [1, 2, 3, 4]:
+                for pad in range(pool_size):
+                    yield (pool_size, stride, pad)
+
+    def input_layer(self, output_shape):
+        return Mock(output_shape=output_shape)
+
+    def layer(self, input_layer, pool_size, stride, pad):
+        from lasagne.layers.pool import Pool3DLayer
+
+        return Pool3DLayer(
+            input_layer,
+            pool_size=pool_size,
+            stride=stride,
+            pad=pad,
+        )
+
+    @pytest.mark.parametrize(
+        "pool_size, stride, pad", list(pool_test_sets_ignoreborder()))
+    def test_get_output_for_ignoreborder(self, pool_size,
+                                         stride, pad):
+        try:
+            input = floatX(np.random.randn(5, 8, 16, 17, 13))
+            input_layer = self.input_layer(input.shape)
+            input_theano = theano.shared(input)
+
+            result = self.layer(
+                input_layer,
+                pool_size,
+                stride,
+                pad,
+            ).get_output_for(input_theano)
+
+            result_eval = result.eval()
+            numpy_result = max_pool_3d_ignoreborder(
+                input, [pool_size]*3, [stride]*3, [pad]*3)
+
+            assert np.all(numpy_result.shape == result_eval.shape)
+            assert np.allclose(result_eval, numpy_result)
+        except NotImplementedError:
+            pytest.skip()
+
+    @pytest.mark.parametrize(
+        "input_shape,output_shape",
+        [((32, 32, 64, 24, 24), (32, 32, 32, 12, 12)),
+         ((None, 32, 48, 24, 24), (None, 32, 24, 12, 12)),
+         ((32, None, 32, 24, 24), (32, None, 16, 12, 12)),
+         ((32, 64, None, 24, 24), (32, 64, None, 12, 12)),
+         ((32, 64, 32, None, 24), (32, 64, 16, None, 12)),
+         ((32, 64, 32, 24, None), (32, 64, 16, 12, None)),
+         ((32, 64, 12, None, None), (32, 64, 6, None, None)),
+         ((32, 64, None, None, None), (32, 64, None, None, None))],
+    )
+    def test_get_output_shape_for(self, input_shape, output_shape):
+        try:
+            input_layer = self.input_layer(input_shape)
+            layer = self.layer(input_layer,
+                               pool_size=(2, 2, 2), stride=None, pad=(0, 0, 0))
+            assert layer.get_output_shape_for(
+                input_shape) == output_shape
+        except NotImplementedError:
+            raise
+        #    pytest.skip()
+
+    def test_fail_on_mismatching_dimensionality(self):
+        from lasagne.layers.pool import Pool3DLayer
+        with pytest.raises(ValueError) as exc:
+            Pool3DLayer((10, 20, 30, 40), 3, 2)
+        assert "Expected 5 input dimensions" in exc.value.args[0]
+        with pytest.raises(ValueError) as exc:
+            Pool3DLayer((10, 20, 30, 40, 50, 60), 3, 2)
+        assert "Expected 5 input dimensions" in exc.value.args[0]
+
+
 class TestMaxPool3DNNLayer:
     def pool_test_sets_ignoreborder():
         for pool_size in [2, 3]:


### PR DESCRIPTION
Hi everyone

I finally I got to do this overdue PR.  Closes #27.

Currently only works with the development version of Theano, which provides the necessary functionality.
For the tests I adapted them from the DNN versions.

I saw that the default for flip_filters in the conv.py is True, but for the convs in dnn.py it is False. Is there a reason for that? Might lead to some confusion!

Thanks for feedback & Cheers,
Michael