### PR TITLE
Fix locally-connected layer for non-square filters

### DIFF
--- a/lasagne/layers/local.py
+++ b/lasagne/layers/local.py
@@ -161,7 +161,7 @@ class LocallyConnected2DLayer(Conv2DLayer):
 
         # start with ii == jj == 0 case to initialize tensor
         i = self.filter_size[0] // 2
-        j = self.filter_size[0] // 2
+        j = self.filter_size[1] // 2
         filter_h_ind = -i-1 if self.flip_filters else i
         filter_w_ind = -j-1 if self.flip_filters else j
         if self.channelwise:

--- a/lasagne/tests/layers/test_local.py
+++ b/lasagne/tests/layers/test_local.py
@@ -84,7 +84,7 @@ def locally_connected2d_test_sets():
     for batch_size in (2, 3):
         for input_shape in ((batch_size, 2, 5, 5), (batch_size, 4, 8, 8)):
             for num_filters in (2, 4):
-                for filter_size in (3, 5):
+                for filter_size in ((3, 3), (3, 5)):
                     for flip_filters in (True, False):
                         for channelwise in (True, False):
                             if channelwise and num_filters != input_shape[1]:
@@ -92,14 +92,14 @@ def locally_connected2d_test_sets():
                             input = np.random.random(input_shape)
                             if channelwise:
                                 W = np.random.random(
-                                    (num_filters,) + (filter_size,) * 2 +
+                                    (num_filters,) + filter_size +
                                     input_shape[2:])
                                 output = channelwise_locally_connected2d(
                                     input, W, flip_filters=flip_filters)
                             else:
                                 W = np.random.random(
                                     (num_filters, input_shape[1]) +
-                                    (filter_size,) * 2 + input_shape[2:])
+                                    filter_size + input_shape[2:])
                                 output = locally_connected2d(
                                     input, W, flip_filters=flip_filters)
                             yield _convert(input, W, output,


### PR DESCRIPTION
The ```j = self.filter_size[0] // 2``` in the initial case of ii == jj == 0 in convolve should be ```j = self.filter_size[1] // 2```.

Before submitting your pull request, please check these hints!

- If you are not familiar with the github workflow, have a look:
  https://guides.github.com/introduction/flow/
  In particular, note that in order to update your pull request to include any
  changes we asked for, you just need to push to your branch again.
- If your pull request addresses a particular issue from our issue tracker,
  reference it in your pull request description on github (not the commit
  message) using the syntax `Closes #123` or `Fixes #123`.
  
Pull request check list:

- Install Lasagne in editable mode to be able to run tests locally:
  http://lasagne.readthedocs.io/en/latest/user/development.html#development-setup
- Make sure PEP8 is followed:
  `python -m pep8 lasagne/`
- Make sure the test suite runs through:
  `python -m py.test`
  (or, to only run tests that include the substring `foo` in their name:
  `python -m py.test -k foo`)
- At the end of the test run output, check if coverage is at 100%. If not (or
  not for the files you changed), you will need to add tests covering the code
  you added.
- It is fine to submit a PR without tests to get initial feedback on the
  implementation, but we cannot merge it without tests.
- If you added/changed any documentation, verify that it renders correctly:
  http://lasagne.readthedocs.io/en/latest/user/development.html#documentation
