### PR TITLE
add warning for float64 in gpu layer modules

### DIFF
--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -1,3 +1,5 @@
+import warnings
+
 import theano
 
 from .. import init
@@ -30,6 +32,14 @@ else:
     raise ImportError(
         "requires GPU support -- see http://lasagne.readthedocs.org/en/"
         "latest/user/installation.html#gpu-support")  # pragma: no cover
+
+if theano.config.floatX == 'float64':
+    warnings.warn("You are using a GPU layer with Theano configured for "
+                  "double precision (floatX=float64). Depending on your "
+                  "Theano version and GPU, this may be slow or unsupported. "
+                  "We recommend to configure Theano for single precision "
+                  "(floatX=float32); see http://lasagne.readthedocs.org/en/"
+                  "latest/user/installation.html#gpu-support.")
 
 __all__ = [
     "Conv2DMMLayer",

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import theano
 import theano.tensor as T
@@ -29,6 +31,14 @@ if not theano.sandbox.cuda.cuda_enabled:
     raise ImportError(
             "requires GPU support -- see http://lasagne.readthedocs.org/en/"
             "latest/user/installation.html#gpu-support")  # pragma: no cover
+
+if theano.config.floatX == 'float64':
+    warnings.warn("You are using a GPU layer with Theano configured for "
+                  "double precision (floatX=float64). Depending on your "
+                  "Theano version and GPU, this may be slow or unsupported. "
+                  "We recommend to configure Theano for single precision "
+                  "(floatX=float32); see http://lasagne.readthedocs.org/en/"
+                  "latest/user/installation.html#gpu-support.")
 
 
 class Conv2DCCLayer(BaseConvLayer):

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -1,3 +1,5 @@
+import warnings
+
 import theano
 
 from .. import init
@@ -39,6 +41,14 @@ else:
     raise ImportError(
         "requires GPU support -- see http://lasagne.readthedocs.org/en/"
         "latest/user/installation.html#gpu-support")  # pragma: no cover
+
+if theano.config.floatX == 'float64':
+    warnings.warn("You are using a GPU layer with Theano configured for "
+                  "double precision (floatX=float64). Depending on your "
+                  "Theano version and GPU, this may be slow or unsupported."
+                  "We recommend to configure Theano for single precision "
+                  "(floatX=float32); see http://lasagne.readthedocs.org/en/"
+                  "latest/user/installation.html#gpu-support.")
 
 __all__ = [
     "Pool2DDNNLayer",


### PR DESCRIPTION
Fixes #706. A warning is added to 3 gpu modules: lasagne.layers.dnn, lasagne.layers.corrmm and lasagne.layers.cuda_convnet. So when ```floatX=float64``` and one of them is imported, the user is warned that cuda array only supports float32 and they should switch to it. We can also change ```floatX``` to ```float32``` automatically and do this favor for the user :D 

What do you think? 