### PR TITLE
Adapt sphinx configuration to modified GPU backend checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -323,13 +323,16 @@ except ImportError:
     from mock import Mock
 
 import theano
-import theano.sandbox.cuda
+import sys
 
 theano.config = Mock(device='gpu')
+theano.sandbox = Mock()
+sys.modules['theano.sandbox'] = theano.sandbox
+sys.modules['theano.sandbox.cuda'] = theano.sandbox.cuda
+sys.modules['theano.sandbox.cuda.dnn'] = theano.sandbox.cuda.dnn
+sys.modules['theano.sandbox.cuda.basic_ops'] = theano.sandbox.cuda.basic_ops
 theano.sandbox.cuda.cuda_enabled = True
-theano.sandbox.cuda.dnn = Mock(dnn_available=lambda: True)
-
-import sys
+theano.sandbox.cuda.dnn.dnn_available = lambda: True
 
 sys.modules['pylearn2'] = Mock()
 sys.modules['pylearn2.sandbox'] = Mock()
@@ -337,7 +340,6 @@ sys.modules['pylearn2.sandbox.cuda_convnet'] = Mock()
 sys.modules['pylearn2.sandbox.cuda_convnet.filter_acts'] = \
     Mock(FilterActs=None)
 
-sys.modules['theano.sandbox.cuda.blas'] = Mock(GpuCorrMM=None)
 
 # fool rtd into thinking it has a recent enough Theano version to support
 # all optional features that otherwise require a bleeding-edge Theano


### PR DESCRIPTION
With #836, the GPU backend checks have changed. The sphinx configuration needs to be adapted such that we can still build the full documentation regardless of the Theano version and device configuration.