### PR TITLE
Correct broadcast patterns for recurrent layers with num_units=1

### DIFF
--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -1007,7 +1007,10 @@ class LSTMLayer(MergeLayer):
         # When theano.scan calls step, input_n will be (n_batch, 4*num_units).
         # We define a slicing function that extract the input to each LSTM gate
         def slice_w(x, n):
-            return x[:, n*self.num_units:(n+1)*self.num_units]
+            s = x[:, n*self.num_units:(n+1)*self.num_units]
+            if self.num_units == 1:
+                s = T.addbroadcast(s, 1)  # Theano cannot infer this by itself
+            return s
 
         # Create single recurrent computation step function
         # input_n is the n'th vector of the input
@@ -1391,7 +1394,10 @@ class GRULayer(MergeLayer):
         # When theano.scan calls step, input_n will be (n_batch, 3*num_units).
         # We define a slicing function that extract the input to each GRU gate
         def slice_w(x, n):
-            return x[:, n*self.num_units:(n+1)*self.num_units]
+            s = x[:, n*self.num_units:(n+1)*self.num_units]
+            if self.num_units == 1:
+                s = T.addbroadcast(s, 1)  # Theano cannot infer this by itself
+            return s
 
         # Create single recurrent computation step function
         # input__n is the n'th vector of the input

--- a/lasagne/tests/layers/test_recurrent.py
+++ b/lasagne/tests/layers/test_recurrent.py
@@ -26,9 +26,9 @@ def test_recurrent_return_shape():
     assert output_val.shape == (num_batch, seq_len, num_units)
 
 
-def test_recurrent_grad():
+@pytest.mark.parametrize('num_units', (6, 1))
+def test_recurrent_grad(num_units):
     num_batch, seq_len, n_features = 5, 3, 10
-    num_units = 6
     l_inp = InputLayer((num_batch, seq_len, n_features))
     l_rec = RecurrentLayer(l_inp,
                            num_units=num_units)
@@ -532,9 +532,9 @@ def test_lstm_return_shape():
     assert output_val.shape == (num_batch, seq_len, num_units)
 
 
-def test_lstm_grad():
+@pytest.mark.parametrize('num_units', (6, 1))
+def test_lstm_grad(num_units):
     num_batch, seq_len, n_features = 5, 3, 10
-    num_units = 6
     l_inp = InputLayer((num_batch, seq_len, n_features))
     l_lstm = LSTMLayer(l_inp, num_units=num_units)
     output = helper.get_output(l_lstm)
@@ -866,9 +866,9 @@ def test_gru_return_shape():
     assert output_val.shape == (num_batch, seq_len, num_units)
 
 
-def test_gru_grad():
+@pytest.mark.parametrize('num_units', (6, 1))
+def test_gru_grad(num_units):
     num_batch, seq_len, n_features = 5, 3, 10
-    num_units = 6
     l_inp = InputLayer((num_batch, seq_len, n_features))
     l_gru = GRULayer(l_inp,
                      num_units=num_units)


### PR DESCRIPTION
Fixes #730. For LSTM and GRU layers with num_units=1, the broadcast pattern of `outputs_info` in `theano.scan()` did not match the broadcast pattern of what was returned by the inner loop function. In particular, slicing a tensor `x[:, n*num_units:(n+1)*num_units]` does not allow Theano to infer that the second dimension is broadcastable, but the dot products against the input-to-hidden, hidden-to-hidden and cell update matrices in the inner loop function do allow Theano to infer the broadcast pattern, creating a mismatch.
This PR solves this by adding an explicit `T.add_broadcast` for `num_units=1` (and adds tests to verify that it works).