### PR TITLE
`Notes on AdaGrad` is not found

### DIFF
--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -401,7 +401,7 @@ def adagrad(loss_or_grads, params, learning_rate=1.0, epsilon=1e-6):
            optimization. JMLR, 12:2121-2159.
 
     .. [2] Chris Dyer:
-           Notes on AdaGrad. http://www.ark.cs.cmu.edu/cdyer/adagrad.pdf
+           Notes on AdaGrad.
     """
 
     grads = get_or_compute_grads(loss_or_grads, params)


### PR DESCRIPTION
```zsh
$ curl -L -v http://www.ark.cs.cmu.edu/cdyer/adagrad.pdf
*   Trying 128.2.42.94:80...
* Connected to www.ark.cs.cmu.edu (128.2.42.94) port 80 (#0)
> GET /cdyer/adagrad.pdf HTTP/1.1
> Host: www.ark.cs.cmu.edu
> User-Agent: curl/7.77.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Found
< Date: Sat, 26 Mar 2022 02:54:35 GMT
< Server: Apache
< Location: http://www.cs.cmu.edu/~ark/cdyer/adagrad.pdf
< Content-Length: 228
< Content-Type: text/html; charset=iso-8859-1
< Set-Cookie: BIGipServer~SCS~wehost-pool-80=181011072.20480.0000; path=/; Httponly
< 
* Ignoring the response-body
* Connection #0 to host www.ark.cs.cmu.edu left intact
* Issue another request to this URL: 'http://www.cs.cmu.edu/~ark/cdyer/adagrad.pdf'
*   Trying 128.2.42.95:80...
* Connected to www.cs.cmu.edu (128.2.42.95) port 80 (#1)
> GET /~ark/cdyer/adagrad.pdf HTTP/1.1
> Host: www.cs.cmu.edu
> User-Agent: curl/7.77.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< Date: Sat, 26 Mar 2022 02:54:36 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Set-Cookie: SHIBLOCATION=tilde; path=/; domain=.cs.cmu.edu
< Content-Length: 1467
< Content-Type: text/html; charset=UTF-8
< Set-Cookie: BALANCEID=balancer.web39.srv.cs.cmu.edu; path=/;
< Set-Cookie: BIGipServer~SCS~cs-userdir-pool-80=533332608.20480.0000; path=/; Httponly
< 
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<html>
<head>
<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
<title>404 - Document not found</title>
...
```