### PR TITLE
use inspect.signature instead of inspect.getargspec if possible

### DIFF
--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -1,6 +1,5 @@
 from collections import deque
 from difflib import get_close_matches
-from inspect import getargspec
 from itertools import chain
 from warnings import warn
 
@@ -190,13 +189,11 @@ def get_output(layer_or_layers, inputs=None, **kwargs):
                                  % layer)
             all_outputs[layer] = layer.get_output_for(layer_inputs, **kwargs)
             try:
-                names, _, _, defaults = getargspec(layer.get_output_for)
+                accepted_kwargs |= set(utils.inspect_kwargs(
+                        layer.get_output_for))
             except TypeError:
                 # If introspection is not possible, skip it
                 pass
-            else:
-                if defaults is not None:
-                    accepted_kwargs |= set(names[-len(defaults):])
             accepted_kwargs |= set(layer.get_output_kwargs)
     unused_kwargs = set(kwargs.keys()) - accepted_kwargs
     if unused_kwargs:

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -230,6 +230,7 @@ class TestGetOutput_Layer:
 
     def test_get_output_with_unused_kwarg(self, layers, get_output):
         l1, l2, l3 = layers
+        l2.get_output_for = lambda data, asdf=123, **kwargs: data
         unused_kwarg = object()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
@@ -237,6 +238,12 @@ class TestGetOutput_Layer:
             assert len(w) == 1
             assert issubclass(w[0].category, UserWarning)
             assert 'perhaps you meant kwarg' in str(w[0].message)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            get_output(l3, adsf=unused_kwarg)
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
+            assert 'perhaps you meant asdf' in str(w[0].message)
 
     def test_get_output_with_no_unused_kwarg(self, layers, get_output):
         l1, l2, l3 = layers

--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -52,6 +52,13 @@ def test_as_tuple_fails():
         as_tuple('asdf', 4, int)
 
 
+def test_inspect_kwargs():
+    from lasagne.utils import inspect_kwargs
+    assert inspect_kwargs(inspect_kwargs) == []
+    assert inspect_kwargs(lambda a, b, c=42, bar='asdf': 0) == ['c', 'bar']
+    assert inspect_kwargs(lambda x, *args, **kwargs: 0) == []
+
+
 def test_compute_norms():
     from lasagne.utils import compute_norms
 

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -202,6 +202,32 @@ def as_tuple(x, N, t=None):
     return X
 
 
+def inspect_kwargs(func):
+    """
+    Inspects a callable and returns a list of all optional keyword arguments.
+
+    Parameters
+    ----------
+    func : callable
+        The callable to inspect
+
+    Returns
+    -------
+    kwargs : list of str
+        Names of all arguments of `func` that have a default value, in order
+    """
+    # We try the Python 3.x way first, then fall back to the Python 2.x way
+    try:
+        from inspect import signature
+    except ImportError:  # pragma: no cover
+        from inspect import getargspec
+        spec = getargspec(func)
+        return spec.args[-len(spec.defaults):] if spec.defaults else []
+    else:  # pragma: no cover
+        params = signature(func).parameters
+        return [p.name for p in params.values() if p.default is not p.empty]
+
+
 def compute_norms(array, norm_axes=None):
     """ Compute incoming weight vector norms.
 


### PR DESCRIPTION
This comes from Debian packaging, the test failed building on Python 3.5 (<https://bugs.debian.org/834910>). The patch is written by Ole Streicher.
Best,
DS