### PR TITLE
Jaccard Similarity Coefficient (objective accuracy)

### DIFF
--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -121,8 +121,6 @@ def align_targets(predictions, targets):
 def jaccard_similarity_accuracy(predictions,targets):
     """Computes the Jaccard similarity coefficient (accuracy) between predictions and targets.
 
-    .. math:: L_i = \\mathbb{I}(t_i = \mathbb{I}(p_i \\ge \\alpha))
-
     Parameters
     ----------
     predictions : Theano tensor

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -87,7 +87,8 @@ __all__ = [
     "binary_hinge_loss",
     "multiclass_hinge_loss",
     "binary_accuracy",
-    "categorical_accuracy"
+    "categorical_accuracy",
+    "jaccard_similarity_accuracy"
 ]
 
 
@@ -117,7 +118,14 @@ def align_targets(predictions, targets):
         targets = as_theano_expression(targets).dimshuffle(0, 'x')
     return predictions, targets
 
-
+def jaccard_similarity_accuracy(predictions,targets,threshold=0.5):
+    predictions,targets = align_targets(predictions,targets)
+    predictions = theano.tensor.ge(predictions,threshold)
+    predictions = theano.tensor.cast(predictions,'uint8')
+    targets = theano.tensor.cast(targets,'uint8')
+    intersection = theano.tensor.and_(predictions,targets)
+    union = theano.tensor.or_(predictions,targets)
+    return intersection.sum()/union.sum()
 def binary_crossentropy(predictions, targets):
     """Computes the binary cross-entropy between predictions and targets.
 


### PR DESCRIPTION
Fix the #816 
@f0k 
This is my try to implement the Jaccard similarity coefficient (Jaccard index) in the objectives. This metric is highly used in evaluating the performance of medical segmentation models where a two-class prediction (probablistic map) is compared with the binary ground truth. 
Please see this as the [reference ](http://www.ee.cuhk.edu.hk/~snli/rshi_ICIP2014.pdf)

Thanks
Saeed