### PR TITLE
Python3 compatibility for lasagne.layers.base

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -41,7 +41,7 @@ class Layer(object):
         self.params = OrderedDict()
         self.get_output_kwargs = []
 
-        if any(d is not None and d <= 0 for d in self.input_shape):
+        if any(d is not None and (type(d) is not tuple and d <= 0) for d in self.input_shape):
             raise ValueError((
                 "Cannot create Layer with a non-positive input_shape "
                 "dimension. input_shape=%r, self.name=%r") % (


### PR DESCRIPTION
This PR addresses an issue that we at [rlworkgroup](https://github.com/rlworkgroup) have come across when using lasagne.layers.base, specifically:
```
  File "/anaconda2/envs/garage/lib/python3.5/site-packages/lasagne/layers/dense.py", line 78, in __init__
    super(DenseLayer, self).__init__(incoming, **kwargs)
  File "/anaconda2/envs/garage/lib/python3.5/site-packages/lasagne/layers/base.py", line 44, in __init__
    if any(d is not None and d <= 0 for d in self.input_shape):
  File "/anaconda2/envs/garage/lib/python3.5/site-packages/lasagne/layers/base.py", line 44, in <genexpr>
    if any(d is not None and d <= 0 for d in self.input_shape):
TypeError: unorderable types: tuple() <= int()
```
This is a [result](https://stackoverflow.com/questions/32800156/typeerror-unorderable-types-tuple-int-in-python-3) of py3 dropping support for direct tuple() and int() comparison.

This is my first PR for Lasagne, so please feel free to provide feedback.