### PR TITLE
Add link on citing Lasagne

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,14 @@ recent research papers are maintained in the separate `Lasagne Recipes
 <https://github.com/Lasagne/Recipes>`_ repository.
 
 
+Citation
+--------
+
+If you find Lasagne useful for your scientific work, please consider citing it
+in resulting publications. We provide a ready-to-use `BibTeX entry for citing
+Lasagne <https://github.com/Lasagne/Lasagne/wiki/Lasagne-Citation-(BibTeX)>`_.
+
+
 Development
 -----------
 


### PR DESCRIPTION
It's not easy to see how to cite Lasagne. Adding a BibTeX entry directly to the README is not ideal: When we release a new version, its README would still have the BibTeX entry for the previous version (since we only get a new Zenodo reference *after* a release). To circumvent this, I've added a BibTeX entry to the wiki and link to it from the README.

Closes #73.