### PR TITLE
Make use of expm1() to implement ELU

### DIFF
--- a/lasagne/nonlinearities.py
+++ b/lasagne/nonlinearities.py
@@ -266,7 +266,7 @@ def elu(x):
        Fast and Accurate Deep Network Learning by Exponential Linear Units
        (ELUs), http://arxiv.org/abs/1511.07289
     """
-    return theano.tensor.switch(x > 0, x, theano.tensor.exp(x) - 1)
+    return theano.tensor.switch(x > 0, x, theano.tensor.expm1(x))
 
 
 # softplus

--- a/lasagne/tests/test_nonlinearities.py
+++ b/lasagne/tests/test_nonlinearities.py
@@ -17,7 +17,7 @@ class TestNonlinearities(object):
         return self.rectify(x)
 
     def elu(self, x, alpha=1):
-        return np.where(x > 0, x, alpha * (np.exp(x) - 1))
+        return np.where(x > 0, x, alpha * (np.expm1(x)))
 
     def softplus(self, x):
         return np.log1p(np.exp(x))


### PR DESCRIPTION
expm1(x) is equivalent to exp(x)-1 but should be more stable since the calculation can be more precise. Available since Theano 0.6rc1 (Oct 2012).