### PR TITLE
Fix #782 TransformerLayer for rectangle images

### DIFF
--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -442,9 +442,12 @@ def _transform_affine(theta, input, downsample_factor):
     grid = _meshgrid(out_height, out_width)
 
     # Transform A x (x_t, y_t, 1)^T -> (x_s, y_s)
+    # Make the transformation in a correctly scaled space
+    scaler = T.as_tensor([width, height, 1]).reshape((3, 1))
+    grid = scaler * grid
     T_g = T.dot(theta, grid)
-    x_s = T_g[:, 0]
-    y_s = T_g[:, 1]
+    x_s = T_g[:, 0] / width
+    y_s = T_g[:, 1] / height
     x_s_flat = x_s.flatten()
     y_s_flat = y_s.flatten()
 

--- a/lasagne/tests/layers/test_special.py
+++ b/lasagne/tests/layers/test_special.py
@@ -416,6 +416,34 @@ class TestTransformLayer():
                                         constant(thetas)]).eval()
         np.testing.assert_allclose(inputs, outputs, rtol=1e-6)
 
+    def test_transform_rotation(self):
+        # Check that a 90° rotation on a rectangle image is correct
+        from lasagne.layers import InputLayer, TransformerLayer
+        from lasagne.utils import floatX
+        from theano.tensor import constant
+        batchsize = 10
+        height = 8
+        width = 16
+        l_in = InputLayer((batchsize, 3, height, width))
+        l_loc = InputLayer((batchsize, 6))
+        layer = TransformerLayer(l_in, l_loc)
+        input_np = np.arange(np.prod(l_in.shape)).reshape(l_in.shape)
+        inputs = floatX(input_np)
+        thetas = floatX(np.tile([0, -1, 0, 1, 0, 0], (batchsize, 1)))
+        outputs = layer.get_output_for([constant(inputs),
+                                        constant(thetas)]).eval()
+        expected = input_np
+        expected = expected.transpose((2, 3, 0, 1))
+        expected = np.rot90(expected)
+        expected = expected.transpose((2, 3, 0, 1))
+        # Compare only the transformed part so that the padding stays free
+        offset = (width - height) // 2
+        expected = expected[:, :, offset: offset + height]
+        outputs = outputs[:, :, :, offset: offset + height].astype('int')
+        # Low precision because of the interpolation
+        # and sensitivity to even a one pixel shift
+        np.testing.assert_allclose(expected, outputs, rtol=1e-2, atol=3)
+
 
 class TestTPSTransformLayer():
 


### PR DESCRIPTION
Fix issue #782 
and add the corresponding test.

A few comments about this PR:
- I chose to only modify the function _transform_affine so that it won't interfere with the TPS Transformer which uses also _interpolate and _meshgrid.
- This is maybe at the cost of performance because I feel like doing and undoing things that could be taken care of in those two functions.
- I am not quite satisfied by the test which is very sensitive to the rounding of the indices, so every idea is welcomed.

PS: this is my very first PR so I'd gladly receive any comment and advice.