### PR TITLE
Added 2D Upscaling Methods - Bilinear (#857), Nearest Neighbor, Subpixel Convolution (Phase Shift)

### DIFF
--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -1,4 +1,6 @@
 import theano.tensor as T
+import theano
+import numpy as np
 
 from .base import Layer
 from ..utils import as_tuple
@@ -652,13 +654,48 @@ class Upscale2DLayer(Layer):
         a square scale factor region. If an iterable, it should have two
         elements.
 
-    mode : {'repeat', 'dilate'}
-        Upscaling mode: repeat element values or upscale leaving zeroes between
-        upscaled elements. Default is 'repeat'.
+        Only ``'dilate'``, ``'nearest'`` and ``'repeat'``
+        support tuple scale factors. ``'bilinear1D'``, ``'bilinear2D'``
+        and ``'subpixel'`` only support integer scale factors, or
+        tuples of the same number.
+
+        Note that for mode ``'subpixel'``, ``scale_factor = r`` and that
+        the number of filters for a given input must be divisible
+        by ``r ** 2``
+
+    mode : {'repeat', 'dilate', 'nearest', 'bilinear1D',
+            'bilinear2D, 'subpixel'}
+        Upscaling mode:
+
+        ``'repeat'`` repeats element values to upscale.
+
+        ``'dilate'`` upscales, leaving zeroes between values.
+
+        ``'nearest'`` uses nearest neighbor upscaling.
+
+        ``'bilinear2D'`` uses bilinear upscaling with same
+        2D kernel for both upscaled axes [1].
+
+        ``'bilinear1D'`` uses bilinear upscale with different 1D
+         kernel for each upscaled axis [1].
+
+        ``'subpixel'`` uses subpixel convolutional upscaling [2].
+
+        Default mode is ``'repeat'``.
 
     **kwargs
         Any additional keyword arguments are passed to the :class:`Layer`
         superclass.
+
+    References
+    ----------
+    .. [1] Augustus Odena, Vincent Dumoulin, Chris Olah (2016):
+           Deconvolution and checkerboard artifacts. Distill.
+           http://distill.pub/2016/deconv-checkerboard/
+    .. [2] Shi, Wenzhe et al (2016):
+           Real-Time Single Image and Video Super-Resolution Using an
+           Efficient Sub-pixel Convolutional Neural Network.
+           https://arxiv.org/pdf/1609.05158.pdf
 
     Notes
     -----
@@ -670,16 +707,41 @@ class Upscale2DLayer(Layer):
     def __init__(self, incoming, scale_factor, mode='repeat', **kwargs):
         super(Upscale2DLayer, self).__init__(incoming, **kwargs)
 
+        if mode not in {'repeat', 'dilate', 'nearest',
+                        'bilinear2D', 'bilinear1D', 'subpixel'}:
+            msg = "Mode must be 'repeat', 'dilate', 'nearest', " \
+                  "'bilinear2D', 'bilinear1D' or 'subpixel', not {0}"
+            raise ValueError(msg.format(mode))
+        self.mode = mode
+
+        if mode == 'subpixel' and self.input_shape[1] == None:
+            raise ValueError(
+                'Number of filters must be defined for subpixel upscale')
+
+        if mode in {'nearest', 'subpixel'} and (
+                        self.input_shape[2] is None or
+                        self.input_shape[3] is None):
+            msg = 'Dimensions of 2 trailing axis must be defined ' \
+                  'for {0} upscaling'
+            raise ValueError(msg.format(mode))
+
         self.scale_factor = as_tuple(scale_factor, 2)
 
         if self.scale_factor[0] < 1 or self.scale_factor[1] < 1:
             raise ValueError('Scale factor must be >= 1, not {0}'.format(
                 self.scale_factor))
 
-        if mode not in {'repeat', 'dilate'}:
-            msg = "Mode must be either 'repeat' or 'dilate', not {0}"
-            raise ValueError(msg.format(mode))
-        self.mode = mode
+        if not (self.mode == 'repeat' or self.mode == 'dilate' or
+                self.mode == 'nearest') and \
+                isinstance(scale_factor, tuple) and \
+                scale_factor[0] != scale_factor[1]:
+            msg = "Scale factor for {0} upscaling must be a scalar " \
+                  "or a tuple of the same number"
+            raise ValueError(msg.format(self.mode))
+
+        if mode == 'subpixel' \
+                and self.input_shape[1] % self.scale_factor[0] ** 2 != 0:
+            raise ValueError('Number of filters must be divisible by r ** 2')
 
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)  # copy / convert to mutable list
@@ -690,18 +752,92 @@ class Upscale2DLayer(Layer):
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        a, b = self.scale_factor
+
+        # create weights for nearest neighbor interpolation
+        def nearest_neighbor_weight_matrix(input_dim, scale_factor):
+            indices = np.arange(0, input_dim * scale_factor)
+            source_indices = np.zeros((indices.shape[0]))
+
+            for x in indices:
+                source_indices[x] = np.min(
+                    np.array([np.floor(np.float(x) / scale_factor),
+                              input_dim - 1]))
+
+            weight_matrix = np.zeros((input_dim,
+                                      input_dim * scale_factor)
+                                     ).astype(theano.config.floatX)
+            source_indices = source_indices.astype(np.int)
+            for col in range(0, weight_matrix.shape[1]):
+                weight_matrix[source_indices[col], col] = 1
+
+            return weight_matrix
+
+        def _phase_shift(self, input, r):
+            def _ps(self, input, r):
+                bsize, _, a, b = self.input_shape
+                upscaled = T.reshape(input, (bsize, r, r, a, b))
+                upscaled = T.transpose(upscaled, (0, 3, 4, 2, 1))
+                upscaled = T.split(
+                    x=upscaled, splits_size=[1] * a, n_splits=a, axis=1)
+                upscaled = [T.reshape(x,
+                                      (bsize, b, r, r)) for x in upscaled]
+                upscaled = T.concatenate(upscaled, axis=2)
+                upscaled = T.split(
+                    x=upscaled, splits_size=[1] * b, n_splits=b, axis=1)
+                upscaled = [T.reshape(x, (bsize, a * r, r)) for x in upscaled]
+                upscaled = T.concatenate(upscaled, axis=2)
+                return upscaled.dimshuffle(0, 'x', 1, 2)
+
+            chan = self.input_shape[1] / (r ** 2)
+            splits = []
+            for q in range(chan):
+                splits.append(r ** 2)
+            if chan > 1:
+                Xc = T.split(
+                    x=input, splits_size=splits, n_splits=chan, axis=1)
+                upscaled = T.concatenate(
+                    [_ps(self, xc, r) for xc in Xc], axis=1)
+            else:
+                upscaled = _ps(self, input, r)
+            return upscaled
+
         upscaled = input
         if self.mode == 'repeat':
+            a, b = self.scale_factor
             if b > 1:
                 upscaled = T.extra_ops.repeat(upscaled, b, 3)
             if a > 1:
                 upscaled = T.extra_ops.repeat(upscaled, a, 2)
         elif self.mode == 'dilate':
+            a, b = self.scale_factor
             if b > 1 or a > 1:
                 output_shape = self.get_output_shape_for(input.shape)
                 upscaled = T.zeros(shape=output_shape, dtype=input.dtype)
                 upscaled = T.set_subtensor(upscaled[:, :, ::a, ::b], input)
+        elif self.mode == 'bilinear2D':
+            upscaled = T.nnet.abstract_conv.bilinear_upsampling(
+                input, self.scale_factor[0],
+                batch_size=self.input_shape[0],
+                num_input_channels=self.input_shape[1],
+                use_1D_kernel=False)
+        elif self.mode == 'bilinear1D':
+            upscaled = T.nnet.abstract_conv.bilinear_upsampling(
+                input, self.scale_factor[0],
+                batch_size=self.input_shape[0],
+                num_input_channels=self.input_shape[1],
+                use_1D_kernel=True)
+        elif self.mode == 'nearest':
+            weight_matrix = nearest_neighbor_weight_matrix(
+                self.input_shape[3], self.scale_factor[0])
+            upscaled = T.dot(upscaled, weight_matrix)
+            upscaled = upscaled.dimshuffle((0, 1, 3, 2))
+            weight_matrix = nearest_neighbor_weight_matrix(
+                self.input_shape[2], self.scale_factor[1])
+            upscaled = T.dot(upscaled, weight_matrix)
+            upscaled = upscaled.dimshuffle((0, 1, 3, 2))
+        elif self.mode == 'subpixel':
+            upscaled = _phase_shift(self, input, self.scale_factor[0])
+
         return upscaled
 
 


### PR DESCRIPTION
This PR:

+ Merges in the added 2D bilinear upscaling from #857 and adds `'bilinear1D'` and `'bilinear2D'` as modes to the existing `Upscale2D` class.

+ Adds in a mode for nearest-neighbor interpolation. Not exactly state of the art, but I've been using it to implement [BEGAN](https://arxiv.org/abs/1703.10717), so it may be useful to others.

+ I'm aware of #862 and may attempt to implement it at some point, but from my skimming of the referenced paper, it mentions that the initialization scheme is for subpixel convolution. As Lasagne appears to lack a subpixel convolution option for upscaling included as part of the library, I added in subpixel convolution phase shift based primarily on the second subpixel convolution method [here](https://gist.github.com/ajbrock/cc083da8c274ff25acdc318b3249b972) + unit tests with the corresponding numpy implementation based on the algorithm in the [paper](https://arxiv.org/abs/1609.05158). 

Currently, Nearest neighbor and subpixel convolution are checked in numpy, bilinear convolution is only checked against shape as in #857.

All suggestions are welcome- It'd be good to see some more upscaling methods in Lasagne. If the documentation does not display correctly, I will try to fix it- I've been having a bit of trouble rendering it on my machine.