### PR TITLE
Properly handle integral types other than plain int

### DIFF
--- a/docs/modules/utils.rst
+++ b/docs/modules/utils.rst
@@ -3,6 +3,8 @@
 
 .. automodule:: lasagne.utils
 
+.. autodata:: int_types
+   :annotation: = (numbers.Integral, np.integer)
 .. autofunction:: floatX
 .. autofunction:: shared_empty
 .. autofunction:: as_theano_expression

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -2,7 +2,7 @@ import theano.tensor as T
 
 from .. import init
 from .. import nonlinearities
-from ..utils import as_tuple, inspect_kwargs
+from ..utils import as_tuple, int_types, inspect_kwargs
 from ..theano_extensions import conv
 
 from .base import Layer
@@ -75,7 +75,7 @@ def conv_output_length(input_length, filter_size, stride, pad=0):
         output_length = input_length + filter_size - 1
     elif pad == 'same':
         output_length = input_length
-    elif isinstance(pad, int):
+    elif isinstance(pad, int_types):
         output_length = input_length + 2 * pad - filter_size + 1
     else:
         raise ValueError('Invalid pad: {0}'.format(pad))
@@ -151,7 +151,7 @@ def conv_input_length(output_length, filter_size, stride, pad=0):
         pad = filter_size - 1
     elif pad == 'same':
         pad = filter_size // 2
-    if not isinstance(pad, int):
+    if not isinstance(pad, int_types):
         raise ValueError('Invalid pad: {0}'.format(pad))
     return (output_length - 1) * stride - 2 * pad + filter_size
 
@@ -288,9 +288,9 @@ class BaseConvLayer(Layer):
                              (n, self.input_shape, n+2, n))
         self.n = n
         self.num_filters = num_filters
-        self.filter_size = as_tuple(filter_size, n, int)
+        self.filter_size = as_tuple(filter_size, n, int_types)
         self.flip_filters = flip_filters
-        self.stride = as_tuple(stride, n, int)
+        self.stride = as_tuple(stride, n, int_types)
         self.untie_biases = untie_biases
 
         if pad == 'same':
@@ -302,7 +302,7 @@ class BaseConvLayer(Layer):
         elif pad in ('full', 'same'):
             self.pad = pad
         else:
-            self.pad = as_tuple(pad, n, int)
+            self.pad = as_tuple(pad, n, int_types)
 
         if (num_groups <= 0 or
                 self.num_filters % num_groups != 0 or
@@ -934,7 +934,7 @@ class TransposedConv2DLayer(BaseConvLayer):
         # output_size must be set before calling the super constructor
         if (not isinstance(output_size, T.Variable) and
                 output_size is not None):
-            output_size = as_tuple(output_size, 2, int)
+            output_size = as_tuple(output_size, 2, int_types)
         self.output_size = output_size
         super(TransposedConv2DLayer, self).__init__(
                 incoming, num_filters, filter_size, stride, crop, untie_biases,
@@ -1127,7 +1127,7 @@ class TransposedConv3DLayer(BaseConvLayer):  # pragma: no cover
         # output_size must be set before calling the super constructor
         if (not isinstance(output_size, T.Variable) and
                 output_size is not None):
-            output_size = as_tuple(output_size, 3, int)
+            output_size = as_tuple(output_size, 3, int_types)
         self.output_size = output_size
         BaseConvLayer.__init__(self, incoming, num_filters, filter_size,
                                stride, crop, untie_biases, W, b,
@@ -1286,7 +1286,7 @@ class DilatedConv2DLayer(BaseConvLayer):
                  W=init.GlorotUniform(), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify, flip_filters=False,
                  **kwargs):
-        self.dilation = as_tuple(dilation, 2, int)
+        self.dilation = as_tuple(dilation, 2, int_types)
         super(DilatedConv2DLayer, self).__init__(
                 incoming, num_filters, filter_size, 1, pad,
                 untie_biases, W, b, nonlinearity, flip_filters, n=2, **kwargs)

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -41,6 +41,7 @@ import theano.tensor as T
 
 from .. import init
 from .. import nonlinearities
+from ..utils import int_types
 
 from .base import Layer
 
@@ -235,7 +236,7 @@ class BatchNormLayer(Layer):
         if axes == 'auto':
             # default: normalize over all but the second axis
             axes = (0,) + tuple(range(2, len(self.input_shape)))
-        elif isinstance(axes, int):
+        elif isinstance(axes, int_types):
             axes = (axes,)
         self.axes = axes
 

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -2,6 +2,7 @@ import numpy as np
 import theano.tensor as T
 
 from ..theano_extensions import padding
+from ..utils import int_types
 
 from .base import Layer
 
@@ -105,11 +106,11 @@ class ReshapeLayer(Layer):
         super(ReshapeLayer, self).__init__(incoming, **kwargs)
         shape = tuple(shape)
         for s in shape:
-            if isinstance(s, int):
+            if isinstance(s, int_types):
                 if s == 0 or s < - 1:
                     raise ValueError("`shape` integers must be positive or -1")
             elif isinstance(s, list):
-                if len(s) != 1 or not isinstance(s[0], int) or s[0] < 0:
+                if len(s) != 1 or not isinstance(s[0], int_types) or s[0] < 0:
                     raise ValueError("`shape` input references must be "
                                      "single-element lists of int >= 0")
             elif isinstance(s, T.TensorVariable):
@@ -232,7 +233,7 @@ class DimshuffleLayer(Layer):
         # Sanity check the pattern
         used_dims = set()
         for p in pattern:
-            if isinstance(p, int):
+            if isinstance(p, int_types):
                 # Dimension p
                 if p in used_dims:
                     raise ValueError("pattern contains dimension {0} more "
@@ -256,7 +257,7 @@ class DimshuffleLayer(Layer):
         output_shape = []
         dims_used = [False] * len(input_shape)
         for p in self.pattern:
-            if isinstance(p, int):
+            if isinstance(p, int_types):
                 if p < 0 or p >= len(input_shape):
                     raise ValueError("pattern contains {0}, but input shape "
                                      "has {1} dimensions "
@@ -321,7 +322,7 @@ class PadLayer(Layer):
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)
 
-        if isinstance(self.width, int):
+        if isinstance(self.width, int_types):
             widths = [self.width] * (len(input_shape) - self.batch_ndim)
         else:
             widths = self.width
@@ -381,7 +382,7 @@ class SliceLayer(Layer):
 
     def get_output_shape_for(self, input_shape):
         output_shape = list(input_shape)
-        if isinstance(self.slice, int):
+        if isinstance(self.slice, int_types):
             del output_shape[self.axis]
         elif input_shape[self.axis] is not None:
             output_shape[self.axis] = len(

--- a/lasagne/layers/special.py
+++ b/lasagne/layers/special.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .. import init
 from .. import nonlinearities
-from ..utils import as_tuple, floatX
+from ..utils import as_tuple, floatX, int_types
 from ..random import get_rng
 from .base import Layer, MergeLayer
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
@@ -94,7 +94,7 @@ class BiasLayer(Layer):
         if shared_axes == 'auto':
             # default: share biases over all but the second axis
             shared_axes = (0,) + tuple(range(2, len(self.input_shape)))
-        elif isinstance(shared_axes, int):
+        elif isinstance(shared_axes, int_types):
             shared_axes = (shared_axes,)
         self.shared_axes = shared_axes
 
@@ -161,7 +161,7 @@ class ScaleLayer(Layer):
         if shared_axes == 'auto':
             # default: share scales over all but the second axis
             shared_axes = (0,) + tuple(range(2, len(self.input_shape)))
-        elif isinstance(shared_axes, int):
+        elif isinstance(shared_axes, int_types):
             shared_axes = (shared_axes,)
         self.shared_axes = shared_axes
 
@@ -1007,7 +1007,7 @@ class ParametricRectifierLayer(Layer):
             self.shared_axes = (0,) + tuple(range(2, len(self.input_shape)))
         elif shared_axes == 'all':
             self.shared_axes = tuple(range(len(self.input_shape)))
-        elif isinstance(shared_axes, int):
+        elif isinstance(shared_axes, int_types):
             self.shared_axes = (shared_axes,)
         else:
             self.shared_axes = shared_axes
@@ -1120,7 +1120,7 @@ class RandomizedRectifierLayer(Layer):
             self.shared_axes = (0,) + tuple(range(2, len(self.input_shape)))
         elif shared_axes == 'all':
             self.shared_axes = tuple(range(len(self.input_shape)))
-        elif isinstance(shared_axes, int):
+        elif isinstance(shared_axes, int_types):
             self.shared_axes = (shared_axes,)
         else:
             self.shared_axes = shared_axes

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -399,6 +399,11 @@ class TestBaseConvLayer:
             BaseConvLayer((2, 3, 4), 1, 3, num_groups=-3)
         assert "must be positive" in exc.value.args[0]
 
+    def test_integer_types(self):
+        from lasagne.layers.conv import BaseConvLayer
+        BaseConvLayer((2, 3, 4), np.int64(1), np.int64(3))
+        BaseConvLayer((2, 3, 4, 5), 1, np.empty((3, 3)).shape)
+
 
 class TestConv1DLayer:
 

--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -60,11 +60,19 @@ def test_one_hot():
 
 
 def test_as_tuple_fails():
-    from lasagne.utils import as_tuple
-    with pytest.raises(ValueError):
+    from lasagne.utils import as_tuple, int_types
+    with pytest.raises(ValueError) as exc:
         as_tuple([1, 2, 3], 4)
-    with pytest.raises(TypeError):
+    assert "length 4" in exc.value.args[0]
+    with pytest.raises(TypeError) as exc:
         as_tuple('asdf', 4, int)
+    assert "of int," in exc.value.args[0]
+    with pytest.raises(TypeError) as exc:
+        as_tuple('asdf', 4, (int, float))
+    assert "of int or float," in exc.value.args[0]
+    with pytest.raises(TypeError) as exc:
+        as_tuple('asdf', 4, int_types)
+    assert "of int," in exc.value.args[0]
 
 
 def test_inspect_kwargs():

--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -5,6 +5,21 @@ import theano
 import theano.tensor as T
 
 
+def test_int_types():
+    from lasagne.utils import int_types
+    assert isinstance(42, int_types)
+    assert isinstance(np.int8(42), int_types)
+    assert isinstance(np.int16(42), int_types)
+    assert isinstance(np.int32(42), int_types)
+    assert isinstance(np.int64(42), int_types)
+    assert isinstance(np.empty(42).shape[0], int_types)
+    assert isinstance(np.prod(np.empty(42).shape), int_types)
+    try:
+        assert isinstance(long(42), int_types)
+    except NameError:
+        pass
+
+
 def test_shared_empty():
     from lasagne.utils import shared_empty
 

--- a/lasagne/theano_extensions/conv.py
+++ b/lasagne/theano_extensions/conv.py
@@ -3,8 +3,9 @@ Alternative convolution implementations for Theano
 """
 
 import numpy as np
-
 import theano.tensor as T
+
+from ..utils import int_types
 
 
 # 1D convolutions
@@ -60,7 +61,7 @@ def conv1d_mc0(input, filters, image_shape=None, filter_shape=None,
 
     if isinstance(border_mode, tuple):
         (border_mode,) = border_mode
-    if isinstance(border_mode, int):
+    if isinstance(border_mode, int_types):
         border_mode = (0, border_mode)
 
     input_mc0 = input.dimshuffle(0, 1, 'x', 2)
@@ -94,7 +95,7 @@ def conv1d_mc1(input, filters, image_shape=None, filter_shape=None,
 
     if isinstance(border_mode, tuple):
         (border_mode,) = border_mode
-    if isinstance(border_mode, int):
+    if isinstance(border_mode, int_types):
         border_mode = (border_mode, 0)
 
     input_mc1 = input.dimshuffle(0, 1, 2, 'x')

--- a/lasagne/theano_extensions/padding.py
+++ b/lasagne/theano_extensions/padding.py
@@ -4,6 +4,8 @@ Padding
 
 import theano.tensor as T
 
+from ..utils import int_types
+
 
 def pad(x, width, val=0, batch_ndim=1):
     """
@@ -33,7 +35,7 @@ def pad(x, width, val=0, batch_ndim=1):
     output_shape = list(input_shape)
     indices = [slice(None) for _ in output_shape]
 
-    if isinstance(width, int):
+    if isinstance(width, int_types):
         widths = [width] * (input_ndim - batch_ndim)
     else:
         widths = width

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -177,8 +177,8 @@ def as_tuple(x, N, t=None):
     x : value or iterable
     N : integer
         length of the desired tuple
-    t : type, optional
-        required type for all elements
+    t : type or tuple of type, optional
+        required type or types for all elements
 
     Returns
     -------
@@ -198,8 +198,14 @@ def as_tuple(x, N, t=None):
         X = (x,) * N
 
     if (t is not None) and not all(isinstance(v, t) for v in X):
+        if t == int_types:
+            expected_type = "int"  # easier to understand
+        elif isinstance(t, tuple):
+            expected_type = " or ".join(tt.__name__ for tt in t)
+        else:
+            expected_type = t.__name__
         raise TypeError("expected a single value or an iterable "
-                        "of {0}, got {1} instead".format(t.__name__, x))
+                        "of {0}, got {1} instead".format(expected_type, x))
 
     if len(X) != N:
         raise ValueError("expected a single value or an iterable "

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -1,7 +1,13 @@
-import numpy as np
+import numbers
 
+import numpy as np
 import theano
 import theano.tensor as T
+
+
+#: Tuple of ``int``-like types for ``isinstance`` checks.
+#: Specifically includes long integers and numpy integers.
+int_types = (numbers.Integral, np.integer)
 
 
 def floatX(arr):


### PR DESCRIPTION
In a couple of places, Lasagne has `isinstance(..., int)` checks. Those will fail for a `long` in Python 2 (which appear in `ndarray.shape` under Windows), and for `np.int64` in Python 3 (which appear in `np.prod(ndarray.shape)`, for example). A generic type check that works both in Python 2 and 3 is `isinstance(x, (numbers.Integral, np.integer))`.
This PR adds `lasagne.utils.int_types`, a tuple of `numbers.Integral, np.integer`, and uses it instead of `int` where appropriate. It also extends `lasagne.utils.as_tuple` to allow a type tuple instead of a single type.

Fixes #847.