### PR TITLE
Catch exception by Theano 0.10+ on importing theano.sandbox.cuda

### DIFF
--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -20,7 +20,7 @@ gpu_enabled = gpu.pygpu_activated
 if not gpu_enabled:
     try:
         from theano.sandbox import cuda as gpu
-    except ImportError:
+    except Exception:  # Theano 0.10+ raises nose.SkipTest
         gpu_enabled = False
     else:
         gpu_enabled = gpu.cuda_enabled

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -23,7 +23,7 @@ if not gpu_enabled:
     try:
         from theano.sandbox import cuda as gpu
         import theano.sandbox.cuda.dnn
-    except ImportError:
+    except Exception:  # Theano 0.10+ raises nose.SkipTest
         gpu_enabled = False
     else:
         gpu_enabled = gpu.cuda_enabled

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -19,7 +19,7 @@ if not gpu:
         from theano.sandbox import cuda
         theano_backend = "cuda_sandbox"
         gpu = cuda.cuda_enabled
-    except ImportError:
+    except Exception:  # Theano 0.10+ raises nose.SkipTest
         gpu = False
     if not gpu:
         theano_backend = "cpu"


### PR DESCRIPTION
At some point after removing `theano.sandbox.cuda`, Theano opted to raise a `nose.SkipTest` exception instead of an `ImportError` when trying to import it. Some checks in Lasagne were still expecting an `ImportError` when `theano.sandbox.cuda` was not available. To avoid introducing a dependency on `nose`, this PR changes those checks to catch a generic `Exception`. This might mask other exceptions for users of Theano 0.8/0.9 trying to get CUDA to run, but avoids misleading exceptions for users of Theano 0.10. Seems that's the best we can do (without introducing a dependency on `nose` or checking the exception class name).