### PR TITLE
Infer broadcast pattern for InputLayer.input_var.

### DIFF
--- a/lasagne/layers/input.py
+++ b/lasagne/layers/input.py
@@ -55,10 +55,11 @@ class InputLayer(Layer):
                 "dimension. shape=%r, self.name=%r") % (
                     self.shape, name))
 
-        ndim = len(shape)
+        ndim = len(self.shape)
         if input_var is None:
-            # create the right TensorType for the given number of dimensions
-            input_var_type = T.TensorType(theano.config.floatX, [False] * ndim)
+            # create the right TensorType for the given dimensionality/shape
+            input_var_type = T.TensorType(theano.config.floatX,
+                                          [s == 1 for s in self.shape])
             var_name = ("%s.input" % name) if name is not None else "input"
             input_var = input_var_type(var_name)
         else:

--- a/lasagne/tests/layers/test_input.py
+++ b/lasagne/tests/layers/test_input.py
@@ -18,6 +18,12 @@ class TestInputLayer:
         from lasagne.layers.input import InputLayer
         assert InputLayer([3, 2]).shape == (3, 2)
 
+    def test_input_var_bcast(self):
+        from lasagne.layers.input import InputLayer
+        assert InputLayer((3, 2)).input_var.broadcastable == (False, False)
+        assert InputLayer((1, 2)).input_var.broadcastable == (True, False)
+        assert InputLayer((None, 1)).input_var.broadcastable == (False, True)
+
     def test_input_var_name(self, layer):
         assert layer.input_var.name == "input"
 


### PR DESCRIPTION
A colleague ran into a problem with a recurrent layer not giving the correct broadcast pattern in the output of the scan's step function. Investigating, the problem turned out that an `InputLayer` of shape `(None, None, 1)` still assigns a broadcast pattern of `(False, False, False)` to the `input_var` automatically created in the constructor.

This PR creates the input variable with the broadcast pattern inferred from the input shape.