### PR TITLE
added check for input.key() to be layer instance

### DIFF
--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -148,7 +148,14 @@ def get_output(layer_or_layers, inputs=None, **kwargs):
     both, while the latter will use two different dropout masks.
     """
     from .input import InputLayer
-    from .base import MergeLayer
+    from .base import MergeLayer, Layer
+    # check if the keys of the dictionary are valid
+    if isinstance(inputs, dict):
+        for input_key in inputs.keys():
+            if (input_key is not None) and (not isinstance(input_key, Layer)):
+                raise TypeError("The inputs dictionary keys must be"
+                                " lasagne layers not %s." %
+                                type(input_key))
     # track accepted kwargs used by get_output_for
     accepted_kwargs = {'deterministic'}
     # obtain topological ordering of all layers the output layer(s) depend on

--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -259,13 +259,14 @@ class TestGetOutput_Layer:
 
     def test_layer_from_shape_invalid_get_output(self, layer_from_shape,
                                                  get_output):
+        from lasagne.layers.base import Layer
         layer = layer_from_shape
         with pytest.raises(ValueError):
             get_output(layer)
         with pytest.raises(ValueError):
             get_output(layer, [1, 2])
         with pytest.raises(ValueError):
-            get_output(layer, {Mock(): [1, 2]})
+            get_output(layer, {Mock(spec=Layer): [1, 2]})
 
     def test_layer_from_shape_valid_get_output(self, layer_from_shape,
                                                get_output):
@@ -453,6 +454,11 @@ class TestGetOutput_MergeLayer:
         assert get_output(layer, inputs) is layer.get_output_for.return_value
         layer.get_output_for.assert_called_with(
             [inputs[None], layer.input_layers[1].input_var])
+
+    def test_invalid_input_key(self, layer_from_shape, get_output):
+        layer = layer_from_shape
+        with pytest.raises(TypeError):
+            get_output(layer, {Mock(): [1, 2]})
 
 
 class TestGetOutputShape_InputLayer:


### PR DESCRIPTION
Fixes https://github.com/Lasagne/Lasagne/issues/773. I think I will still need to add tests for coverage. 