### PR TITLE
Support grouped convolutions

### DIFF
--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -136,6 +136,12 @@ class Conv2DMMLayer(BaseConvLayer):
         be set to ``True`` if weights are loaded into it that were learnt using
         a regular :class:`lasagne.layers.Conv2DLayer`, for example.
 
+    num_groups : int (default: 1)
+        The number of groups to split the input channels and output channels
+        into, such that data does not cross the group boundaries. Requires the
+        number of channels to be divisible by the number of groups, and
+        requires Theano 0.10 or later for more than one group.
+
     **kwargs
         Any additional keyword arguments are passed to the `Layer` superclass.
 
@@ -150,14 +156,16 @@ class Conv2DMMLayer(BaseConvLayer):
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
                  pad=0, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
-                 flip_filters=False, **kwargs):
+                 flip_filters=False, num_groups=1, **kwargs):
         super(Conv2DMMLayer, self).__init__(incoming, num_filters, filter_size,
                                             stride, pad, untie_biases, W, b,
-                                            nonlinearity, flip_filters, n=2,
-                                            **kwargs)
+                                            nonlinearity, flip_filters,
+                                            num_groups, n=2, **kwargs)
         border_mode = 'half' if self.pad == 'same' else self.pad
+        extra_kwargs = {'num_groups': num_groups} if num_groups > 1 else {}
         self.corr_mm_op = GpuCorrMM(subsample=self.stride,
-                                    border_mode=border_mode)
+                                    border_mode=border_mode,
+                                    **extra_kwargs)
 
     def convolve(self, input, **kwargs):
         filters = self.W

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -375,6 +375,12 @@ class Conv2DDNNLayer(BaseConvLayer):
         be set to ``True`` if weights are loaded into it that were learnt using
         a regular :class:`lasagne.layers.Conv2DLayer`, for example.
 
+    num_groups : int (default: 1)
+        The number of groups to split the input channels and output channels
+        into, such that data does not cross the group boundaries. Requires the
+        number of channels to be divisible by the number of groups, and
+        requires Theano 0.10 or later for more than one group.
+
     **kwargs
         Any additional keyword arguments are passed to the `Layer` superclass.
 
@@ -389,11 +395,12 @@ class Conv2DDNNLayer(BaseConvLayer):
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1),
                  pad=0, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
-                 flip_filters=False, **kwargs):
+                 flip_filters=False, num_groups=1, **kwargs):
         super(Conv2DDNNLayer, self).__init__(incoming, num_filters,
                                              filter_size, stride, pad,
                                              untie_biases, W, b, nonlinearity,
-                                             flip_filters, n=2, **kwargs)
+                                             flip_filters, num_groups, n=2,
+                                             **kwargs)
 
     def convolve(self, input, **kwargs):
         # by default we assume 'cross', consistent with corrmm.
@@ -401,13 +408,16 @@ class Conv2DDNNLayer(BaseConvLayer):
         border_mode = self.pad
         if border_mode == 'same':
             border_mode = tuple(s // 2 for s in self.filter_size)
+        extra_kwargs = {}
+        if self.num_groups > 1:  # pragma: no cover
+            extra_kwargs = {'num_groups': self.num_groups}
 
         conved = dnn.dnn_conv(img=input,
                               kerns=self.W,
                               subsample=self.stride,
                               border_mode=border_mode,
-                              conv_mode=conv_mode
-                              )
+                              conv_mode=conv_mode,
+                              **extra_kwargs)
         return conved
 
 
@@ -500,6 +510,12 @@ class Conv3DDNNLayer(BaseConvLayer):
         anyway because the filters are learned, but if you want to compute
         predictions with pre-trained weights, take care if they need flipping.
 
+    num_groups : int (default: 1)
+        The number of groups to split the input channels and output channels
+        into, such that data does not cross the group boundaries. Requires the
+        number of channels to be divisible by the number of groups, and
+        requires Theano 0.10 or later for more than one group.
+
     **kwargs
         Any additional keyword arguments are passed to the `Layer` superclass.
 
@@ -514,11 +530,12 @@ class Conv3DDNNLayer(BaseConvLayer):
     def __init__(self, incoming, num_filters, filter_size, stride=(1, 1, 1),
                  pad=0, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
-                 flip_filters=False, **kwargs):
+                 flip_filters=False, num_groups=1, **kwargs):
         super(Conv3DDNNLayer, self).__init__(incoming, num_filters,
                                              filter_size, stride, pad,
                                              untie_biases, W, b, nonlinearity,
-                                             flip_filters, n=3, **kwargs)
+                                             flip_filters, num_groups, n=3,
+                                             **kwargs)
 
     def convolve(self, input, **kwargs):
         # by default we assume 'cross', consistent with corrmm.
@@ -526,13 +543,16 @@ class Conv3DDNNLayer(BaseConvLayer):
         border_mode = self.pad
         if border_mode == 'same':
             border_mode = tuple(s // 2 for s in self.filter_size)
+        extra_kwargs = {}
+        if self.num_groups > 1:
+            extra_kwargs = {'num_groups': self.num_groups}
 
         conved = dnn.dnn_conv3d(img=input,
                                 kerns=self.W,
                                 subsample=self.stride,
                                 border_mode=border_mode,
-                                conv_mode=conv_mode
-                                )
+                                conv_mode=conv_mode,
+                                **extra_kwargs)
         return conved
 
 

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -25,7 +25,7 @@ if not gpu:
         theano_backend = "cpu"
 
 
-def convNd(input, kernel, pad, stride=1, n=None):
+def convNd(input, kernel, pad, stride=1, groups=1, n=None):
     """Execute a batch of a stack of N-dimensional convolutions.
 
     Parameters
@@ -34,12 +34,20 @@ def convNd(input, kernel, pad, stride=1, n=None):
     kernel : numpy array
     pad : {0, 'valid', 'same', 'full'}, int or tuple of int
     stride : int or tuple of int
+    groups: int
     n : int
 
     Returns
     -------
     numpy array
     """
+    if groups > 1:
+        input = input.reshape(input.shape[0], groups, -1, *input.shape[2:])
+        kernel = kernel.reshape(groups, -1, *kernel.shape[1:])
+        return np.concatenate([convNd(input[:, g], kernel[g], pad, stride,
+                                      groups=1, n=n)
+                               for g in range(groups)], axis=1)
+
     if n is None:
         n = input.ndim - 2
     if pad not in ['valid', 'same', 'full']:
@@ -170,6 +178,14 @@ def convNd_test_sets(n):
     flip = (slice(None), slice(None)) + (slice(None, None, -1),) * n
     output = convNd(input, kernel[flip], pad='valid')
     yield _convert(input, kernel, output, {'flip_filters': False})
+
+    # num_groups=3 case
+    input_shape = (2, 6) + extra_shape[-n:]
+    input = np.random.random(input_shape)
+    kernel = np.random.random((9, 2) + (3,) * n)
+    output = convNd(input, kernel, pad='valid', groups=3)
+    yield _convert(input, kernel, output, {'num_groups': 3,
+                                           'flip_filters': True})
 
 
 def conv3d_test_sets():
@@ -374,6 +390,15 @@ class TestBaseConvLayer:
             BaseConvLayer((10, 20, 30, 40), 1, 3, n=1)
         assert "Expected 3 input dimensions" in exc.value.args[0]
 
+    def test_fail_on_mismatching_groups(self):
+        from lasagne.layers.conv import BaseConvLayer
+        with pytest.raises(ValueError) as exc:
+            BaseConvLayer((2, 3, 4), 1, 3, num_groups=2)
+        assert "evenly divide" in exc.value.args[0]
+        with pytest.raises(ValueError) as exc:
+            BaseConvLayer((2, 3, 4), 1, 3, num_groups=-3)
+        assert "must be positive" in exc.value.args[0]
+
 
 class TestConv1DLayer:
 
@@ -397,7 +422,7 @@ class TestConv1DLayer:
             assert actual.shape == layer.output_shape
             assert np.allclose(actual, output)
 
-        except NotImplementedError:
+        except (NotImplementedError, RuntimeError):
             pass
 
     def test_init_none_nonlinearity_bias(self, DummyInputLayer):
@@ -460,7 +485,7 @@ class TestConv2DLayerImplementations:
             assert actual.shape == layer.output_shape
             assert np.allclose(actual, output)
 
-        except NotImplementedError:
+        except (NotImplementedError, RuntimeError):
             pytest.skip()
 
     @pytest.mark.parametrize(
@@ -488,7 +513,7 @@ class TestConv2DLayerImplementations:
             assert actual.shape == output.shape
             assert np.allclose(actual, output)
 
-        except NotImplementedError:
+        except (NotImplementedError, RuntimeError):
             pytest.skip()
 
     def test_init_none_nonlinearity_bias(self, Conv2DImpl, DummyInputLayer):
@@ -557,7 +582,7 @@ class TestConv3DLayerImplementations:
             assert actual.shape == layer.output_shape
             assert np.allclose(actual, output)
 
-        except NotImplementedError:
+        except (NotImplementedError, RuntimeError):
             pytest.skip()
 
     @pytest.mark.parametrize(
@@ -586,7 +611,7 @@ class TestConv3DLayerImplementations:
             assert actual.shape == output.shape
             assert np.allclose(actual, output)
 
-        except NotImplementedError:
+        except (NotImplementedError, RuntimeError):
             pytest.skip()
 
     def test_init_none_nonlinearity_bias(self, Conv3DImpl, DummyInputLayer):

--- a/lasagne/tests/layers/test_local.py
+++ b/lasagne/tests/layers/test_local.py
@@ -151,7 +151,7 @@ class TestLocallyConnected2DLayer:
             LocallyConnected2DLayer(input_layer, 4, 3, channelwise=True)
         assert "num_filters and the number of input channels should match" \
                in exc.value.args[0]
-        input_layer = DummyInputLayer((10, None, 4, 4))
+        input_layer = DummyInputLayer((10, 2, None, 4))
         with pytest.raises(ValueError) as exc:
             LocallyConnected2DLayer(input_layer, 4, 3, channelwise=True)
         assert "A LocallyConnected2DLayer requires a fixed input shape " \

--- a/lasagne/theano_extensions/conv.py
+++ b/lasagne/theano_extensions/conv.py
@@ -41,7 +41,8 @@ def conv1d_sc(input, filters, image_shape=None, filter_shape=None,
 
 
 def conv1d_mc0(input, filters, image_shape=None, filter_shape=None,
-               border_mode='valid', subsample=(1,), filter_flip=True):
+               border_mode='valid', subsample=(1,), filter_flip=True,
+               num_groups=1):
     """
     using conv2d with width == 1
     """
@@ -65,15 +66,17 @@ def conv1d_mc0(input, filters, image_shape=None, filter_shape=None,
     input_mc0 = input.dimshuffle(0, 1, 'x', 2)
     filters_mc0 = filters.dimshuffle(0, 1, 'x', 2)
 
+    extra_kwargs = {'num_groups': num_groups} if num_groups > 1 else {}
     conved = T.nnet.conv2d(
         input_mc0, filters_mc0, image_shape_mc0, filter_shape_mc0,
         subsample=(1, subsample[0]), border_mode=border_mode,
-        filter_flip=filter_flip)
+        filter_flip=filter_flip, **extra_kwargs)
     return conved[:, :, 0, :]  # drop the unused dimension
 
 
 def conv1d_mc1(input, filters, image_shape=None, filter_shape=None,
-               border_mode='valid', subsample=(1,), filter_flip=True):
+               border_mode='valid', subsample=(1,), filter_flip=True,
+               num_groups=1):
     """
     using conv2d with height == 1
     """
@@ -97,10 +100,11 @@ def conv1d_mc1(input, filters, image_shape=None, filter_shape=None,
     input_mc1 = input.dimshuffle(0, 1, 2, 'x')
     filters_mc1 = filters.dimshuffle(0, 1, 2, 'x')
 
+    extra_kwargs = {'num_groups': num_groups} if num_groups > 1 else {}
     conved = T.nnet.conv2d(
         input_mc1, filters_mc1, image_shape_mc1, filter_shape_mc1,
         subsample=(subsample[0], 1), border_mode=border_mode,
-        filter_flip=filter_flip)
+        filter_flip=filter_flip, **extra_kwargs)
     return conved[:, :, :, 0]  # drop the unused dimension
 
 


### PR DESCRIPTION
Adds support for grouped convolutions in the `Conv*DLayer` classes, along with tests, usable only with Theano 0.10 and above (a proper error message is given for older Theano versions).

Dilated and transposed convolutions should support groups as well, but this can wait until after #716 and #850, respectively.