### PR TITLE
A easy way to reuse lasagne networks

### DIFF
--- a/lasagne/layers/join.py
+++ b/lasagne/layers/join.py
@@ -1,0 +1,140 @@
+# coding:utf-8
+# vi:tabstop=4:shiftwidth=4:expandtab:sts=4
+
+import lasagne
+
+__all__ = [
+        'BatchNormLayer',
+        'copy_batch_norm',
+        'join_layer'
+        ]
+
+
+class BatchNormLayer(lasagne.layers.BatchNormLayer):
+    def __init__(self, *args, **kwargs):
+        self.init_kargs = kwargs
+        self.init_args = args
+        super(BatchNormLayer,  self).__init__(*args, **kwargs)
+
+    def copy(self):
+        return BatchNormLayer(*self.init_args, **self.init_kargs)
+
+
+class CopyLayer(lasagne.layers.Layer):
+    def __init__(self,  layer):
+        self.layer = layer
+        if hasattr(layer,  'input_layers'):
+            self.input_layers = layer.input_layers
+        if hasattr(layer,  'input_layer'):
+            self.input_layer = layer.input_layer
+        if hasattr(layer,  'input_shapes'):
+            self.input_shapes = layer.input_shapes
+        if hasattr(layer,  'input_shape'):
+            self.input_shape = layer.input_shape
+        self.name = layer.name
+        self.params = layer.params
+        self.get_output_kwargs = layer.get_output_kwargs
+
+    def get_output_for(self,  *args,  **kwargs):
+        return self.layer.get_output_for(*args, **kwargs)
+
+    def get_output_shape_for(self,  *args,  **kwargs):
+        return self.layer.get_output_shape_for(*args, **kwargs)
+
+    @lasagne.layers.Layer.output_shape.getter
+    def output_shape(self):
+        return self.layer.output_shape
+
+
+class CopyMergeLayer(CopyLayer, lasagne.layers.MergeLayer):
+    pass
+
+
+def copylayer(layer):
+    assert layer is not CopyLayer
+    if isinstance(layer, lasagne.layers.MergeLayer):
+        return CopyMergeLayer(layer)
+    else:
+        return CopyLayer(layer)
+
+
+def reallayer(p):
+    while isinstance(p, CopyLayer):
+        p = p.layer
+    return p
+
+
+def copy_batch_norm(layer):
+    real = reallayer(layer)
+
+    if isinstance(real, BatchNormLayer):
+        real = real.copy()
+    elif isinstance(real, lasagne.layers.BatchNormLayer):
+        raise Exception('Can not handle lasagne.layers.BatchNormLayer, '
+                        'you should use lasagne.layers.join.BatchNormLayer '
+                        'instead.')
+    if isinstance(real, lasagne.layers.InputLayer):
+        return real
+    else:
+        res = layer
+        if hasattr(layer,  'input_layer'):
+            tmp = copy_batch_norm(layer.input_layer)
+            if tmp != layer.input_layer:
+                res = copylayer(real)
+                res.input_layer = tmp
+                assert res.input_layer == tmp
+        if hasattr(layer,  'input_layers'):
+            tmp = map(lambda x: copy_batch_norm(x), layer.input_layers)
+            for t, r in zip(tmp, layer.input_layers):
+                if t != r:
+                    res = copylayer(real)
+                    res.input_layers = tmp
+                    assert res.input_layers == tmp
+                    break
+        return res
+
+
+def join_layer(layer, m):
+    """
+    Substitute sub layers of `layer`.
+
+    Parameters
+    ----------
+
+    layer : Layer object
+        the original network
+
+    m : dict from Layer to Layer
+        key of m will be substituted by corresponding value
+
+    Return
+    ------
+
+    New network.
+
+    """
+
+    real = reallayer(layer)
+
+    if layer in m:
+        return m[layer]
+    elif isinstance(real, lasagne.layers.InputLayer):
+        return real
+    else:
+        res = layer
+        # res = copylayer(real)
+        if hasattr(layer,  'input_layer'):
+            tmp = join_layer(layer.input_layer, m)
+            if tmp != layer.input_layer:
+                res = copylayer(real)
+                res.input_layer = tmp
+                assert res.input_layer == tmp
+        if hasattr(layer,  'input_layers'):
+            tmp = map(lambda x: join_layer(x, m), layer.input_layers)
+            for t, r in zip(tmp, layer.input_layers):
+                if t != r:
+                    res = copylayer(real)
+                    res.input_layers = tmp
+                    assert res.input_layers == tmp
+                    break
+        return res

--- a/lasagne/tests/test_join.py
+++ b/lasagne/tests/test_join.py
@@ -1,0 +1,70 @@
+import numpy as np
+import os
+# os.environ['THEANO_FLAGS'] = "device = cpu"
+# import fcntl
+# lck = open('theano.lck', 'w+')
+# fcntl.flock(lck, fcntl.LOCK_EX)
+# print 'start theano ...'
+import theano
+import theano.tensor as T
+import lasagne
+from lasagne.layers.join import join_layer as JoinLayer
+import pytest
+
+
+def test_join_substitue_input():
+
+    var1 = T.imatrix('var1')
+    var2 = T.imatrix('var2')
+
+    input = lasagne.layers.InputLayer(shape=(1, 1), input_var=var1)
+    input2 = lasagne.layers.InputLayer(shape=(1, 1), input_var=var2)
+    network = input
+    network = lasagne.layers.NonlinearityLayer(network, T.invert)
+    network = JoinLayer(network, {input: input2})
+
+    out = lasagne.layers.get_output(network)
+    fun = theano.function([var2], out)
+    res = fun(np.zeros((1, 1), dtype='int8'))
+    assert res[0, 0] == -1
+
+
+def test_join_substitue_nest():
+
+    var1 = T.imatrix('var1')
+    var2 = T.imatrix('var2')
+    var3 = T.imatrix('var3')
+
+    input1 = lasagne.layers.InputLayer(shape=(1, 1), input_var=var1)
+    input2 = lasagne.layers.InputLayer(shape=(1, 1), input_var=var2)
+    input3 = lasagne.layers.InputLayer(shape=(1, 1), input_var=var3)
+    network = input1
+    network = lasagne.layers.NonlinearityLayer(network, T.invert)
+    network = JoinLayer(network, {input1: input2})
+    network = JoinLayer(network, {input2: input3})
+
+    out = lasagne.layers.get_output(network)
+    fun = theano.function([var3], out)
+    res = fun(np.zeros((1, 1), dtype='int8'))
+    assert res[0, 0] == -1
+
+
+def test_join_substitue_both():
+
+    var1 = T.imatrix('var1')
+    var2 = T.imatrix('var2')
+    var3 = T.imatrix('var3')
+
+    input1 = lasagne.layers.InputLayer(shape=(1, 1), input_var=var1)
+    input2 = lasagne.layers.InputLayer(shape=(1, 1), input_var=var2)
+    input3 = lasagne.layers.InputLayer(shape=(1, 1), input_var=var3)
+    network = lasagne.layers.ElemwiseMergeLayer((input1, input2), T.add)
+    network = JoinLayer(network, {input1: input2})
+    network = JoinLayer(network, {input2: input3})
+
+    out = lasagne.layers.get_output(network)
+    fun = theano.function([var3], out)
+    res = fun(np.ones((1, 1), dtype='int8'))
+    assert res[0, 0] == 2
+
+# test_join_substitue_input()


### PR DESCRIPTION
The idea to create join.py is that some time I want reuse the networks I built using lasagne, or join two network together. 

For example, I have a deep conv network which map a 3x64x64 image to a 64 feature point 64x1x1, and a transform network which map a 64x1x1 point to another 64x1x1 point, I want to join them together. I can do it this way:

joined_network=lasagne.layers.Input(shape=(None,64,1,1),input_var=lasagne.get_output(transform_network,lasagne.layers.get_output(conv_network))

There is a problem: lasagne.layers.get_all_params(joined_network) does not return the params in conv_network and transform_network. I think lasagne miss something, something just like lasagne.layers.get_output() but return a new network instead of a theano expression, that is why I created lasagne.layers.join.join_layer()

Such a network returned by lasagne.layers.join.join_layer() shares params with the original layers, generally BatchNormLayer should not share params, for that you can call lasagne.layers.join.copy_batch_norm() after all the lasagne.layers.join.join_layer() calls.